### PR TITLE
Refactor CDL page structure and consolidate dropdown state management

### DIFF
--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -150,6 +150,9 @@ describe('Header', () => {
 
     it('ACE domain2 サブリンクが存在すること', () => {
         const { container } = render(<Header />);
+        const button = screen.getByRole('button', { name: /associate cloud engineer/i });
+        fireEvent.click(button);
+        expect(button).toHaveAttribute('aria-expanded', 'true');
         const link = container.querySelector(
             'a[href="/gcl/associate-cloud-engineer/domain2"]'
         );
@@ -158,6 +161,9 @@ describe('Header', () => {
 
     it('ACE domain3 サブリンクが存在すること', () => {
         const { container } = render(<Header />);
+        const button = screen.getByRole('button', { name: /associate cloud engineer/i });
+        fireEvent.click(button);
+        expect(button).toHaveAttribute('aria-expanded', 'true');
         const link = container.querySelector(
             'a[href="/gcl/associate-cloud-engineer/domain3"]'
         );

--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -28,6 +28,8 @@ describe('Header', () => {
 
     it('GenAI Leader ページへのリンクが存在すること', () => {
         render(<Header />);
+        const button = screen.getByRole('button', { name: /generative ai leader/i });
+        fireEvent.click(button);
         const link = screen.getByRole('link', { name: /generative ai leader 概要/i });
         expect(link).toHaveAttribute('href', '/gcl/genai-leader');
     });
@@ -69,21 +71,27 @@ describe('Header', () => {
     });
 
     it('ACE 概要リンクが /gcl/associate-cloud-engineer を指すこと', () => {
-        const { container } = render(<Header />);
-        const link = container.querySelector('a[href="/gcl/associate-cloud-engineer"]');
-        expect(link).toBeInTheDocument();
+        render(<Header />);
+        const button = screen.getByRole('button', { name: /associate cloud engineer/i });
+        fireEvent.click(button);
+        const link = screen.getAllByRole('link', { name: /^概要$/i })[0];
+        expect(link).toHaveAttribute('href', '/gcl/associate-cloud-engineer');
     });
 
     it('ACE architecture-guide サブリンクが存在すること', () => {
-        const { container } = render(<Header />);
-        const link = container.querySelector('a[href="/gcl/associate-cloud-engineer/architecture-guide"]');
-        expect(link).toBeInTheDocument();
+        render(<Header />);
+        const button = screen.getByRole('button', { name: /associate cloud engineer/i });
+        fireEvent.click(button);
+        const link = screen.getByRole('link', { name: /試験対策・アーキテクチャ詳細ガイド/i });
+        expect(link).toHaveAttribute('href', '/gcl/associate-cloud-engineer/architecture-guide');
     });
 
     it('ACE domain1 サブリンクが存在すること', () => {
-        const { container } = render(<Header />);
-        const link = container.querySelector('a[href="/gcl/associate-cloud-engineer/domain1"]');
-        expect(link).toBeInTheDocument();
+        render(<Header />);
+        const button = screen.getByRole('button', { name: /associate cloud engineer/i });
+        fireEvent.click(button);
+        const link = screen.getByRole('link', { name: /domain 1: 環境設定 包括的解説/i });
+        expect(link).toHaveAttribute('href', '/gcl/associate-cloud-engineer/domain1');
     });
 
     it('nav 要素として描画されること', () => {
@@ -93,24 +101,32 @@ describe('Header', () => {
 
     it('Section 1 へのドロップダウンリンクが存在すること', () => {
         render(<Header />);
+        const button = screen.getByRole('button', { name: /generative ai leader/i });
+        fireEvent.click(button);
         const link = screen.getByRole('link', { name: /section 1/i });
         expect(link).toHaveAttribute('href', '/gcl/genai-leader/section1');
     });
 
     it('Section 2 へのドロップダウンリンクが存在すること', () => {
         render(<Header />);
+        const button = screen.getByRole('button', { name: /generative ai leader/i });
+        fireEvent.click(button);
         const link = screen.getByRole('link', { name: /section 2/i });
         expect(link).toHaveAttribute('href', '/gcl/genai-leader/section2');
     });
 
     it('Section 3 へのドロップダウンリンクが存在すること', () => {
         render(<Header />);
+        const button = screen.getByRole('button', { name: /generative ai leader/i });
+        fireEvent.click(button);
         const link = screen.getByRole('link', { name: /section 3/i });
         expect(link).toHaveAttribute('href', '/gcl/genai-leader/section3');
     });
 
     it('Section 4 へのドロップダウンリンクが存在すること', () => {
         render(<Header />);
+        const button = screen.getByRole('button', { name: /generative ai leader/i });
+        fireEvent.click(button);
         const link = screen.getByRole('link', { name: /section 4/i });
         expect(link).toHaveAttribute('href', '/gcl/genai-leader/section4');
     });
@@ -134,9 +150,11 @@ describe('Header', () => {
     });
 
     it('Cloud Digital Leader ページへのリンクが存在すること', () => {
-        const { container } = render(<Header />);
-        const link = container.querySelector('a[href="/gcl/cloud-digital-leader"]');
-        expect(link).toBeInTheDocument();
+        render(<Header />);
+        const button = screen.getByRole('button', { name: /cloud digital leader/i });
+        fireEvent.click(button);
+        const link = screen.getByRole('link', { name: /cloud digital leader 認定試験/i });
+        expect(link).toHaveAttribute('href', '/gcl/cloud-digital-leader');
     });
 
     it('Cloud Digital Leader ドロップダウンが Escape キーで閉じること', () => {
@@ -149,24 +167,20 @@ describe('Header', () => {
     });
 
     it('ACE domain2 サブリンクが存在すること', () => {
-        const { container } = render(<Header />);
+        render(<Header />);
         const button = screen.getByRole('button', { name: /associate cloud engineer/i });
         fireEvent.click(button);
         expect(button).toHaveAttribute('aria-expanded', 'true');
-        const link = container.querySelector(
-            'a[href="/gcl/associate-cloud-engineer/domain2"]'
-        );
+        const link = screen.getByRole('link', { name: /domain 2: 計画と実装 包括的解説/i });
         expect(link).toBeInTheDocument();
     });
 
     it('ACE domain3 サブリンクが存在すること', () => {
-        const { container } = render(<Header />);
+        render(<Header />);
         const button = screen.getByRole('button', { name: /associate cloud engineer/i });
         fireEvent.click(button);
         expect(button).toHaveAttribute('aria-expanded', 'true');
-        const link = container.querySelector(
-            'a[href="/gcl/associate-cloud-engineer/domain3"]'
-        );
+        const link = screen.getByRole('link', { name: /domain 3: 運用管理 包括的解説/i });
         expect(link).toBeInTheDocument();
     });
 });

--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -114,4 +114,53 @@ describe('Header', () => {
         const link = screen.getByRole('link', { name: /section 4/i });
         expect(link).toHaveAttribute('href', '/gcl/genai-leader/section4');
     });
+
+    it('Cloud Digital Leader ドロップダウントリガーが存在すること', () => {
+        render(<Header />);
+        const button = screen.getByRole('button', { name: /cloud digital leader/i });
+        expect(button).toBeInTheDocument();
+        expect(button).toHaveAttribute('aria-haspopup', 'true');
+        expect(button).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('Cloud Digital Leader ドロップダウントリガーがクリックで開閉すること', () => {
+        render(<Header />);
+        const button = screen.getByRole('button', { name: /cloud digital leader/i });
+        expect(button).toHaveAttribute('aria-expanded', 'false');
+        fireEvent.click(button);
+        expect(button).toHaveAttribute('aria-expanded', 'true');
+        fireEvent.click(button);
+        expect(button).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('Cloud Digital Leader ページへのリンクが存在すること', () => {
+        const { container } = render(<Header />);
+        const link = container.querySelector('a[href="/gcl/cloud-digital-leader"]');
+        expect(link).toBeInTheDocument();
+    });
+
+    it('Cloud Digital Leader ドロップダウンが Escape キーで閉じること', () => {
+        render(<Header />);
+        const button = screen.getByRole('button', { name: /cloud digital leader/i });
+        fireEvent.click(button);
+        expect(button).toHaveAttribute('aria-expanded', 'true');
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(button).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('ACE domain2 サブリンクが存在すること', () => {
+        const { container } = render(<Header />);
+        const link = container.querySelector(
+            'a[href="/gcl/associate-cloud-engineer/domain2"]'
+        );
+        expect(link).toBeInTheDocument();
+    });
+
+    it('ACE domain3 サブリンクが存在すること', () => {
+        const { container } = render(<Header />);
+        const link = container.querySelector(
+            'a[href="/gcl/associate-cloud-engineer/domain3"]'
+        );
+        expect(link).toBeInTheDocument();
+    });
 });

--- a/__tests__/gcl/associate-cloud-engineer/domain2/page.test.tsx
+++ b/__tests__/gcl/associate-cloud-engineer/domain2/page.test.tsx
@@ -14,7 +14,7 @@ describe('Domain 2: Planning and Implementing a Cloud Solution ページ', () =>
     });
 
     it('hero セクションにドメイン説明が含まれること', () => {
-        expect(screen.getByText(/計画と実装/)).toBeInTheDocument();
+        expect(screen.getAllByText(/計画と実装/).length).toBeGreaterThanOrEqual(1);
     });
 
     it('試験配点情報が表示されること', () => {
@@ -33,7 +33,7 @@ describe('Domain 2: Planning and Implementing a Cloud Solution ページ', () =>
     });
 
     it('コンピューティングサービスの章見出しが存在すること', () => {
-        expect(screen.getByText(/コンピューティングサービス/)).toBeInTheDocument();
+        expect(screen.getAllByText(/コンピューティングサービス/).length).toBeGreaterThanOrEqual(1);
     });
 
     it('Terraform の章見出しが存在すること', () => {

--- a/__tests__/gcl/associate-cloud-engineer/domain2/page.test.tsx
+++ b/__tests__/gcl/associate-cloud-engineer/domain2/page.test.tsx
@@ -18,7 +18,7 @@ describe('Domain 2: Planning and Implementing a Cloud Solution ページ', () =>
     });
 
     it('試験配点情報が表示されること', () => {
-        expect(screen.getByText(/~21%/)).toBeInTheDocument();
+        expect(screen.getAllByText(/~21%/).length).toBeGreaterThanOrEqual(1);
     });
 
     it('全16章の見出しが存在すること', () => {
@@ -37,7 +37,7 @@ describe('Domain 2: Planning and Implementing a Cloud Solution ページ', () =>
     });
 
     it('Terraform の章見出しが存在すること', () => {
-        expect(screen.getByText(/Terraform/)).toBeInTheDocument();
+        expect(screen.getAllByText(/Terraform/).length).toBeGreaterThanOrEqual(1);
     });
 
     it('ベストプラクティスセクションが存在すること', () => {

--- a/__tests__/gcl/associate-cloud-engineer/domain2/page.test.tsx
+++ b/__tests__/gcl/associate-cloud-engineer/domain2/page.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Domain2Page from '@/app/gcl/associate-cloud-engineer/domain2/page';
+
+describe('Domain 2: Planning and Implementing a Cloud Solution ページ', () => {
+    beforeEach(() => {
+        render(<Domain2Page />);
+    });
+
+    it('ページコンポーネントがレンダリングされること', () => {
+        expect(
+            screen.getAllByText(/Planning and Implementing/).length
+        ).toBeGreaterThanOrEqual(1);
+    });
+
+    it('hero セクションにドメイン説明が含まれること', () => {
+        expect(screen.getByText(/計画と実装/)).toBeInTheDocument();
+    });
+
+    it('試験配点情報が表示されること', () => {
+        expect(screen.getByText(/~21%/)).toBeInTheDocument();
+    });
+
+    it('全16章の見出しが存在すること', () => {
+        expect(
+            screen.getAllByRole('heading', { level: 2 }).length
+        ).toBeGreaterThanOrEqual(16);
+    });
+
+    it('sticky nav に各章へのリンクが含まれること', () => {
+        const nav = screen.getByRole('navigation');
+        expect(nav).toBeInTheDocument();
+    });
+
+    it('コンピューティングサービスの章見出しが存在すること', () => {
+        expect(screen.getByText(/コンピューティングサービス/)).toBeInTheDocument();
+    });
+
+    it('Terraform の章見出しが存在すること', () => {
+        expect(screen.getByText(/Terraform/)).toBeInTheDocument();
+    });
+
+    it('ベストプラクティスセクションが存在すること', () => {
+        expect(
+            screen.getAllByText(/ベストプラクティス/).length
+        ).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/__tests__/gcl/associate-cloud-engineer/domain3/page.test.tsx
+++ b/__tests__/gcl/associate-cloud-engineer/domain3/page.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Domain3Page from '@/app/gcl/associate-cloud-engineer/domain3/page';
+
+describe('Domain 3: Ensuring Successful Operation of a Cloud Solution ページ', () => {
+    beforeEach(() => {
+        render(<Domain3Page />);
+    });
+
+    it('ページコンポーネントがレンダリングされること', () => {
+        expect(
+            screen.getAllByText(/Ensuring Successful Operation/).length
+        ).toBeGreaterThanOrEqual(1);
+    });
+
+    it('hero セクションにドメイン説明が含まれること', () => {
+        expect(
+            screen.getAllByText(/運用管理/).length
+        ).toBeGreaterThanOrEqual(1);
+    });
+
+    it('試験配点情報が表示されること', () => {
+        expect(
+            screen.getAllByText(/~22%/).length
+        ).toBeGreaterThanOrEqual(1);
+    });
+
+    it('全17章の見出しが存在すること', () => {
+        expect(
+            screen.getAllByRole('heading', { level: 2 }).length
+        ).toBeGreaterThanOrEqual(17);
+    });
+
+    it('sticky nav に各章へのリンクが含まれること', () => {
+        const nav = screen.getByRole('navigation');
+        expect(nav).toBeInTheDocument();
+    });
+
+    it('SRE の章見出しが存在すること', () => {
+        expect(
+            screen.getAllByText(/SRE/).length
+        ).toBeGreaterThanOrEqual(1);
+    });
+
+    it('Cloud Monitoring の章見出しが存在すること', () => {
+        expect(
+            screen.getAllByText(/Cloud Monitoring/).length
+        ).toBeGreaterThanOrEqual(1);
+    });
+
+    it('ベストプラクティスセクションが存在すること', () => {
+        expect(
+            screen.getAllByText(/ベストプラクティス/).length
+        ).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/__tests__/gcl/associate-cloud-engineer/domain3/page.test.tsx
+++ b/__tests__/gcl/associate-cloud-engineer/domain3/page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import Domain3Page from '@/app/gcl/associate-cloud-engineer/domain3/page';
 
 describe('Domain 3: Ensuring Successful Operation of a Cloud Solution ページ', () => {
@@ -34,6 +34,12 @@ describe('Domain 3: Ensuring Successful Operation of a Cloud Solution ページ'
     it('sticky nav に各章へのリンクが含まれること', () => {
         const nav = screen.getByRole('navigation');
         expect(nav).toBeInTheDocument();
+
+        const links = within(nav).getAllByRole('link');
+        const hrefs = links.map((a) => a.getAttribute('href'));
+        for (let i = 0; i <= 17; i++) {
+            expect(hrefs).toContain(`#ch${i}`);
+        }
     });
 
     it('SRE の章見出しが存在すること', () => {

--- a/__tests__/gcl/cloud-digital-leader/page.test.tsx
+++ b/__tests__/gcl/cloud-digital-leader/page.test.tsx
@@ -22,7 +22,7 @@ describe('Cloud Digital Leader 認定試験 ページ', () => {
         expect(screen.getAllByText('50–60問').length).toBeGreaterThanOrEqual(1);
     });
 
-    it('全8セクションの見出しが存在すること', () => {
+    it('全9セクションの見出しが存在すること', () => {
         render(<CloudDigitalLeaderPage />);
         expect(screen.getByRole('heading', { level: 2, name: /試験概要と出題セクション/i })).toBeInTheDocument();
         expect(screen.getByRole('heading', { level: 2, name: /DX・クラウド基礎/i })).toBeInTheDocument();

--- a/__tests__/gcl/cloud-digital-leader/page.test.tsx
+++ b/__tests__/gcl/cloud-digital-leader/page.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CloudDigitalLeaderPage from '@/app/gcl/cloud-digital-leader/page';
+
+describe('Cloud Digital Leader 認定試験 ページ', () => {
+    beforeEach(() => {
+        render(<CloudDigitalLeaderPage />);
+    });
+
+    it('ページコンポーネントがレンダリングされること', () => {
+        expect(
+            screen.getAllByText(/Cloud Digital Leader/).length
+        ).toBeGreaterThanOrEqual(1);
+    });
+
+    it('hero セクションにタイトルが含まれること', () => {
+        expect(
+            screen.getAllByText(/認定試験/).length
+        ).toBeGreaterThanOrEqual(1);
+    });
+
+    it('試験仕様情報が表示されること', () => {
+        expect(
+            screen.getAllByText(/60問/).length
+        ).toBeGreaterThanOrEqual(1);
+    });
+
+    it('全8セクションの見出しが存在すること', () => {
+        expect(
+            screen.getAllByRole('heading', { level: 2 }).length
+        ).toBeGreaterThanOrEqual(8);
+    });
+
+    it('sticky nav に各セクションへのリンクが含まれること', () => {
+        const nav = screen.getByRole('navigation');
+        expect(nav).toBeInTheDocument();
+    });
+
+    it('DX・クラウド基礎セクションが存在すること', () => {
+        expect(
+            screen.getAllByText(/DX/).length
+        ).toBeGreaterThanOrEqual(1);
+    });
+
+    it('AI・ML セクションが存在すること', () => {
+        expect(
+            screen.getAllByText(/AI/).length
+        ).toBeGreaterThanOrEqual(1);
+    });
+
+    it('ベストプラクティスセクションが存在すること', () => {
+        expect(
+            screen.getAllByText(/ベストプラクティス/).length
+        ).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/__tests__/gcl/cloud-digital-leader/page.test.tsx
+++ b/__tests__/gcl/cloud-digital-leader/page.test.tsx
@@ -1,56 +1,63 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import CloudDigitalLeaderPage from '@/app/gcl/cloud-digital-leader/page';
+import CloudDigitalLeaderPage from '@/app/gcl/cloud-digital-leader/page.tsx';
 
 describe('Cloud Digital Leader 認定試験 ページ', () => {
-    beforeEach(() => {
-        render(<CloudDigitalLeaderPage />);
-    });
-
     it('ページコンポーネントがレンダリングされること', () => {
-        expect(
-            screen.getAllByText(/Cloud Digital Leader/).length
-        ).toBeGreaterThanOrEqual(1);
+        const { container } = render(<CloudDigitalLeaderPage />);
+        expect(container.querySelector('.cdl-page')).toBeInTheDocument();
     });
 
     it('hero セクションにタイトルが含まれること', () => {
-        expect(
-            screen.getAllByText(/認定試験/).length
-        ).toBeGreaterThanOrEqual(1);
+        render(<CloudDigitalLeaderPage />);
+        const titles = screen.getAllByText(/Cloud Digital Leader/i);
+        expect(titles.length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByRole('heading', { level: 1, name: /Cloud Digital Leader/i })).toBeInTheDocument();
     });
 
     it('試験仕様情報が表示されること', () => {
-        expect(
-            screen.getAllByText(/60問/).length
-        ).toBeGreaterThanOrEqual(1);
+        render(<CloudDigitalLeaderPage />);
+        expect(screen.getByText('試験時間')).toBeInTheDocument();
+        expect(screen.getByText('90分')).toBeInTheDocument();
+        expect(screen.getAllByText('50–60問').length).toBeGreaterThanOrEqual(1);
     });
 
     it('全8セクションの見出しが存在すること', () => {
-        expect(
-            screen.getAllByRole('heading', { level: 2 }).length
-        ).toBeGreaterThanOrEqual(8);
+        render(<CloudDigitalLeaderPage />);
+        expect(screen.getByRole('heading', { level: 2, name: /試験概要と出題セクション/i })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2, name: /DX・クラウド基礎/i })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2, name: /データとイノベーション/i })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2, name: /インフラとモダナイゼーション/i })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2, name: /セキュリティと運用/i })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2, name: /AI\/ML/i })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2, name: /サービス早見表/i })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2, name: /試験攻略チェックリスト/i })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2, name: /参照リソース/i })).toBeInTheDocument();
     });
 
     it('sticky nav に各セクションへのリンクが含まれること', () => {
-        const nav = screen.getByRole('navigation');
+        render(<CloudDigitalLeaderPage />);
+        const nav = screen.getByRole('navigation', { name: /セクションナビゲーション/i });
         expect(nav).toBeInTheDocument();
+        expect(screen.getByText('試験概要')).toBeInTheDocument();
+        expect(screen.getByText('AI/ML')).toBeInTheDocument();
     });
 
     it('DX・クラウド基礎セクションが存在すること', () => {
-        expect(
-            screen.getAllByText(/DX/).length
-        ).toBeGreaterThanOrEqual(1);
+        render(<CloudDigitalLeaderPage />);
+        expect(screen.getByText(/デジタルトランスフォーメーションと Google Cloud/i)).toBeInTheDocument();
+        expect(screen.getByText(/NIST 定義/i)).toBeInTheDocument();
     });
 
     it('AI・ML セクションが存在すること', () => {
-        expect(
-            screen.getAllByText(/AI/).length
-        ).toBeGreaterThanOrEqual(1);
+        render(<CloudDigitalLeaderPage />);
+        expect(screen.getAllByText(/Google AI 原則/i).length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByText(/社会に有益である/i)).toBeInTheDocument();
     });
 
-    it('ベストプラクティスセクションが存在すること', () => {
-        expect(
-            screen.getAllByText(/ベストプラクティス/).length
-        ).toBeGreaterThanOrEqual(1);
+    it('重要コンセプトセクションが存在すること', () => {
+        render(<CloudDigitalLeaderPage />);
+        expect(screen.getByRole('heading', { level: 2, name: /必ず押さえるべき概念/i })).toBeInTheDocument();
+        expect(screen.getByText(/推奨学習ロードマップ/i)).toBeInTheDocument();
     });
 });

--- a/app/gcl/associate-cloud-engineer/domain2/domain2.css
+++ b/app/gcl/associate-cloud-engineer/domain2/domain2.css
@@ -4,26 +4,31 @@
    スコープクラス: .d2-page
    =================================================================== */
 
+/* Layer 3: Domain 2 固有テーマ — globals.css セマンティックトークンを上書き */
 :root {
-    --d2-bg:          #07090e;
-    --d2-surface:     #0c1220;
-    --d2-surface2:    #111a2e;
-    --d2-surface3:    #172038;
-    --d2-border:      #1a2d50;
+    --color-background: #07090e;
+    --color-foreground: #c8d6e8;
+    --color-card:       #0c1220;
+    --color-border:     #1a2d50;
+    --color-primary:    #4a9eff;
+    --color-muted-foreground: #8899b0;
+}
+
+/* Domain 2 固有プリミティブ（グローバルセマンティックに対応するものがない値） */
+.d2-page {
+    --d2-surface2:      #111a2e;
+    --d2-surface3:      #172038;
     --d2-border-bright: #2a4a80;
-    --d2-blue:        #4a9eff;
-    --d2-cyan:        #22d3ee;
-    --d2-green:       #10b981;
-    --d2-yellow:      #f59e0b;
-    --d2-orange:      #f97316;
-    --d2-purple:      #8b5cf6;
-    --d2-red:         #ef4444;
-    --d2-pink:        #ec4899;
-    --d2-text:        #c8d6e8;
-    --d2-text-muted:  #8899b0;
-    --d2-text-bright: #e8f2ff;
-    --d2-glow:        0 0 24px rgba(74, 158, 255, 0.22);
-    --d2-glow-sm:     0 0 10px rgba(74, 158, 255, 0.15);
+    --d2-cyan:          #22d3ee;
+    --d2-green:         #10b981;
+    --d2-yellow:        #f59e0b;
+    --d2-orange:        #f97316;
+    --d2-purple:        #8b5cf6;
+    --d2-red:           #ef4444;
+    --d2-pink:          #ec4899;
+    --d2-text-bright:   #e8f2ff;
+    --d2-glow:          0 0 24px rgba(74, 158, 255, 0.22);
+    --d2-glow-sm:       0 0 10px rgba(74, 158, 255, 0.15);
 }
 
 /* ─── Reset & Base ─────────────────────────────────────────────── */
@@ -32,8 +37,8 @@
 }
 
 .d2-page {
-    background: var(--d2-bg, #07090e);
-    color: var(--d2-text, #c8d6e8);
+    background: var(--color-background, #07090e);
+    color: var(--color-foreground, #c8d6e8);
     min-height: 100vh;
     font-family: var(--font-body, 'Noto Sans JP', sans-serif);
     line-height: 1.75;
@@ -48,7 +53,7 @@
     background:
         radial-gradient(ellipse 70% 50% at 50% 0%, rgba(74, 158, 255, 0.18) 0%, transparent 70%),
         linear-gradient(160deg, #07090e 0%, #091422 45%, #0d1d3a 75%, #07090e 100%);
-    border-bottom: 1px solid var(--d2-border, #1a2d50);
+    border-bottom: 1px solid var(--color-border, #1a2d50);
 }
 
 .d2-page .hero::before {
@@ -71,7 +76,7 @@
     border-radius: 999px;
     padding: 4px 16px;
     font-size: 12px;
-    color: var(--d2-blue, #4a9eff);
+    color: var(--color-primary, #4a9eff);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     margin-bottom: 20px;
@@ -87,7 +92,7 @@
 }
 
 .d2-page .hero h1 span {
-    background: linear-gradient(135deg, var(--d2-blue, #4a9eff), var(--d2-cyan, #22d3ee));
+    background: linear-gradient(135deg, var(--color-primary, #4a9eff), var(--d2-cyan, #22d3ee));
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -95,7 +100,7 @@
 
 .d2-page .hero-sub {
     font-size: 16px;
-    color: var(--d2-text-muted, #8899b0);
+    color: var(--color-muted-foreground, #8899b0);
     max-width: 640px;
     margin: 0 auto 28px;
 }
@@ -112,19 +117,19 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    background: var(--d2-surface, #0c1220);
-    border: 1px solid var(--d2-border, #1a2d50);
+    background: var(--color-card, #0c1220);
+    border: 1px solid var(--color-border, #1a2d50);
     border-radius: 8px;
     padding: 6px 14px;
     font-size: 13px;
-    color: var(--d2-text, #c8d6e8);
+    color: var(--color-foreground, #c8d6e8);
 }
 
 .d2-page .hero-badge .dot {
     width: 7px;
     height: 7px;
     border-radius: 50%;
-    background: var(--d2-blue, #4a9eff);
+    background: var(--color-primary, #4a9eff);
     flex-shrink: 0;
 }
 
@@ -140,7 +145,7 @@
     background: rgba(7, 9, 14, 0.92);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
-    border-bottom: 1px solid var(--d2-border, #1a2d50);
+    border-bottom: 1px solid var(--color-border, #1a2d50);
     overflow-x: auto;
     scrollbar-width: none;
 }
@@ -163,7 +168,7 @@
     border-radius: 6px;
     font-size: 12px;
     font-weight: 600;
-    color: var(--d2-text-muted, #8899b0);
+    color: var(--color-muted-foreground, #8899b0);
     text-decoration: none;
     white-space: nowrap;
     transition: background 0.15s, color 0.15s;
@@ -199,7 +204,7 @@
     gap: 16px;
     margin-bottom: 28px;
     padding-bottom: 20px;
-    border-bottom: 1px solid var(--d2-border, #1a2d50);
+    border-bottom: 1px solid var(--color-border, #1a2d50);
 }
 
 .d2-page .sec-num {
@@ -214,7 +219,7 @@
     font-weight: 800;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     background: rgba(74, 158, 255, 0.12);
-    color: var(--d2-blue, #4a9eff);
+    color: var(--color-primary, #4a9eff);
     border: 1px solid rgba(74, 158, 255, 0.25);
 }
 
@@ -236,7 +241,7 @@
 
 .d2-page .sec-head-txt p {
     font-size: 13px;
-    color: var(--d2-text-muted, #8899b0);
+    color: var(--color-muted-foreground, #8899b0);
     margin: 0;
 }
 
@@ -248,14 +253,14 @@
     font-weight: 700;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     background: rgba(74, 158, 255, 0.12);
-    color: var(--d2-blue, #4a9eff);
+    color: var(--color-primary, #4a9eff);
     border: 1px solid rgba(74, 158, 255, 0.20);
 }
 
 /* ─── Topic Card ──────────────────────────────────────────────────── */
 .d2-page .tcard {
-    background: var(--d2-surface, #0c1220);
-    border: 1px solid var(--d2-border, #1a2d50);
+    background: var(--color-card, #0c1220);
+    border: 1px solid var(--color-border, #1a2d50);
     border-radius: 14px;
     padding: 24px;
     margin-bottom: 20px;
@@ -280,7 +285,7 @@
     font-size: 11px;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     background: rgba(74, 158, 255, 0.12);
-    color: var(--d2-blue, #4a9eff);
+    color: var(--color-primary, #4a9eff);
     padding: 2px 8px;
     border-radius: 4px;
     flex-shrink: 0;
@@ -288,7 +293,7 @@
 
 .d2-page .tcard > p {
     font-size: 14px;
-    color: var(--d2-text, #c8d6e8);
+    color: var(--color-foreground, #c8d6e8);
     margin-bottom: 16px;
     line-height: 1.75;
 }
@@ -303,7 +308,7 @@
 
 .d2-page .titem {
     background: var(--d2-surface2, #111a2e);
-    border: 1px solid var(--d2-border, #1a2d50);
+    border: 1px solid var(--color-border, #1a2d50);
     border-radius: 8px;
     padding: 12px 14px;
 }
@@ -311,14 +316,14 @@
 .d2-page .tname {
     font-size: 12px;
     font-weight: 700;
-    color: var(--d2-blue, #4a9eff);
+    color: var(--color-primary, #4a9eff);
     margin-bottom: 5px;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
 }
 
 .d2-page .tdef {
     font-size: 13px;
-    color: var(--d2-text, #c8d6e8);
+    color: var(--color-foreground, #c8d6e8);
     line-height: 1.6;
 }
 
@@ -327,7 +332,7 @@
     overflow-x: auto;
     margin-bottom: 18px;
     border-radius: 10px;
-    border: 1px solid var(--d2-border, #1a2d50);
+    border: 1px solid var(--color-border, #1a2d50);
 }
 
 .d2-page .ctable {
@@ -338,20 +343,20 @@
 
 .d2-page .ctable th {
     background: var(--d2-surface2, #111a2e);
-    color: var(--d2-blue, #4a9eff);
+    color: var(--color-primary, #4a9eff);
     font-weight: 700;
     padding: 10px 14px;
     text-align: left;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 12px;
-    border-bottom: 1px solid var(--d2-border, #1a2d50);
+    border-bottom: 1px solid var(--color-border, #1a2d50);
     white-space: nowrap;
 }
 
 .d2-page .ctable td {
     padding: 10px 14px;
-    color: var(--d2-text, #c8d6e8);
-    border-bottom: 1px solid var(--d2-border, #1a2d50);
+    color: var(--color-foreground, #c8d6e8);
+    border-bottom: 1px solid var(--color-border, #1a2d50);
     vertical-align: top;
     line-height: 1.6;
 }
@@ -394,7 +399,7 @@
 
 .d2-page .bp li {
     font-size: 13px;
-    color: var(--d2-text, #c8d6e8);
+    color: var(--color-foreground, #c8d6e8);
     margin-bottom: 6px;
     line-height: 1.65;
 }
@@ -424,7 +429,7 @@
 .d2-page .wb p,
 .d2-page .wb li {
     font-size: 13px;
-    color: var(--d2-text, #c8d6e8);
+    color: var(--color-foreground, #c8d6e8);
     line-height: 1.65;
     margin: 0;
 }
@@ -433,7 +438,7 @@
 .d2-page .ib {
     background: rgba(74, 158, 255, 0.06);
     border: 1px solid rgba(74, 158, 255, 0.20);
-    border-left: 3px solid var(--d2-blue, #4a9eff);
+    border-left: 3px solid var(--color-primary, #4a9eff);
     border-radius: 8px;
     padding: 14px 18px;
     margin-bottom: 14px;
@@ -442,7 +447,7 @@
 .d2-page .ibt {
     font-size: 11px;
     font-weight: 700;
-    color: var(--d2-blue, #4a9eff);
+    color: var(--color-primary, #4a9eff);
     text-transform: uppercase;
     letter-spacing: 0.08em;
     margin-bottom: 8px;
@@ -452,7 +457,7 @@
 .d2-page .ib p,
 .d2-page .ib li {
     font-size: 13px;
-    color: var(--d2-text, #c8d6e8);
+    color: var(--color-foreground, #c8d6e8);
     line-height: 1.65;
     margin: 0;
 }
@@ -460,7 +465,7 @@
 /* ─── Code Block ──────────────────────────────────────────────────── */
 .d2-page .codeblock {
     background: #060a14;
-    border: 1px solid var(--d2-border, #1a2d50);
+    border: 1px solid var(--color-border, #1a2d50);
     border-radius: 10px;
     padding: 18px 20px;
     margin-bottom: 14px;
@@ -468,19 +473,19 @@
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 12.5px;
     line-height: 1.75;
-    color: var(--d2-text, #c8d6e8);
+    color: var(--color-foreground, #c8d6e8);
     white-space: pre;
     scrollbar-width: thin;
-    scrollbar-color: var(--d2-border, #1a2d50) transparent;
+    scrollbar-color: var(--color-border, #1a2d50) transparent;
 }
 
 .d2-page .codeblock::-webkit-scrollbar { height: 4px; }
 .d2-page .codeblock::-webkit-scrollbar-track { background: transparent; }
-.d2-page .codeblock::-webkit-scrollbar-thumb { background: var(--d2-border, #1a2d50); border-radius: 2px; }
+.d2-page .codeblock::-webkit-scrollbar-thumb { background: var(--color-border, #1a2d50); border-radius: 2px; }
 
 /* syntax highlighting */
 .d2-page .codeblock .comment { color: #4a6080; }
-.d2-page .codeblock .cmd     { color: var(--d2-blue, #4a9eff); font-weight: 600; }
+.d2-page .codeblock .cmd     { color: var(--color-primary, #4a9eff); font-weight: 600; }
 .d2-page .codeblock .flag    { color: var(--d2-cyan, #22d3ee); }
 .d2-page .codeblock .val     { color: var(--d2-green, #10b981); }
 .d2-page .codeblock .str     { color: var(--d2-yellow, #f59e0b); }
@@ -501,13 +506,13 @@
     align-items: center;
     gap: 8px;
     background: var(--d2-surface2, #111a2e);
-    border: 1px solid var(--d2-border, #1a2d50);
+    border: 1px solid var(--color-border, #1a2d50);
     border-bottom: none;
     border-radius: 8px 8px 0 0;
     padding: 6px 14px;
     font-size: 11px;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
-    color: var(--d2-text-muted, #8899b0);
+    color: var(--color-muted-foreground, #8899b0);
 }
 
 .d2-page .cb-label .dot {
@@ -549,13 +554,13 @@
 .d2-page .src {
     margin-top: 16px;
     padding-top: 14px;
-    border-top: 1px solid var(--d2-border, #1a2d50);
+    border-top: 1px solid var(--color-border, #1a2d50);
 }
 
 .d2-page .srct {
     font-size: 11px;
     font-weight: 700;
-    color: var(--d2-text-muted, #8899b0);
+    color: var(--color-muted-foreground, #8899b0);
     text-transform: uppercase;
     letter-spacing: 0.08em;
     margin-bottom: 8px;
@@ -566,7 +571,7 @@
     align-items: center;
     gap: 4px;
     font-size: 12px;
-    color: var(--d2-blue, #4a9eff);
+    color: var(--color-primary, #4a9eff);
     text-decoration: none;
     margin-right: 14px;
     transition: opacity 0.15s;
@@ -578,15 +583,15 @@
 .d2-page .page-footer {
     text-align: center;
     padding: 32px 20px;
-    border-top: 1px solid var(--d2-border, #1a2d50);
+    border-top: 1px solid var(--color-border, #1a2d50);
     font-size: 13px;
-    color: var(--d2-text-muted, #8899b0);
+    color: var(--color-muted-foreground, #8899b0);
 }
 
 /* ─── Divider ─────────────────────────────────────────────────────── */
 .d2-page .sdivider {
     border: none;
-    border-top: 1px solid var(--d2-border, #1a2d50);
+    border-top: 1px solid var(--color-border, #1a2d50);
     margin: 48px 0;
 }
 
@@ -601,7 +606,7 @@
     display: flex;
     gap: 10px;
     font-size: 13px;
-    color: var(--d2-text, #c8d6e8);
+    color: var(--color-foreground, #c8d6e8);
     padding: 6px 0;
     border-bottom: 1px solid rgba(26, 45, 80, 0.5);
     line-height: 1.65;
@@ -615,7 +620,7 @@
     height: 20px;
     border-radius: 50%;
     background: rgba(74, 158, 255, 0.15);
-    color: var(--d2-blue, #4a9eff);
+    color: var(--color-primary, #4a9eff);
     font-size: 10px;
     font-weight: 700;
     display: flex;

--- a/app/gcl/associate-cloud-engineer/domain2/domain2.css
+++ b/app/gcl/associate-cloud-engineer/domain2/domain2.css
@@ -1,0 +1,658 @@
+/* ===================================================================
+   Domain 2: Planning and Implementing a Cloud Solution
+   Blueprint テーマ — 設計図・電気回路・アーキテクチャのイメージ
+   スコープクラス: .d2-page
+   =================================================================== */
+
+:root {
+    --d2-bg:          #07090e;
+    --d2-surface:     #0c1220;
+    --d2-surface2:    #111a2e;
+    --d2-surface3:    #172038;
+    --d2-border:      #1a2d50;
+    --d2-border-bright: #2a4a80;
+    --d2-blue:        #4a9eff;
+    --d2-cyan:        #22d3ee;
+    --d2-green:       #10b981;
+    --d2-yellow:      #f59e0b;
+    --d2-orange:      #f97316;
+    --d2-purple:      #8b5cf6;
+    --d2-red:         #ef4444;
+    --d2-pink:        #ec4899;
+    --d2-text:        #c8d6e8;
+    --d2-text-muted:  #8899b0;
+    --d2-text-bright: #e8f2ff;
+    --d2-glow:        0 0 24px rgba(74, 158, 255, 0.22);
+    --d2-glow-sm:     0 0 10px rgba(74, 158, 255, 0.15);
+}
+
+/* ─── Reset & Base ─────────────────────────────────────────────── */
+.d2-page * {
+    box-sizing: border-box;
+}
+
+.d2-page {
+    background: var(--d2-bg, #07090e);
+    color: var(--d2-text, #c8d6e8);
+    min-height: 100vh;
+    font-family: var(--font-body, 'Noto Sans JP', sans-serif);
+    line-height: 1.75;
+}
+
+/* ─── Hero Section ──────────────────────────────────────────────── */
+.d2-page .hero {
+    position: relative;
+    overflow: hidden;
+    padding: 72px 24px 56px;
+    text-align: center;
+    background:
+        radial-gradient(ellipse 70% 50% at 50% 0%, rgba(74, 158, 255, 0.18) 0%, transparent 70%),
+        linear-gradient(160deg, #07090e 0%, #091422 45%, #0d1d3a 75%, #07090e 100%);
+    border-bottom: 1px solid var(--d2-border, #1a2d50);
+}
+
+.d2-page .hero::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image:
+        linear-gradient(rgba(74, 158, 255, 0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(74, 158, 255, 0.04) 1px, transparent 1px);
+    background-size: 40px 40px;
+    pointer-events: none;
+}
+
+.d2-page .hero-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(74, 158, 255, 0.10);
+    border: 1px solid rgba(74, 158, 255, 0.25);
+    border-radius: 999px;
+    padding: 4px 16px;
+    font-size: 12px;
+    color: var(--d2-blue, #4a9eff);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 20px;
+}
+
+.d2-page .hero h1 {
+    font-size: clamp(26px, 5vw, 44px);
+    font-weight: 900;
+    color: var(--d2-text-bright, #e8f2ff);
+    letter-spacing: -0.02em;
+    margin-bottom: 12px;
+    line-height: 1.2;
+}
+
+.d2-page .hero h1 span {
+    background: linear-gradient(135deg, var(--d2-blue, #4a9eff), var(--d2-cyan, #22d3ee));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.d2-page .hero-sub {
+    font-size: 16px;
+    color: var(--d2-text-muted, #8899b0);
+    max-width: 640px;
+    margin: 0 auto 28px;
+}
+
+.d2-page .hero-meta {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 16px;
+    margin-top: 8px;
+}
+
+.d2-page .hero-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--d2-surface, #0c1220);
+    border: 1px solid var(--d2-border, #1a2d50);
+    border-radius: 8px;
+    padding: 6px 14px;
+    font-size: 13px;
+    color: var(--d2-text, #c8d6e8);
+}
+
+.d2-page .hero-badge .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--d2-blue, #4a9eff);
+    flex-shrink: 0;
+}
+
+.d2-page .hero-badge .dot-green { background: var(--d2-green, #10b981); }
+.d2-page .hero-badge .dot-yellow { background: var(--d2-yellow, #f59e0b); }
+.d2-page .hero-badge .dot-cyan { background: var(--d2-cyan, #22d3ee); }
+
+/* ─── Sticky Nav ─────────────────────────────────────────────────── */
+.d2-page .snav {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    background: rgba(7, 9, 14, 0.92);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--d2-border, #1a2d50);
+    overflow-x: auto;
+    scrollbar-width: none;
+}
+
+.d2-page .snav::-webkit-scrollbar { display: none; }
+
+.d2-page .snav-inner {
+    display: flex;
+    gap: 4px;
+    padding: 8px 16px;
+    width: max-content;
+    min-width: 100%;
+}
+
+.d2-page .snav-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 5px 12px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--d2-text-muted, #8899b0);
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background 0.15s, color 0.15s;
+}
+
+.d2-page .snav-link:hover {
+    background: var(--d2-surface2, #111a2e);
+    color: var(--d2-text-bright, #e8f2ff);
+}
+
+.d2-page .snav-num {
+    font-size: 10px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    opacity: 0.7;
+}
+
+/* ─── Wrapper ─────────────────────────────────────────────────────── */
+.d2-page .wrapper {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 40px 20px 80px;
+}
+
+/* ─── Section Gap ─────────────────────────────────────────────────── */
+.d2-page .sgap {
+    margin-bottom: 64px;
+}
+
+/* ─── Section Header ──────────────────────────────────────────────── */
+.d2-page .sec-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+    margin-bottom: 28px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--d2-border, #1a2d50);
+}
+
+.d2-page .sec-num {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 15px;
+    font-weight: 800;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    background: rgba(74, 158, 255, 0.12);
+    color: var(--d2-blue, #4a9eff);
+    border: 1px solid rgba(74, 158, 255, 0.25);
+}
+
+.d2-page .sec-num.sn-cyan   { background: rgba(34, 211, 238, 0.12); color: var(--d2-cyan, #22d3ee); border-color: rgba(34, 211, 238, 0.25); }
+.d2-page .sec-num.sn-green  { background: rgba(16, 185, 129, 0.12); color: var(--d2-green, #10b981); border-color: rgba(16, 185, 129, 0.25); }
+.d2-page .sec-num.sn-purple { background: rgba(139, 92, 246, 0.12); color: var(--d2-purple, #8b5cf6); border-color: rgba(139, 92, 246, 0.25); }
+.d2-page .sec-num.sn-orange { background: rgba(249, 115, 22, 0.12); color: var(--d2-orange, #f97316); border-color: rgba(249, 115, 22, 0.25); }
+.d2-page .sec-num.sn-yellow { background: rgba(245, 158, 11, 0.12); color: var(--d2-yellow, #f59e0b); border-color: rgba(245, 158, 11, 0.25); }
+
+.d2-page .sec-head-txt { flex: 1; }
+
+.d2-page .sec-head-txt h2 {
+    font-size: 20px;
+    font-weight: 800;
+    color: var(--d2-text-bright, #e8f2ff);
+    margin-bottom: 4px;
+    letter-spacing: -0.01em;
+}
+
+.d2-page .sec-head-txt p {
+    font-size: 13px;
+    color: var(--d2-text-muted, #8899b0);
+    margin: 0;
+}
+
+.d2-page .pct-badge {
+    flex-shrink: 0;
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 700;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    background: rgba(74, 158, 255, 0.12);
+    color: var(--d2-blue, #4a9eff);
+    border: 1px solid rgba(74, 158, 255, 0.20);
+}
+
+/* ─── Topic Card ──────────────────────────────────────────────────── */
+.d2-page .tcard {
+    background: var(--d2-surface, #0c1220);
+    border: 1px solid var(--d2-border, #1a2d50);
+    border-radius: 14px;
+    padding: 24px;
+    margin-bottom: 20px;
+    transition: border-color 0.2s;
+}
+
+.d2-page .tcard:hover {
+    border-color: var(--d2-border-bright, #2a4a80);
+}
+
+.d2-page .ttitle {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--d2-text-bright, #e8f2ff);
+    margin-bottom: 14px;
+}
+
+.d2-page .tid {
+    font-size: 11px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    background: rgba(74, 158, 255, 0.12);
+    color: var(--d2-blue, #4a9eff);
+    padding: 2px 8px;
+    border-radius: 4px;
+    flex-shrink: 0;
+}
+
+.d2-page .tcard > p {
+    font-size: 14px;
+    color: var(--d2-text, #c8d6e8);
+    margin-bottom: 16px;
+    line-height: 1.75;
+}
+
+/* ─── Term Grid ───────────────────────────────────────────────────── */
+.d2-page .tgrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 10px;
+    margin-bottom: 18px;
+}
+
+.d2-page .titem {
+    background: var(--d2-surface2, #111a2e);
+    border: 1px solid var(--d2-border, #1a2d50);
+    border-radius: 8px;
+    padding: 12px 14px;
+}
+
+.d2-page .tname {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--d2-blue, #4a9eff);
+    margin-bottom: 5px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.d2-page .tdef {
+    font-size: 13px;
+    color: var(--d2-text, #c8d6e8);
+    line-height: 1.6;
+}
+
+/* ─── Comparison Table ────────────────────────────────────────────── */
+.d2-page .ctable-wrap {
+    overflow-x: auto;
+    margin-bottom: 18px;
+    border-radius: 10px;
+    border: 1px solid var(--d2-border, #1a2d50);
+}
+
+.d2-page .ctable {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+}
+
+.d2-page .ctable th {
+    background: var(--d2-surface2, #111a2e);
+    color: var(--d2-blue, #4a9eff);
+    font-weight: 700;
+    padding: 10px 14px;
+    text-align: left;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 12px;
+    border-bottom: 1px solid var(--d2-border, #1a2d50);
+    white-space: nowrap;
+}
+
+.d2-page .ctable td {
+    padding: 10px 14px;
+    color: var(--d2-text, #c8d6e8);
+    border-bottom: 1px solid var(--d2-border, #1a2d50);
+    vertical-align: top;
+    line-height: 1.6;
+}
+
+.d2-page .ctable tr:last-child td { border-bottom: none; }
+
+.d2-page .ctable tr:hover td {
+    background: rgba(74, 158, 255, 0.04);
+}
+
+.d2-page .ctable td strong {
+    color: var(--d2-text-bright, #e8f2ff);
+    font-weight: 700;
+}
+
+/* ─── Best Practice Box ───────────────────────────────────────────── */
+.d2-page .bp {
+    background: rgba(16, 185, 129, 0.06);
+    border: 1px solid rgba(16, 185, 129, 0.20);
+    border-left: 3px solid var(--d2-green, #10b981);
+    border-radius: 8px;
+    padding: 16px 18px;
+    margin-bottom: 14px;
+}
+
+.d2-page .bpt {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--d2-green, #10b981);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 10px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.d2-page .bp ul {
+    margin: 0;
+    padding-left: 18px;
+}
+
+.d2-page .bp li {
+    font-size: 13px;
+    color: var(--d2-text, #c8d6e8);
+    margin-bottom: 6px;
+    line-height: 1.65;
+}
+
+.d2-page .bp li:last-child { margin-bottom: 0; }
+
+/* ─── Warning Box ─────────────────────────────────────────────────── */
+.d2-page .wb {
+    background: rgba(245, 158, 11, 0.06);
+    border: 1px solid rgba(245, 158, 11, 0.20);
+    border-left: 3px solid var(--d2-yellow, #f59e0b);
+    border-radius: 8px;
+    padding: 14px 18px;
+    margin-bottom: 14px;
+}
+
+.d2-page .wbt {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--d2-yellow, #f59e0b);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 8px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.d2-page .wb p,
+.d2-page .wb li {
+    font-size: 13px;
+    color: var(--d2-text, #c8d6e8);
+    line-height: 1.65;
+    margin: 0;
+}
+
+/* ─── Info Box ─────────────────────────────────────────────────────── */
+.d2-page .ib {
+    background: rgba(74, 158, 255, 0.06);
+    border: 1px solid rgba(74, 158, 255, 0.20);
+    border-left: 3px solid var(--d2-blue, #4a9eff);
+    border-radius: 8px;
+    padding: 14px 18px;
+    margin-bottom: 14px;
+}
+
+.d2-page .ibt {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--d2-blue, #4a9eff);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 8px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.d2-page .ib p,
+.d2-page .ib li {
+    font-size: 13px;
+    color: var(--d2-text, #c8d6e8);
+    line-height: 1.65;
+    margin: 0;
+}
+
+/* ─── Code Block ──────────────────────────────────────────────────── */
+.d2-page .codeblock {
+    background: #060a14;
+    border: 1px solid var(--d2-border, #1a2d50);
+    border-radius: 10px;
+    padding: 18px 20px;
+    margin-bottom: 14px;
+    overflow-x: auto;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 12.5px;
+    line-height: 1.75;
+    color: var(--d2-text, #c8d6e8);
+    white-space: pre;
+    scrollbar-width: thin;
+    scrollbar-color: var(--d2-border, #1a2d50) transparent;
+}
+
+.d2-page .codeblock::-webkit-scrollbar { height: 4px; }
+.d2-page .codeblock::-webkit-scrollbar-track { background: transparent; }
+.d2-page .codeblock::-webkit-scrollbar-thumb { background: var(--d2-border, #1a2d50); border-radius: 2px; }
+
+/* syntax highlighting */
+.d2-page .codeblock .comment { color: #4a6080; }
+.d2-page .codeblock .cmd     { color: var(--d2-blue, #4a9eff); font-weight: 600; }
+.d2-page .codeblock .flag    { color: var(--d2-cyan, #22d3ee); }
+.d2-page .codeblock .val     { color: var(--d2-green, #10b981); }
+.d2-page .codeblock .str     { color: var(--d2-yellow, #f59e0b); }
+.d2-page .codeblock .kw      { color: var(--d2-purple, #8b5cf6); font-weight: 600; }
+.d2-page .codeblock .fn      { color: var(--d2-orange, #f97316); }
+.d2-page .codeblock .cls     { color: var(--d2-pink, #ec4899); }
+.d2-page .codeblock .num     { color: var(--d2-cyan, #22d3ee); }
+.d2-page .codeblock .out     { color: #6a8080; }
+.d2-page .codeblock .prompt  { color: #4a6080; user-select: none; }
+
+/* ─── Code Block Label ────────────────────────────────────────────── */
+.d2-page .cb-wrap {
+    margin-bottom: 14px;
+}
+
+.d2-page .cb-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--d2-surface2, #111a2e);
+    border: 1px solid var(--d2-border, #1a2d50);
+    border-bottom: none;
+    border-radius: 8px 8px 0 0;
+    padding: 6px 14px;
+    font-size: 11px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    color: var(--d2-text-muted, #8899b0);
+}
+
+.d2-page .cb-label .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+}
+
+.d2-page .cb-label .dot-red    { background: #ef4444; }
+.d2-page .cb-label .dot-yellow { background: #f59e0b; }
+.d2-page .cb-label .dot-green  { background: #10b981; }
+
+.d2-page .cb-wrap .codeblock {
+    border-radius: 0 0 10px 10px;
+    margin-bottom: 0;
+}
+
+/* ─── Subsection Title ────────────────────────────────────────────── */
+.d2-page .stitle {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--d2-cyan, #22d3ee);
+    margin: 20px 0 10px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.d2-page .stitle::before {
+    content: '';
+    width: 3px;
+    height: 14px;
+    background: var(--d2-cyan, #22d3ee);
+    border-radius: 2px;
+    flex-shrink: 0;
+}
+
+/* ─── Resource Links ──────────────────────────────────────────────── */
+.d2-page .src {
+    margin-top: 16px;
+    padding-top: 14px;
+    border-top: 1px solid var(--d2-border, #1a2d50);
+}
+
+.d2-page .srct {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--d2-text-muted, #8899b0);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 8px;
+}
+
+.d2-page .src a {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--d2-blue, #4a9eff);
+    text-decoration: none;
+    margin-right: 14px;
+    transition: opacity 0.15s;
+}
+
+.d2-page .src a:hover { opacity: 0.75; }
+
+/* ─── Page Footer ─────────────────────────────────────────────────── */
+.d2-page .page-footer {
+    text-align: center;
+    padding: 32px 20px;
+    border-top: 1px solid var(--d2-border, #1a2d50);
+    font-size: 13px;
+    color: var(--d2-text-muted, #8899b0);
+}
+
+/* ─── Divider ─────────────────────────────────────────────────────── */
+.d2-page .sdivider {
+    border: none;
+    border-top: 1px solid var(--d2-border, #1a2d50);
+    margin: 48px 0;
+}
+
+/* ─── Step List ───────────────────────────────────────────────────── */
+.d2-page .slist {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 14px;
+}
+
+.d2-page .slist li {
+    display: flex;
+    gap: 10px;
+    font-size: 13px;
+    color: var(--d2-text, #c8d6e8);
+    padding: 6px 0;
+    border-bottom: 1px solid rgba(26, 45, 80, 0.5);
+    line-height: 1.65;
+}
+
+.d2-page .slist li:last-child { border-bottom: none; }
+
+.d2-page .slist .snum {
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: rgba(74, 158, 255, 0.15);
+    color: var(--d2-blue, #4a9eff);
+    font-size: 10px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 2px;
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+    .d2-page .tgrid {
+        grid-template-columns: 1fr;
+    }
+
+    .d2-page .sec-head {
+        flex-wrap: wrap;
+    }
+}
+
+@media (max-width: 640px) {
+    .d2-page .hero {
+        padding: 48px 16px 36px;
+    }
+
+    .d2-page .hero h1 {
+        font-size: 24px;
+    }
+
+    .d2-page .hero-meta {
+        gap: 8px;
+    }
+
+    .d2-page .wrapper {
+        padding: 24px 14px 60px;
+    }
+
+    .d2-page .tcard {
+        padding: 16px;
+    }
+}

--- a/app/gcl/associate-cloud-engineer/domain2/layout.tsx
+++ b/app/gcl/associate-cloud-engineer/domain2/layout.tsx
@@ -1,0 +1,9 @@
+import './domain2.css';
+
+export default function Domain2Layout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return <>{children}</>;
+}

--- a/app/gcl/associate-cloud-engineer/domain2/page.tsx
+++ b/app/gcl/associate-cloud-engineer/domain2/page.tsx
@@ -153,6 +153,36 @@ function Chapter1() {
                     参考: cloud.google.com/blog/topics/developers-practitioners/where-should-i-run-my-stuff-choosing-google-cloud-compute-option
                 </div>
             </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">1.3</span>コスト最適化: Pricing Calculator と確約利用割引（補足）</div>
+                <p className="tcard-desc">アーキテクチャ計画段階でのコスト見積もりと制御メカニズムを理解することが、クラウド破産を防ぐ鍵です。</p>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">最適化手法</span>
+                        <span className="cthead">説明</span>
+                        <span className="cthead">対象</span>
+                    </div>
+                    {[
+                        ['Pricing Calculator', 'リソースの予想利用量から月額料金をシミュレーション。リージョンごとの差分も把握可能', 'すべてのサービス'],
+                        ['確約利用割引（CUD）1年', '1年間の利用確約でオンデマンド価格から最大20%割引', 'Compute Engine / Cloud SQL'],
+                        ['確約利用割引（CUD）3年', '3年間の利用確約で最大70%割引', 'Compute Engine / Cloud SQL'],
+                        ['財務バッファ', 'サーバーレスの見積もりには10〜20%の余裕を追加（トラフィックスパイク対応）', 'Cloud Run / Functions / MIG'],
+                        ['カスタム割り当て（Quotas）', 'BigQuery の1日あたりの処理データ量に上限を設定して高額請求を防止', 'BigQuery'],
+                        ['Maximum bytes billed', 'クエリ単位で上限バイト数を設定。上限超過クエリは実行前に失敗させる', 'BigQuery'],
+                    ].map(([method, desc, target]) => (
+                        <div className="ctable-row" key={method}>
+                            <span className="ctval">{method}</span>
+                            <span className="ctdef">{desc}</span>
+                            <span className="ctdef">{target}</span>
+                        </div>
+                    ))}
+                </div>
+                <div className="wb">
+                    <div className="wbt">初学者の罠</div>
+                    <p>BigQuery で <code>LIMIT</code> 句を使っても、列指向ストレージの特性上スキャンされるデータ量（課金対象バイト数）は一切減少しません。必ず<strong>テーブルプレビュー機能</strong>を使い、クエリ前に推定コストを確認してください。</p>
+                </div>
+            </div>
         </div>
     );
 }
@@ -381,6 +411,193 @@ gcloud compute firewall-rules create allow-ssh-bastion \\
                 </div>
                 <div className="src">
                     参考: cloud.google.com/blog/products/compute/top-compute-engine-documentation-pages/
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter16() {
+    return (
+        <div id="ch16" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn16">16</div>
+                <div className="sec-head-txt">
+                    <h2>試験対策まとめ</h2>
+                    <p>頻出パターン・重要用語チェックリスト・推奨リソース — ACE Domain 2 完全攻略ガイド</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">16.1</span>試験頻出の選択問題パターン</div>
+
+                <p className="stitle">パターン①: コンピューティングサービスの選択</p>
+                <pre className="codeblock">{`【問題文の例】
+「画像処理のバッチジョブを実行したい。
+ コストを最小化しつつ、停止されても問題ない。
+ どのサービスを使うべきか？」
+
+正解: Spot VM + MIG
+理由:
+  ・バッチジョブ → 停止されても問題ない
+  ・コスト最小化 → Spot VM（最大91%割引）
+  ・停止後の自動再作成 → MIG と組み合わせ
+
+【問題文の例】
+「HTTP API を提供したい。
+ アイドル時間はコストゼロにしたい。
+ どのサービスを使うべきか？」
+
+正解: Cloud Run
+理由:
+  ・HTTP API → Cloud Run
+  ・アイドル時コストゼロ → ゼロスケール可能`}</pre>
+
+                <p className="stitle">パターン②: データベースの選択</p>
+                <pre className="codeblock">{`【問題文の例】
+「グローバルに展開する金融システムで
+ 強い整合性が必要。99.999% の可用性が必要。
+ どのDBを使うべきか？」
+
+正解: Cloud Spanner
+理由:
+  ・グローバル分散 → Spanner
+  ・強整合性 → Spanner（ACID）
+  ・99.999% SLA → Spanner のみが提供
+
+【問題文の例】
+「IoT デバイスから毎秒100万件のデータが来る。
+ 低レイテンシでの書き込みが必要。
+ どのDBを使うべきか？」
+
+正解: Cloud Bigtable
+理由:
+  ・超大規模・高スループット → Bigtable
+  ・時系列データ → Bigtable のユースケース`}</pre>
+
+                <p className="stitle">パターン③: ネットワーク設計</p>
+                <pre className="codeblock">{`【問題文の例】
+「複数のチームが同じ VPC ネットワークを使いたい。
+ ネットワーク管理は1チームが担当し、
+ 各チームはアプリのみ管理したい。」
+
+正解: Shared VPC
+理由:
+  ・ネットワーク管理の集中化 → ホストプロジェクト
+  ・各チームがアプリを管理 → サービスプロジェクト
+
+【問題文の例】
+「VPC A が VPC B と Peering。
+ VPC B が VPC C と Peering。
+ A から C に直接通信できるか？」
+
+正解: できない（Peering は推移的でない）`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">16.2</span>Domain 2 重要用語チェックリスト</div>
+
+                <p className="stitle">コンピューティング</p>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス</div>
+                    <ul>
+                        <li>Spot VM は最大 <strong>91%</strong> 割引で、いつでもプリエンプトされる</li>
+                        <li>Spot VM はバッチ・ML・レンダリングに最適（Web サーバーは NG）</li>
+                        <li>GKE Autopilot は Pod リソース単位の課金（アイドルコストなし）</li>
+                        <li>GKE Standard は特権コンテナや DaemonSet が必要な場合に選択</li>
+                        <li>Workload Identity で GKE から GCP API にアクセス（JSON キー禁止）</li>
+                        <li>Cloud Run はゼロスケール可能なサーバーレスコンテナ</li>
+                    </ul>
+                </div>
+
+                <p className="stitle">ストレージ・データベース</p>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス</div>
+                    <ul>
+                        <li>Cloud Storage の 4 クラス（Standard/Nearline/Coldline/Archive）の使い分け</li>
+                        <li>Nearline=30日、Coldline=90日、Archive=365日 の最小保存期間</li>
+                        <li>OLM（Object Lifecycle Management）でストレージクラスを自動移行</li>
+                        <li>署名付き URL の最大有効期間は <strong>7日間</strong></li>
+                        <li>Cloud SQL は標準 RDBMS、Spanner はグローバル分散（99.999%）</li>
+                        <li>Bigtable は ペタバイトスケール・時系列データ</li>
+                        <li>Firestore はリアルタイム同期・モバイル/IoT バックエンド</li>
+                    </ul>
+                </div>
+
+                <p className="stitle">ネットワーク</p>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス</div>
+                    <ul>
+                        <li>Google Cloud VPC は <strong>グローバル</strong>（リージョンをまたぐ）</li>
+                        <li>Shared VPC: ホストプロジェクトがネットワークを集中管理</li>
+                        <li>VPC Peering は <strong>推移的でない</strong>（A-B-C でも A-C は通信不可）</li>
+                        <li>Cloud NAT: 外部 IP なし VM のインターネットアウトバウンド</li>
+                        <li>Cloud DNS 転送ゾーン: GCP → オンプレの DNS 解決</li>
+                        <li>Global ALB はグローバル配信、Regional LB はリージョン内限定</li>
+                        <li>コンプライアンス要件（データ主権）には必ずリージョナル LB</li>
+                    </ul>
+                </div>
+
+                <p className="stitle">Terraform</p>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス</div>
+                    <ul>
+                        <li>State ファイルは <strong>Cloud Storage のリモートバックエンド</strong>に保存</li>
+                        <li>State ファイルを <strong>手動編集禁止</strong></li>
+                        <li><code>terraform plan -out=tfplan</code> → <code>terraform apply tfplan</code> の順番</li>
+                        <li>CI/CD の認証は JSON キーではなく <strong>Workload Identity/ADC</strong></li>
+                        <li>Terraform 1.5以降は <code>import</code> ブロックで既存リソースを取り込み</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">16.3</span>推奨学習リソース（Domain 2）</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">リソース</span>
+                        <span className="cthead">URL</span>
+                    </div>
+                    {[
+                        ['ACE 試験公式ページ', 'cloud.google.com/learn/certification/cloud-engineer'],
+                        ['Compute Engine ドキュメント', 'cloud.google.com/compute/docs'],
+                        ['OS Login 設定', 'cloud.google.com/compute/docs/oslogin/set-up-oslogin'],
+                        ['Spot VM の作成と使用', 'cloud.google.com/compute/docs/instances/create-use-spot'],
+                        ['GKE Autopilot セキュリティ', 'cloud.google.com/kubernetes-engine/docs/concepts/autopilot-security'],
+                        ['GKE Autopilot vs Standard', 'cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison'],
+                        ['Cloud Run ネットワーキング', 'cloud.google.com/run/docs/configuring/networking-best-practices'],
+                        ['Cloud Storage ベストプラクティス', 'cloud.google.com/storage/docs/best-practices'],
+                        ['データベース選定ガイド', 'cloud.google.com/blog/topics/developers-practitioners/your-google-cloud-database-options-explained'],
+                        ['VPC 設計ベストプラクティス', 'cloud.google.com/architecture/best-practices-vpc-design'],
+                        ['Shared VPC', 'cloud.google.com/vpc/docs/shared-vpc'],
+                        ['Cloud NAT のベストプラクティス', 'cloud.google.com/blog/products/networking/6-best-practices-for-running-cloud-nat'],
+                        ['ロードバランサ選定', 'cloud.google.com/load-balancing/docs/choosing-load-balancer'],
+                        ['Terraform ベストプラクティス', 'cloud.google.com/docs/terraform/best-practices/operations'],
+                    ].map(([resource, url]) => (
+                        <div className="ctable-row" key={resource}>
+                            <span className="ctval">{resource}</span>
+                            <span className="ctdef">{url}</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">16.ADV</span>Domain 2 学習の最終アドバイス</div>
+                <div className="wb">
+                    <div className="wbt">最終アドバイス</div>
+                    <p>Domain 2 は ACE 試験の中で<strong>最大配点（≈21%）</strong>です。以下の点を徹底的に習得してください。</p>
+                </div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス</div>
+                    <ul>
+                        <li><strong>① サービス選定の「理由」を説明できるようにする</strong><br />
+                            「このサービスを選ぶのはなぜか？」を自分の言葉で説明できること</li>
+                        <li><strong>② アンチパターンと推奨パターンをセットで覚える</strong><br />
+                            「❌ JSON キー → ✅ Workload Identity」のように対比で理解する</li>
+                        <li><strong>③ 実際に手を動かす（ハンズオン）</strong><br />
+                            Cloud Shell や Google Cloud Skills Boost で実際に触ることが最高の学習法</li>
+                    </ul>
                 </div>
             </div>
         </div>
@@ -834,6 +1051,47 @@ serviceAccount: 'projects/PROJECT/serviceAccounts/terraform-sa@PROJECT.iam.gserv
                         ))}
                     </div>
                 </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">10.ADV</span>AlloyDB アーキテクチャ深掘り: コンピュート/ストレージ分離（補足）</div>
+                <pre className="codeblock">{`【AlloyDB の革新的アーキテクチャ】
+
+従来の PostgreSQL:
+  プライマリ DB が WAL（Write-Ahead Logging）を処理しながら
+  ページをディスクに書き込む → I/O 負荷が高い
+  「Torn Pages（不完全なページ書き込み）」問題のリスクあり
+
+AlloyDB のコンピュート/ストレージ分離:
+  WAL レコードのみをインテリジェントな分散ストレージ層
+  （Log Processing Service: LPS）に送信
+
+  LPS が担当:
+  ├── WAL の解析・適用
+  ├── ページの更新（コンピュート層に代わって）
+  └── ネットワーク効率の最大化
+
+  → プライマリ DB は I/O の重い作業から解放
+  → Torn Pages 問題を根本から解決
+  → リードレプリカを極めて低遅延でスケールアウト可能`}</pre>
+
+                <pre className="codeblock">{`【Hyperdisk（次世代ブロックストレージ）との使い分け】
+
+Persistent Disk（従来）:
+  容量・スループット・IOPS が連動して決まる
+
+Hyperdisk（新世代）:
+  容量 と スループット/IOPS を完全に独立してプロビジョニング
+  → データ分析: 大容量・高スループット を低コストで実現
+  → 高I/O DB: 大容量 は不要だが高IOPSが必要、という場合に最適
+  → 動的な変更が可能（再起動不要）
+
+用途別推奨:
+  ├── 一般的な VM ワークロード → Balanced Persistent Disk
+  ├── 高I/O データベース → Hyperdisk Extreme
+  ├── データ分析・高スループット → Hyperdisk Throughput
+  └── キャッシュ・一時データ → Local SSD（VM停止でデータ消滅）`}</pre>
+                <div className="src">参考: cloud.google.com/blog/products/databases/alloydb-for-postgresql-intelligent-scalable-storage</div>
             </div>
         </div>
     );
@@ -2093,6 +2351,33 @@ spec:
                     </div>
                 </div>
             </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.ADV</span>GKE ネットワーク深掘り: VPC-native クラスター（補足）</div>
+                <pre className="codeblock">{`【ルートベース vs VPC ネイティブ クラスター】
+
+ルートベース クラスター（旧）:
+  Pod の IP ルーティングを VPC の静的ルートに依存
+  → ノード数増加でルート割り当て上限（クォータ）に到達
+  → スケーラビリティのボトルネックとなる
+  → 一度作成したら VPC ネイティブに移行不可！
+
+VPC ネイティブ クラスター（現在のデフォルト・推奨）:
+  エイリアスIP（Alias IPs）で Pod に直接 IP を割り当て
+  → VPC ルーティングテーブルを消費しない
+  → 無限に近いスケーラビリティを実現
+
+VPC ネイティブが有効にする追加機能:
+  ├── コンテナネイティブ負荷分散（NEG: Network Endpoint Group）
+  │   → LB が Pod に直接ルーティング（VMを経由しない高効率）
+  └── Google API へのプライベートアクセス（VPC SC との連携）
+
+計画段階での重要な教訓:
+  → 新規クラスターは必ず VPC ネイティブを選択
+  → ルートベースから VPC ネイティブへの移行は不可能
+     （クラスターを作り直す必要がある）`}</pre>
+                <div className="src">参考: cloud.google.com/kubernetes-engine/docs/how-to/routes-based-cluster</div>
+            </div>
         </div>
     );
 }
@@ -2799,10 +3084,7 @@ export default function Domain2Page() {
                 <Chapter13 />
                 <Chapter14 />
                 <Chapter15 />
-                <div id="ch16" className="sgap">
-                    <h2>試験対策まとめ</h2>
-                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>ベストプラクティス: 実装中...</p>
-                </div>
+                <Chapter16 />
             </div>
 
             <footer className="page-footer">

--- a/app/gcl/associate-cloud-engineer/domain2/page.tsx
+++ b/app/gcl/associate-cloud-engineer/domain2/page.tsx
@@ -387,6 +387,458 @@ gcloud compute firewall-rules create allow-ssh-bastion \\
     );
 }
 
+function Chapter14() {
+    return (
+        <div id="ch14" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn14">14</div>
+                <div className="sec-head-txt">
+                    <h2>ロードバランサの選定と設定</h2>
+                    <p>ALB/NLB・URL マップ・Cloud Armor・コンプライアンス要件 — トラフィック分散の完全ガイド</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">14.1</span>ロードバランサ選定フローチャート</div>
+                <pre className="codeblock">{`どんなトラフィック？
+├── HTTP/HTTPS
+│   └── Application Load Balancer (L7)
+│       ├── グローバル配信が必要 → Global External ALB (Premium Tier)
+│       ├── リージョン内に限定 → Regional External ALB
+│       └── VPC 内部のみ → Internal ALB
+│
+└── TCP/UDP/その他
+    └── Network Load Balancer (L4)
+        ├── SSL オフロード必要 → Proxy Network LB
+        └── 送信元 IP 保持・UDP が必要 → Passthrough Network LB
+            └── 内部通信のみ → Internal Passthrough NLB`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">14.2</span>Application Load Balancer（L7）</div>
+
+                <p className="stitle">Global External ALB（グローバル外部 ALB）</p>
+                <pre className="codeblock">{`特徴:
+  ├── Anycast IP（1つのIPで全世界にサービス提供）
+  ├── ユーザーに最も近いエッジ PoP で SSL 終端
+  ├── URL ベースのルーティング（/api/* → API バックエンド）
+  ├── ヘッダーベースのルーティング
+  ├── Cloud Armor（DDoS 防御）と統合
+  └── Premium Tier ネットワーク使用（Google のバックボーン）
+
+主なユースケース:
+  ├── グローバルな Web サービス
+  ├── 複数リージョンにバックエンドを分散
+  └── セキュリティ要件の高い Web アプリ`}</pre>
+
+                <p className="stitle">URL マップによるルーティング</p>
+                <pre className="codeblock">{`URL マップの例:
+
+/ （デフォルト）→ フロントエンド MIG
+/api/*         → API Cloud Run サービス
+/static/*      → Cloud Storage バケット（静的コンテンツ）
+/admin/*       → 管理者用バックエンド（特定 IP のみ Cloud Armor で制限）`}</pre>
+
+                <pre className="codeblock">{`# URL マップを作成
+gcloud compute url-maps create my-url-map \\
+  --default-service=frontend-backend-service
+
+# パスマッチャーを追加
+gcloud compute url-maps add-path-matcher my-url-map \\
+  --path-matcher-name=api-matcher \\
+  --default-service=frontend-backend-service \\
+  --backend-service-path-rules=/api/*=api-backend-service,/static/*=storage-backend`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">14.3</span>Network Load Balancer（L4）</div>
+                <pre className="codeblock">{`Proxy Network LB（プロキシ型）:
+  クライアント ─── 接続終端 ─── Cloud LB ─── 新しい接続 ─── バックエンド
+
+  ・LB でTCP接続を終端
+  ・SSL オフロードが可能
+  ・クライアントの送信元IPが失われる（X-Forwarded-For ヘッダーで補完）
+
+Passthrough Network LB（パススルー型）:
+  クライアント ──────────────── バックエンド（直接）
+              ↑ パケットをそのまま転送
+
+  ・クライアントの送信元IPをそのままバックエンドに転送
+  ・TCP/UDP/ESP/GRE/ICMP に対応
+  ・バックエンドが直接クライアントに応答（DSR: Direct Server Return）
+
+使い分け:
+  送信元IP が必要（ログ記録・地域制限など）→ Passthrough
+  SSL オフロードが必要 → Proxy`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">14.4</span>コンプライアンス要件とロードバランサの選択</div>
+                <div className="wb">
+                    <div className="wbt">試験頻出</div>
+                    <p>データ主権・コンプライアンス要件がある場合</p>
+                </div>
+                <pre className="codeblock">{`【コンプライアンス要件がある場合】
+
+「すべてのトラフィックを日本国内に留める必要がある」
+「SSL/TLS 終端は必ず東京リージョンで行わなければならない」
+
+→ グローバルスコープの ALB は使えない！
+  グローバル ALB はエッジで SSL 終端するため
+  海外の PoP でも処理される可能性がある
+
+→ 必ず「リージョナル」ロードバランサを選択
+  Regional External ALB または
+  Regional Internal ALB`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">14.5</span>Cloud Armor（DDoS 防御）</div>
+                <pre className="codeblock">{`【Cloud Armor の主な機能】
+
+DDoS 防御:
+  → アプリケーション層（L7）の攻撃を自動軽減
+
+WAF（Web Application Firewall）:
+  → SQLインジェクション・XSS などを検出・ブロック
+
+カスタムルール:
+  → 特定 IP からのブロック
+  → 地理情報ベースのアクセス制御
+
+レート制限:
+  → 1つの IP から大量リクエストをブロック`}</pre>
+
+                <pre className="codeblock">{`# Cloud Armor ポリシーを作成して ALB に適用
+gcloud compute security-policies create my-security-policy \\
+  --description="WAF and DDoS protection"
+
+# 日本以外からのアクセスをブロック
+gcloud compute security-policies rules create 1000 \\
+  --security-policy=my-security-policy \\
+  --expression="origin.region_code != 'JP'" \\
+  --action=deny-403
+
+# ALB バックエンドサービスにポリシーを適用
+gcloud compute backend-services update my-backend-service \\
+  --security-policy=my-security-policy \\
+  --global`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">14.BP</span>ベストプラクティス: ロードバランサ</div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス</div>
+                    <div className="ctable">
+                        <div className="ctable-head">
+                            <span className="cthead">#</span>
+                            <span className="cthead">ベストプラクティス</span>
+                            <span className="cthead">理由</span>
+                        </div>
+                        {[
+                            ['1', '本番 Web アプリには Cloud Armor を必ず設定', 'DDoS・WAF 保護'],
+                            ['2', 'コンプライアンス要件がある場合はリージョナル LB を選択', 'データの地理的制限'],
+                            ['3', 'バックエンドサービスにヘルスチェックを設定', '異常バックエンドへのルーティング防止'],
+                            ['4', 'グローバル ALB は Premium Tier ネットワークで使用', 'Standard Tier では真のグローバル配信にならない'],
+                            ['5', '送信元 IP が必要なら Passthrough NLB を選択', 'Proxy 型は送信元 IP が失われる'],
+                        ].map(([num, bp, reason]) => (
+                            <div className="ctable-row" key={num}>
+                                <span className="ctval">{num}</span>
+                                <span className="ctval">{bp}</span>
+                                <span className="ctdef">{reason}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter15() {
+    return (
+        <div id="ch15" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn15">15</div>
+                <div className="sec-head-txt">
+                    <h2>Infrastructure as Code (Terraform)</h2>
+                    <p>State管理・リモートバックエンド・CI/CD統合・GitOps — IaC の完全ガイド</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">15.1</span>なぜ IaC が重要か？</div>
+                <pre className="codeblock">{`【手動でコンソール操作する問題】
+
+  ├── 再現性がない（「あの設定どうやったっけ？」）
+  ├── 環境間の差異（dev と prod の設定が微妙に違う）
+  ├── 監査ができない（「誰がいつ何を変えたか？」）
+  └── ヒューマンエラー（クリック間違い）
+
+【Terraform（IaC）による解決】
+
+  ├── コードとして定義 → 完全に再現可能
+  ├── Git で管理 → 変更履歴が完全に記録される
+  ├── PR レビュー → 本番適用前に人間がチェック
+  └── plan → apply の 2 ステップで安全に適用`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">15.2</span>Terraform の基本構造</div>
+                <pre className="codeblock">{`# main.tf - リソースの定義
+resource "google_compute_instance" "web_server" {
+  name         = "web-server-prod"
+  machine_type = "n2-standard-4"
+  zone         = "asia-northeast1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+      size  = 50
+    }
+  }
+
+  network_interface {
+    network    = "my-vpc"
+    subnetwork = "web-subnet"
+    # access_config なし = 外部IP なし（推奨）
+  }
+
+  metadata = {
+    enable-oslogin = "TRUE"
+  }
+
+  tags = ["web-server"]
+}
+
+# variables.tf - 変数の定義
+variable "project_id" {
+  description = "Google Cloud プロジェクト ID"
+  type        = string
+}
+
+variable "region" {
+  description = "デプロイするリージョン"
+  type        = string
+  default     = "asia-northeast1"
+}
+
+# outputs.tf - 出力値の定義
+output "instance_internal_ip" {
+  description = "VM の内部 IP"
+  value       = google_compute_instance.web_server.network_interface[0].network_ip
+}`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">15.3</span>State ファイルの管理（最重要）</div>
+                <p className="tcard-desc">Terraform は「terraform.tfstate」というファイルで「コードと実際のGCPリソースの対応関係」を管理します。</p>
+                <pre className="codeblock">{`terraform.tfstate の中身（例）:
+{
+  "resources": [
+    {
+      "type": "google_compute_instance",
+      "name": "web_server",
+      "instances": [
+        {
+          "attributes": {
+            "id": "projects/my-proj/zones/asia-northeast1-a/instances/web-server-prod",
+            "machine_type": "n2-standard-4",
+            ...
+          }
+        }
+      ]
+    }
+  ]
+}
+
+もしこのファイルが壊れると:
+  Terraform がリソースを「存在しない」と思い込み
+  → 既存リソースを削除して再作成しようとする！
+  → 本番環境への大規模障害！`}</pre>
+                <div className="wb">
+                    <div className="wbt">絶対禁止</div>
+                    <p><code>terraform.tfstate</code> を手動で編集してはいけません！</p>
+                </div>
+
+                <p className="stitle">ローカル State の問題点</p>
+                <pre className="codeblock">{`【ローカル State の問題】
+
+開発者 A が terraform apply
+  → ローカルの tfstate が更新
+
+開発者 B が同時に terraform apply（古い tfstate を持っている）
+  → State の競合！
+  → リソースが重複作成 or 意図しない削除！
+
+→ チーム開発でのローカル State は使用禁止`}</pre>
+
+                <p className="stitle">リモートバックエンドの設定（Cloud Storage）</p>
+                <pre className="codeblock">{`# backend.tf
+terraform {
+  backend "gcs" {
+    bucket  = "my-terraform-state-bucket"
+    prefix  = "terraform/state"
+  }
+}`}</pre>
+
+                <pre className="codeblock">{`# State 用の Cloud Storage バケットを作成
+gcloud storage buckets create gs://my-terraform-state-bucket \\
+  --location=asia-northeast1 \\
+  --uniform-bucket-level-access
+
+# バージョニングを有効化（State の変更履歴を保存）
+gcloud storage buckets update gs://my-terraform-state-bucket \\
+  --versioning
+
+# State ロックは GCS バックエンドで自動的に有効化される
+# → 並行 apply を自動防止！`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">15.4</span>Terraform の安全なデプロイフロー</div>
+                <pre className="codeblock">{`【標準的なデプロイフロー】
+
+Step 1: コードを変更してコミット
+  ↓
+Step 2: terraform plan でプレビュー
+  $ terraform plan -out=tfplan
+
+  出力例:
+  Plan: 1 to add, 2 to change, 0 to destroy.
+
+  + google_compute_instance.new_vm       ← 追加される
+  ~ google_compute_instance.web_server   ← 変更される
+
+  → 変更内容を確認してレビュー
+
+Step 3: プランファイルを使って適用
+  $ terraform apply tfplan
+
+  → plan 時と同じ内容のみ適用（サプライズなし！）
+
+【重要】プランファイルの注意点:
+  プランファイルは実行環境（パスなど）に依存するため
+  環境間を移動して使うことはできない`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">15.5</span>既存リソースの Import</div>
+
+                <p className="stitle">従来の方法（Terraform {`<`} 1.5）</p>
+                <pre className="codeblock">{`# Console で手動作成した VM を Terraform 管理下に置く
+terraform import google_compute_instance.my_vm \\
+  projects/PROJECT/zones/asia-northeast1-a/instances/my-vm`}</pre>
+
+                <p className="stitle">モダンな方法（Terraform {`>=`} 1.5 推奨）</p>
+                <pre className="codeblock">{`# main.tf に import ブロックを追加
+import {
+  to = google_compute_instance.my_vm
+  id = "projects/PROJECT/zones/asia-northeast1-a/instances/my-vm"
+}
+
+resource "google_compute_instance" "my_vm" {
+  name         = "my-vm"
+  # ... リソースの設定
+}`}</pre>
+
+                <pre className="codeblock">{`# import を含む plan を実行
+terraform plan  # import ブロックを検出して取り込み計画を表示
+
+# 問題なければ apply
+terraform apply`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">15.6</span>CI/CD パイプラインとの統合（GitOps）</div>
+                <pre className="codeblock">{`リポジトリ構造:
+
+my-infra/
+├── environments/
+│   ├── dev/
+│   │   ├── main.tf
+│   │   ├── variables.tf
+│   │   └── terraform.tfvars
+│   │
+│   └── prod/
+│       ├── main.tf
+│       ├── variables.tf
+│       └── terraform.tfvars
+│
+└── modules/
+    ├── vpc/
+    ├── gke/
+    └── cloud-sql/
+
+【ブランチ戦略】
+  feature/xxx → dev ブランチへの PR
+                  ↓ マージ
+              dev ブランチ → dev 環境に自動 apply
+                  ↓ 承認
+              main ブランチへの PR → レビュー
+                  ↓ マージ
+              main ブランチ → prod 環境に自動 apply`}</pre>
+
+                <p className="stitle">Cloud Build による CI/CD</p>
+                <pre className="codeblock">{`# cloudbuild.yaml
+steps:
+  # Terraform の初期化
+  - name: 'hashicorp/terraform:1.5'
+    entrypoint: 'terraform'
+    args: ['init', '-backend-config=bucket=my-state-bucket']
+    dir: 'environments/\${_ENV}'
+
+  # プランの実行
+  - name: 'hashicorp/terraform:1.5'
+    entrypoint: 'terraform'
+    args: ['plan', '-out=tfplan']
+    dir: 'environments/\${_ENV}'
+
+  # 適用（main ブランチのみ）
+  - name: 'hashicorp/terraform:1.5'
+    entrypoint: 'terraform'
+    args: ['apply', '-auto-approve', 'tfplan']
+    dir: 'environments/\${_ENV}'
+
+substitutions:
+  _ENV: 'dev'
+
+# Cloud Build のサービスアカウントで実行（JSON キー不要！）
+serviceAccount: 'projects/PROJECT/serviceAccounts/terraform-sa@PROJECT.iam.gserviceaccount.com'`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">15.BP</span>ベストプラクティス: Terraform</div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス</div>
+                    <div className="ctable">
+                        <div className="ctable-head">
+                            <span className="cthead">#</span>
+                            <span className="cthead">ベストプラクティス</span>
+                            <span className="cthead">理由</span>
+                        </div>
+                        {[
+                            ['1', 'State は Cloud Storage リモートバックエンドに保存', '競合・紛失防止'],
+                            ['2', 'State バケットはバージョニングを有効化', '誤操作からの復元'],
+                            ['3', 'terraform plan -out=tfplan を必ず実施', '意図しない変更の防止'],
+                            ['4', 'State ファイルを手動編集禁止', '設定破損リスク'],
+                            ['5', 'CI/CD 認証は Workload Identity/ADC を使用（JSON キー禁止）', 'キー漏洩防止'],
+                            ['6', '環境ごとに別ディレクトリ・別 State バケットを使用', '誤った環境への適用防止'],
+                            ['7', 'terraform import ブロックで既存リソースを管理下へ', 'コンソールで作ったリソースをIaC管理に移行'],
+                        ].map(([num, bp, reason]) => (
+                            <div className="ctable-row" key={num}>
+                                <span className="ctval">{num}</span>
+                                <span className="ctval">{bp}</span>
+                                <span className="ctdef">{reason}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
 function Chapter11() {
     return (
         <div id="ch11" className="sgap">
@@ -2345,14 +2797,8 @@ export default function Domain2Page() {
                 <Chapter11 />
                 <Chapter12 />
                 <Chapter13 />
-                <div id="ch14" className="sgap">
-                    <h2>ロードバランサ</h2>
-                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
-                </div>
-                <div id="ch15" className="sgap">
-                    <h2>Terraform による IaC</h2>
-                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
-                </div>
+                <Chapter14 />
+                <Chapter15 />
                 <div id="ch16" className="sgap">
                     <h2>試験対策まとめ</h2>
                     <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>ベストプラクティス: 実装中...</p>

--- a/app/gcl/associate-cloud-engineer/domain2/page.tsx
+++ b/app/gcl/associate-cloud-engineer/domain2/page.tsx
@@ -1,0 +1,120 @@
+import type { Metadata } from 'next';
+import './domain2.css';
+
+export const metadata: Metadata = {
+    title: 'Domain 2: Planning and Implementing a Cloud Solution',
+    description:
+        'Google Cloud ACE Domain 2 包括的解説。コンピューティング・ストレージ・ネットワーク・Terraform の計画と実装を詳解。',
+};
+
+export default function Domain2Page() {
+    return (
+        <div className="d2-page">
+            <section className="hero">
+                <div className="hero-eyebrow">ACE Domain 2 · ~21%</div>
+                <h1>
+                    Planning and Implementing{' '}
+                    <span>a Cloud Solution</span>
+                </h1>
+                <p className="hero-sub">
+                    クラウドソリューションの計画と実装 — 初学者でもわかる詳細解説とベストプラクティス
+                </p>
+                <div className="hero-meta">
+                    <span className="hero-badge">
+                        <span className="dot dot-green" />
+                        試験配点 ~21%
+                    </span>
+                    <span className="hero-badge">
+                        <span className="dot dot-cyan" />
+                        全16章
+                    </span>
+                    <span className="hero-badge">
+                        <span className="dot" />
+                        コードブロック 234個
+                    </span>
+                </div>
+            </section>
+
+            <nav className="snav" role="navigation" aria-label="章ナビゲーション">
+                <div className="snav-inner">
+                    <a href="#ch0" className="snav-link"><span className="snav-num">00</span>全体マップ</a>
+                    <a href="#ch1" className="snav-link"><span className="snav-num">01</span>コンピューティング選定</a>
+                    <a href="#ch2" className="snav-link"><span className="snav-num">02</span>Compute Engine</a>
+                    <a href="#ch3" className="snav-link"><span className="snav-num">03</span>Spot VM</a>
+                    <a href="#ch4" className="snav-link"><span className="snav-num">04</span>MIG</a>
+                    <a href="#ch5" className="snav-link"><span className="snav-num">05</span>GKE</a>
+                    <a href="#ch6" className="snav-link"><span className="snav-num">06</span>Cloud Run</a>
+                    <a href="#ch7" className="snav-link"><span className="snav-num">07</span>Cloud Functions</a>
+                    <a href="#ch8" className="snav-link"><span className="snav-num">08</span>Cloud Storage</a>
+                    <a href="#ch9" className="snav-link"><span className="snav-num">09</span>ブロック/ファイル</a>
+                    <a href="#ch10" className="snav-link"><span className="snav-num">10</span>データベース</a>
+                    <a href="#ch11" className="snav-link"><span className="snav-num">11</span>VPC</a>
+                    <a href="#ch12" className="snav-link"><span className="snav-num">12</span>Shared VPC</a>
+                    <a href="#ch13" className="snav-link"><span className="snav-num">13</span>Cloud NAT/DNS</a>
+                    <a href="#ch14" className="snav-link"><span className="snav-num">14</span>ロードバランサ</a>
+                    <a href="#ch15" className="snav-link"><span className="snav-num">15</span>Terraform</a>
+                    <a href="#ch16" className="snav-link"><span className="snav-num">16</span>試験対策</a>
+                </div>
+            </nav>
+
+            <div className="wrapper">
+                <div id="ch0" className="sgap">
+                    <p style={{ color: 'var(--d2-text-muted)' }}>コンテンツ実装中...</p>
+                </div>
+                <div id="ch1" className="sgap">
+                    <h2>コンピューティングサービスの選定</h2>
+                </div>
+                <div id="ch2" className="sgap">
+                    <h2>Compute Engine 詳解</h2>
+                </div>
+                <div id="ch3" className="sgap">
+                    <h2>Spot VM の活用</h2>
+                </div>
+                <div id="ch4" className="sgap">
+                    <h2>Managed Instance Groups (MIG)</h2>
+                </div>
+                <div id="ch5" className="sgap">
+                    <h2>Google Kubernetes Engine (GKE)</h2>
+                </div>
+                <div id="ch6" className="sgap">
+                    <h2>Cloud Run</h2>
+                </div>
+                <div id="ch7" className="sgap">
+                    <h2>Cloud Functions</h2>
+                </div>
+                <div id="ch8" className="sgap">
+                    <h2>Cloud Storage</h2>
+                </div>
+                <div id="ch9" className="sgap">
+                    <h2>ブロック・ファイルストレージ</h2>
+                </div>
+                <div id="ch10" className="sgap">
+                    <h2>データベース選定</h2>
+                </div>
+                <div id="ch11" className="sgap">
+                    <h2>VPC 設計</h2>
+                </div>
+                <div id="ch12" className="sgap">
+                    <h2>Shared VPC と VPC Peering</h2>
+                </div>
+                <div id="ch13" className="sgap">
+                    <h2>Cloud NAT と Cloud DNS</h2>
+                </div>
+                <div id="ch14" className="sgap">
+                    <h2>ロードバランサ</h2>
+                </div>
+                <div id="ch15" className="sgap">
+                    <h2>Terraform による IaC</h2>
+                </div>
+                <div id="ch16" className="sgap">
+                    <h2>試験対策まとめ</h2>
+                    <p style={{ color: 'var(--d2-text-muted)' }}>ベストプラクティス: コンテンツ実装中...</p>
+                </div>
+            </div>
+
+            <footer className="page-footer">
+                <p>Domain 2: Planning and Implementing a Cloud Solution</p>
+            </footer>
+        </div>
+    );
+}

--- a/app/gcl/associate-cloud-engineer/domain2/page.tsx
+++ b/app/gcl/associate-cloud-engineer/domain2/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import './domain2.css';
 
 export const metadata: Metadata = {
     title: 'Domain 2: Planning and Implementing a Cloud Solution',

--- a/app/gcl/associate-cloud-engineer/domain2/page.tsx
+++ b/app/gcl/associate-cloud-engineer/domain2/page.tsx
@@ -387,6 +387,333 @@ gcloud compute firewall-rules create allow-ssh-bastion \\
     );
 }
 
+function Chapter11() {
+    return (
+        <div id="ch11" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn11">11</div>
+                <div className="sec-head-txt">
+                    <h2>VPC ネットワーク設計</h2>
+                    <p>グローバルVPC・カスタムモードサブネット・タグベースFWルール — ネットワーク基盤の設計ガイド</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">11.1</span>Google Cloud VPC の特徴</div>
+                <pre className="codeblock">{`【他のクラウドとの違い】
+
+他社クラウド（一般的）:        Google Cloud VPC:
+  リージョンごとに VPC          1つの VPC がグローバルに存在
+  asia-northeast1 VPC
+  us-central1 VPC        →     グローバル VPC
+                                 ├── サブネット（東京）
+                                 ├── サブネット（米国）
+                                 └── サブネット（欧州）
+
+→ マルチリージョン展開でもVPCを1つで管理できる！
+→ リージョン間の通信はGoogle のプライベートネットワーク（高速・低コスト）`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">11.2</span>サブネット設計</div>
+                <pre className="codeblock">{`【自動モード VPC】
+  → サブネットが各リージョンに自動作成（10.128.0.0/9）
+  → お試し・開発用途に便利
+  → 本番環境には不推奨（IP 範囲が固定）
+
+【カスタムモード VPC（本番環境推奨）】
+  → 自分でサブネットとIPレンジを定義
+  → 将来の VPC Peering で重複しないよう計画的に設計`}</pre>
+
+                <p className="stitle">サブネットの IP 範囲設計例</p>
+                <pre className="codeblock">{`【企業全体の IP 設計例】
+
+10.0.0.0/8 を会社全体に割り当て
+
+├── 10.1.0.0/16  → 東京リージョン（asia-northeast1）
+│   ├── 10.1.1.0/24  → 東京 Web 層（asia-northeast1-a）
+│   ├── 10.1.2.0/24  → 東京 App 層（asia-northeast1-b）
+│   └── 10.1.3.0/24  → 東京 DB 層（asia-northeast1-c）
+│
+├── 10.2.0.0/16  → 大阪リージョン（asia-northeast2）
+│   └── ...
+│
+└── 10.3.0.0/16  → オンプレミス（VPN/Interconnect で接続）`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">11.3</span>ファイアウォールルールの設計</div>
+                <pre className="codeblock">{`ファイアウォールルールは VPC レベルで管理（ハードウェアでなくソフトウェア）
+
+方向:
+  ├── INGRESS（入ってくるトラフィック）
+  └── EGRESS（出ていくトラフィック）
+
+対象の指定方法:
+  ├── ネットワークタグ（例: tag=web-server）← 推奨
+  ├── サービスアカウント
+  └── IP レンジ（例: 0.0.0.0/0 = すべて）
+
+優先度（Priority）: 数値が小さいほど優先（0〜65534）
+  デフォルト拒否ルール: Priority=65535（最低優先度）`}</pre>
+
+                <p className="stitle">ベストプラクティス: タグベースのファイアウォール</p>
+                <pre className="codeblock">{`# Web サーバータグを持つ VM に HTTP/HTTPS を許可
+gcloud compute firewall-rules create allow-web \\
+  --network=my-vpc \\
+  --direction=INGRESS \\
+  --priority=1000 \\
+  --action=ALLOW \\
+  --rules=tcp:80,tcp:443 \\
+  --target-tags=web-server \\
+  --source-ranges=0.0.0.0/0
+
+# App サーバーはロードバランサからのみアクセスを許可
+gcloud compute firewall-rules create allow-app-from-lb \\
+  --network=my-vpc \\
+  --direction=INGRESS \\
+  --priority=1000 \\
+  --action=ALLOW \\
+  --rules=tcp:8080 \\
+  --target-tags=app-server \\
+  --source-tags=load-balancer`}</pre>
+            </div>
+        </div>
+    );
+}
+
+function Chapter12() {
+    return (
+        <div id="ch12" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn12">12</div>
+                <div className="sec-head-txt">
+                    <h2>Shared VPC と VPC Peering</h2>
+                    <p>ホストプロジェクト・サービスプロジェクト・推移的接続の制約 — マルチプロジェクトネットワーク設計</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">12.1</span>Shared VPC（共有 VPC）</div>
+                <pre className="codeblock">{`【Shared VPC がない場合の問題】
+
+各チームが独自の VPC を持つ:
+  Project A（フロントエンドチーム）: 10.0.0.0/16
+  Project B（バックエンドチーム）: 10.1.0.0/16
+  Project C（DBチーム）: 10.2.0.0/16
+
+  問題: 各チームが自分でネットワークを管理 → 設定のばらつき
+       セキュリティポリシーの一貫性がない
+       ネットワーク管理の責任が分散
+
+【Shared VPC による解決】
+
+ホストプロジェクト（ネットワーク管理チームが所有）
+  └── VPC（統一されたサブネット・ファイアウォール）
+
+サービスプロジェクト A（フロントエンドチーム）
+  └── アプリ → ホストプロジェクトの VPC のサブネットを利用
+
+サービスプロジェクト B（バックエンドチーム）
+  └── アプリ → ホストプロジェクトの VPC のサブネットを利用
+
+メリット:
+  ✓ ネットワーク設定を一元管理（セキュリティポリシーの統一）
+  ✓ ネットワーク管理とアプリ開発の職務分掌
+  ✓ 各チームのコストは独立したプロジェクトで管理`}</pre>
+
+                <p className="stitle">Shared VPC の設定</p>
+                <pre className="codeblock">{`# ホストプロジェクトを指定
+gcloud compute shared-vpc enable HOST_PROJECT_ID
+
+# サービスプロジェクトをホストに紐付け
+gcloud compute shared-vpc associated-projects add SERVICE_PROJECT_ID \\
+  --host-project=HOST_PROJECT_ID
+
+# Network User ロールをサービスプロジェクトのチームに付与
+# （サブネットの使用権限のみ、VPC の設定変更は不可）
+gcloud projects add-iam-policy-binding HOST_PROJECT_ID \\
+  --member="group:backend-team@example.com" \\
+  --role="roles/compute.networkUser" \\
+  --condition="resource.name == projects/HOST_PROJECT_ID/regions/asia-northeast1/subnetworks/backend-subnet"`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">12.2</span>VPC Network Peering</div>
+                <pre className="codeblock">{`VPC A（Project 1）  ← Peering →  VPC B（Project 2）
+
+・内部 IP でプライベートに通信
+・Google のプライベートネットワークを使用（高速）
+・インターネットを経由しない
+・トラフィックが GCP を出ない
+
+使用場面:
+  ├── 異なるプロジェクト間の内部通信
+  └── 異なる組織の VPC 間の接続`}</pre>
+
+                <p className="stitle">⚠️ VPC Peering の重要な制約</p>
+                <pre className="codeblock">{`【制約 1: 推移的（Transitive）ではない】
+
+VPC A ── Peering ── VPC B ── Peering ── VPC C
+
+A と B は通信できる ✅
+B と C は通信できる ✅
+A と C は通信できない ❌ ← これが最重要！
+
+→ A と C を通信させるには、A-C 間の Peering を別途作成する必要あり
+
+【制約 2: IP アドレスの重複不可】
+
+VPC A: 10.0.0.0/16
+VPC B: 10.0.0.0/16 ← 重複！Peering 不可！
+
+→ Peering する VPC 間は IP 範囲が重複してはいけない
+→ カスタムモード VPC でIP を計画的に設計することが重要`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">12.3</span>Shared VPC vs VPC Peering の使い分け</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">判断基準</span>
+                        <span className="cthead">Shared VPC</span>
+                        <span className="cthead">VPC Peering</span>
+                    </div>
+                    {[
+                        ['管理の一元化', '✅（ホストプロジェクトで集中管理）', '❌（各VPCで個別管理）'],
+                        ['同一組織内', '✅', '✅'],
+                        ['異なる組織間', '❌', '✅'],
+                        ['スケール', '多数のプロジェクトに対応', '1対1の接続'],
+                        ['設定の複雑さ', '中程度', '低い'],
+                    ].map(([criteria, shared, peering]) => (
+                        <div className="ctable-row" key={criteria}>
+                            <span className="ctval">{criteria}</span>
+                            <span className="ctdef">{shared}</span>
+                            <span className="ctdef">{peering}</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter13() {
+    return (
+        <div id="ch13" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn13">13</div>
+                <div className="sec-head-txt">
+                    <h2>Cloud NAT と Cloud DNS</h2>
+                    <p>外部IP不要のアウトバウンド接続・ハイブリッドDNS解決 — セキュアなネットワーク出口設計</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">13.1</span>Cloud NAT</div>
+                <pre className="codeblock">{`【なぜ Cloud NAT が必要か？】
+
+セキュリティのベストプラクティス:
+  VM に外部 IP を割り当てない
+  → でも VM からインターネット（パッケージDL等）へのアクセスが必要
+
+解決策: Cloud NAT
+
+外部IP なし の VM
+    ↓
+Cloud NAT（送信元 IP を変換）
+    ↓
+インターネット（apt-get install, etc.）
+
+VM の外部 IP = Cloud NAT の IP（共有）
+→ 個々の VM の IP が外部に直接露出しない`}</pre>
+
+                <p className="stitle">Cloud NAT の設定</p>
+                <pre className="codeblock">{`# Cloud Router を作成（Cloud NAT の前提条件）
+gcloud compute routers create my-router \\
+  --network=my-vpc \\
+  --region=asia-northeast1
+
+# Cloud NAT を作成
+gcloud compute routers nats create my-nat \\
+  --router=my-router \\
+  --region=asia-northeast1 \\
+  --nat-all-subnet-ip-ranges \\
+  --auto-allocate-nat-external-ips`}</pre>
+
+                <p className="stitle">Cloud NAT のポート枯渇問題</p>
+                <pre className="codeblock">{`【ポート枯渇とは？】
+
+Cloud NAT は送信元 IP:ポート でセッションを識別
+各 VM に割り当てられるポート数には上限がある
+
+VM が同時接続数の上限を超えると:
+  → 新しい接続が確立できない
+  → "Connection refused" エラー
+
+【監視コマンド（MQL クエリ）】
+fetch nat_gateway
+| metric 'compute.googleapis.com/nat/port_usage'
+| align mean_aligner()
+| every 1m
+
+【対策】
+  ├── ポート数を手動増加（--min-ports-per-vm）
+  ├── 静的 NAT IP を追加
+  └── コネクションプールの最適化（アプリ側）`}</pre>
+
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: Cloud NAT</div>
+                    <ul>
+                        <li><strong>すべての VM に外部 IP を割り当てない</strong>（Cloud NAT でアウトバウンドを確保）</li>
+                        <li><strong>ポート使用率を Cloud Monitoring で継続監視</strong></li>
+                        <li><strong>--min-ports-per-vm</strong> を接続数に応じて適切に設定</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">13.2</span>Cloud DNS</div>
+
+                <p className="stitle">ハイブリッド環境でのDNS解決</p>
+                <pre className="codeblock">{`【シナリオ: オンプレミス + Google Cloud のハイブリッド構成】
+
+問題: 2つの環境でのDNS名前解決を統合したい
+
+Cloud DNS のプライベートゾーン:
+  gcp.internal → GCPリソースの名前解決
+
+オンプレミスの DNS サーバー:
+  corp.internal → オンプレミスリソースの名前解決
+
+【解決策】
+
+① オンプレ → GCP のプライベートゾーンを解決:
+  Cloud DNS にインバウンドフォワーダーを設定
+  オンプレの DNS が 169.254.169.254 に転送
+
+② GCP → オンプレのDNSを解決:
+  Cloud DNS に転送ゾーン（Forwarding Zone）を設定
+  gcp で corp.internal クエリ → オンプレ DNS サーバーに転送`}</pre>
+
+                <pre className="codeblock">{`# 転送ゾーンを作成（GCP → オンプレの DNS を解決）
+gcloud dns managed-zones create on-prem-forwarding \\
+  --dns-name=corp.internal. \\
+  --description="Forward to on-premises DNS" \\
+  --visibility=private \\
+  --networks=my-vpc \\
+  --forwarding-targets=10.0.0.53
+
+# インバウンドポリシーを作成（オンプレ → GCP を解決）
+gcloud dns policies create inbound-policy \\
+  --description="Inbound DNS forwarding" \\
+  --networks=my-vpc \\
+  --enable-inbound-forwarding`}</pre>
+            </div>
+        </div>
+    );
+}
+
 function Chapter8() {
     return (
         <div id="ch8" className="sgap">
@@ -2015,18 +2342,9 @@ export default function Domain2Page() {
                 <Chapter8 />
                 <Chapter9 />
                 <Chapter10 />
-                <div id="ch11" className="sgap">
-                    <h2>VPC 設計</h2>
-                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
-                </div>
-                <div id="ch12" className="sgap">
-                    <h2>Shared VPC と VPC Peering</h2>
-                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
-                </div>
-                <div id="ch13" className="sgap">
-                    <h2>Cloud NAT と Cloud DNS</h2>
-                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
-                </div>
+                <Chapter11 />
+                <Chapter12 />
+                <Chapter13 />
                 <div id="ch14" className="sgap">
                     <h2>ロードバランサ</h2>
                     <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>

--- a/app/gcl/associate-cloud-engineer/domain2/page.tsx
+++ b/app/gcl/associate-cloud-engineer/domain2/page.tsx
@@ -387,6 +387,600 @@ gcloud compute firewall-rules create allow-ssh-bastion \\
     );
 }
 
+function Chapter5() {
+    return (
+        <div id="ch5" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn5">05</div>
+                <div className="sec-head-txt">
+                    <h2>Google Kubernetes Engine (GKE)</h2>
+                    <p>Autopilot vs Standard・Workload Identity・Binary Authorization・オートスケーリングの完全ガイド</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.1</span>Kubernetes の基本概念</div>
+                <pre className="codeblock">{`【Kubernetes の主要オブジェクト】
+
+Pod（ポッド）
+  └── 1つ以上のコンテナをまとめた最小デプロイ単位
+      例: nginx コンテナ + ログ収集サイドカー
+
+Deployment（デプロイメント）
+  └── Pod の望ましい状態を定義・管理
+      例: 「このアプリを3つのレプリカで動かす」
+
+Service（サービス）
+  └── Pod へのネットワークアクセスを提供
+      例: 「このラベルを持つPodに負荷分散する」
+
+Node（ノード）
+  └── Pod が実際に動く仮想マシン（VM）
+      GKE では Compute Engine VM が Node になる
+
+Namespace（ネームスペース）
+  └── クラスタを論理的に分割する仮想境界
+      例: namespace: frontend, backend, monitoring`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.2</span>GKE の 2 つのモード: Autopilot vs Standard</div>
+
+                <p className="stitle">モード選択のフローチャート</p>
+                <pre className="codeblock">{`特権コンテナが必要？ → YES → Standard モード
+カーネルパラメータの変更が必要？ → YES → Standard モード
+DaemonSet でのエージェント配置が必要？ → YES → Standard モード
+既存のノード管理チームがある？ → YES → Standard モード
+                    ↓
+              それ以外の場合
+                    ↓
+          Autopilot モード（推奨）`}</pre>
+
+                <p className="stitle">🚀 GKE Autopilot モード</p>
+                <pre className="codeblock">{`【Autopilot でGoogle が自動管理するもの】
+
+インフラ管理:
+  ├── ノードのプロビジョニング（VM の作成）
+  ├── ノードのスケーリング（増減）
+  ├── ノードのアップグレード（Kubernetes バージョン更新）
+  └── ノードの修復（障害ノードの自動交換）
+
+セキュリティ:
+  ├── Kubernetes Baseline セキュリティ標準の強制適用
+  ├── 特権コンテナのブロック
+  ├── ホスト名前空間へのアクセス制限
+  └── Workload Identity の自動有効化
+
+【Autopilot の課金モデル】
+  ❌ ノード（VM）単位の課金 ではなく
+  ✅ Pod が要求する vCPU / メモリ / エフェメラルストレージ の課金
+
+  例: Pod が requests: cpu=0.5, memory=1Gi を設定
+    → その Pod が動いている時間だけ課金
+    → アイドルノードへの課金なし！`}</pre>
+
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">制約（Autopilot）</span>
+                        <span className="cthead">説明</span>
+                    </div>
+                    {[
+                        ['特権コンテナ', '❌ 実行不可'],
+                        ['HostPath ボリューム', '❌ 使用不可'],
+                        ['NodeSelector（特定ノードへの配置）', '限定的'],
+                        ['DaemonSet', '❌ 基本的に不可'],
+                        ['カーネルパラメータ変更', '❌ 不可'],
+                    ].map(([constraint, desc]) => (
+                        <div className="ctable-row" key={constraint}>
+                            <span className="ctval">{constraint}</span>
+                            <span className="ctdef">{desc}</span>
+                        </div>
+                    ))}
+                </div>
+
+                <p className="stitle">⚙️ GKE Standard モード</p>
+                <pre className="codeblock">{`【Standard でユーザーが管理するもの】
+
+・ノードプールの作成・削除
+・マシンタイプの選択
+・ノードのアップグレード（手動またはスケジュール設定）
+・ノード上の DaemonSet の管理
+
+【Standard が必要な場面】
+  ├── 特権コンテナの実行（一部のセキュリティツールなど）
+  ├── カーネルパラメータ（sysctl）の変更
+  ├── GPU / TPU ノードプールの設定
+  ├── カスタムロギング/監視エージェント（DaemonSet）
+  └── Bare Metal/特殊ハードウェアの要件`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.3</span>GKE クラスタの作成</div>
+
+                <p className="stitle">Autopilot クラスタの作成</p>
+                <pre className="codeblock">{`# Autopilot クラスタを作成（推奨設定）
+gcloud container clusters create-auto my-autopilot-cluster \\
+  --region=asia-northeast1 \\
+  --network=my-vpc \\
+  --subnetwork=my-subnet \\
+  --enable-private-nodes \\
+  --master-ipv4-cidr=172.16.0.0/28
+
+# クラスタへの認証情報を取得（kubectl で操作できるようにする）
+gcloud container clusters get-credentials my-autopilot-cluster \\
+  --region=asia-northeast1`}</pre>
+
+                <p className="stitle">Standard クラスタの作成</p>
+                <pre className="codeblock">{`# Standard クラスタを作成
+gcloud container clusters create my-standard-cluster \\
+  --machine-type=n2-standard-4 \\
+  --num-nodes=3 \\
+  --region=asia-northeast1 \\
+  --node-locations=asia-northeast1-a,asia-northeast1-b,asia-northeast1-c \\
+  --enable-autoscaling \\
+  --min-nodes=1 \\
+  --max-nodes=10 \\
+  --workload-pool=PROJECT_ID.svc.id.goog \\
+  --enable-private-nodes \\
+  --master-ipv4-cidr=172.16.0.0/28`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.4</span>GKE のセキュリティ設計</div>
+
+                <p className="stitle">Workload Identity Federation（最重要）</p>
+                <pre className="codeblock">{`【❌ 危険なアンチパターン】
+サービスアカウントの JSON キーを
+Kubernetes Secret に保存して Pod から参照
+    ↓
+キーが漏洩するリスク / キーの定期ローテーションの手間
+
+【✅ 正しい方法: Workload Identity】
+
+Kubernetes Service Account (KSA)
+    ↓ bind（紐付け）
+Google Cloud IAM Service Account (GSA)
+    ↓
+Pod は KSA を使って Google Cloud API に直接アクセス
+（JSON キー不要！）`}</pre>
+
+                <pre className="codeblock">{`# 1. Google Cloud IAM サービスアカウントを作成
+gcloud iam service-accounts create my-app-sa \\
+  --display-name="My Application SA"
+
+# 2. 必要な IAM ロールを付与（例: Cloud Storage の読み取り）
+gcloud projects add-iam-policy-binding PROJECT_ID \\
+  --member="serviceAccount:my-app-sa@PROJECT_ID.iam.gserviceaccount.com" \\
+  --role="roles/storage.objectViewer"
+
+# 3. KSA と GSA を紐付け
+gcloud iam service-accounts add-iam-policy-binding \\
+  my-app-sa@PROJECT_ID.iam.gserviceaccount.com \\
+  --role="roles/iam.workloadIdentityUser" \\
+  --member="serviceAccount:PROJECT_ID.svc.id.goog[NAMESPACE/KSA_NAME]"`}</pre>
+
+                <pre className="codeblock">{`# Kubernetes Service Account に GSA を紐付けるアノテーション
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-ksa
+  namespace: my-app
+  annotations:
+    iam.gke.io/gcp-service-account: my-app-sa@PROJECT_ID.iam.gserviceaccount.com
+---
+# Pod で KSA を使用
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+spec:
+  serviceAccountName: my-ksa
+  containers:
+  - name: my-container
+    image: my-image`}</pre>
+
+                <p className="stitle">Binary Authorization（コンテナの完全性保証）</p>
+                <pre className="codeblock">{`【Binary Authorization の仕組み】
+
+CI パイプライン:
+  コードビルド → テスト通過 → イメージに署名
+
+GKE デプロイ時:
+  Binary Authorization が署名を検証
+    ├── 有効な署名あり → デプロイ許可 ✅
+    └── 署名なし・無効 → デプロイ拒否 ❌
+
+【防げる攻撃】
+  ├── 承認されていないイメージの誤デプロイ
+  ├── サプライチェーン攻撃（パッケージへの悪意のあるコード挿入）
+  └── 本番環境への未テストイメージのデプロイ`}</pre>
+
+                <p className="stitle">セキュリティポスチャダッシュボード</p>
+                <pre className="codeblock">{`GKE Console → セキュリティポスチャ
+
+自動スキャン項目:
+  ├── Pod の設定上の懸念事項
+  │   例: 「root として実行している」「特権コンテナ」
+  ├── コンテナイメージの脆弱性（CVE）
+  │   例: 「コンテナの libssl に高リスクのCVEあり」
+  └── 推奨される修正アクション（自動提示）`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.5</span>GKE のオートスケーリング</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">スケーリング種別</span>
+                        <span className="cthead">対象</span>
+                        <span className="cthead">仕組み</span>
+                    </div>
+                    {[
+                        ['HPA（Horizontal Pod Autoscaler）', 'Pod 数', 'CPU/メモリ/カスタムメトリクスに基づいてPodを増減'],
+                        ['VPA（Vertical Pod Autoscaler）', 'Pod のリソース量', 'CPU/メモリのリクエストを自動調整'],
+                        ['Cluster Autoscaler', 'ノード数', 'Podがスケジュールできない時にノードを追加'],
+                        ['KEDA', 'Pod 数', 'Pub/Subキューなど外部メトリクスに基づいてスケール'],
+                    ].map(([type, target, how]) => (
+                        <div className="ctable-row" key={type}>
+                            <span className="ctval">{type}</span>
+                            <span className="ctdef">{target}</span>
+                            <span className="ctdef">{how}</span>
+                        </div>
+                    ))}
+                </div>
+                <pre className="codeblock">{`# HPA の設定例
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: my-app-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-app
+  minReplicas: 2
+  maxReplicas: 20
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 60  # CPU 60% を目標に Pod 数を調整`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.BP</span>ベストプラクティス: GKE</div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス</div>
+                    <div className="ctable">
+                        <div className="ctable-head">
+                            <span className="cthead">#</span>
+                            <span className="cthead">ベストプラクティス</span>
+                            <span className="cthead">理由</span>
+                        </div>
+                        {[
+                            ['1', '新規クラスタは Autopilot を選択（特別な要件がなければ）', '運用負荷ゼロ・セキュリティが自動強化'],
+                            ['2', 'JSON キーは絶対に使わず Workload Identity を使用', '認証情報の漏洩を根本的に防止'],
+                            ['3', 'プライベートクラスタ（外部 IP なし）で構築', 'ノードへの直接攻撃を遮断'],
+                            ['4', 'Binary Authorization を有効化', '承認されていないイメージのデプロイを阻止'],
+                            ['5', 'Security Posture Dashboard を定期確認', 'CVE と設定ミスをプロアクティブに解消'],
+                            ['6', 'リソースリクエストとリミットを必ず設定', 'Podのリソース競合・コスト最適化'],
+                            ['7', 'Namespace で環境・チームを分離', 'マルチテナントのアクセス制御'],
+                        ].map(([num, bp, reason]) => (
+                            <div className="ctable-row" key={num}>
+                                <span className="ctval">{num}</span>
+                                <span className="ctval">{bp}</span>
+                                <span className="ctdef">{reason}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter6() {
+    return (
+        <div id="ch6" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn6">06</div>
+                <div className="sec-head-txt">
+                    <h2>Cloud Run</h2>
+                    <p>サーバーレスコンテナ — ゼロスケール・Direct VPC Egress・カナリアデプロイの完全ガイド</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">6.1</span>Cloud Run とは？</div>
+                <p className="tcard-desc">
+                    Cloud Run はコンテナイメージを渡すだけで動くフルマネージドのサーバーレスプラットフォームです。
+                </p>
+                <pre className="codeblock">{`【Cloud Run の特徴】
+
+デプロイは 3ステップだけ:
+  1. コンテナイメージをビルド（Artifact Registry へ push）
+  2. Cloud Run にデプロイ
+  3. HTTPS エンドポイントが自動生成されて完了！
+
+スケーリング:
+  リクエストが来たら → 自動でスケールアウト
+  リクエストがなければ → ゼロにスケールダウン（コストゼロ）
+
+料金:
+  リクエスト処理中のみ課金
+  アイドル時間は無料（最小インスタンス=0の場合）`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">6.2</span>Cloud Run の 2 世代の実行環境</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">項目</span>
+                        <span className="cthead">第1世代</span>
+                        <span className="cthead">第2世代（推奨）</span>
+                    </div>
+                    {[
+                        ['CPU', 'リクエスト処理中のみ', '常時利用可能'],
+                        ['ネットワーク', 'VPC コネクタ経由', 'Direct VPC Egress（高速）'],
+                        ['スループット', '制限あり', '最大2Gbps'],
+                        ['並行処理', '最大 250 リクエスト/インスタンス', '最大 1000 リクエスト/インスタンス'],
+                    ].map(([item, gen1, gen2]) => (
+                        <div className="ctable-row" key={item}>
+                            <span className="ctval">{item}</span>
+                            <span className="ctdef">{gen1}</span>
+                            <span className="ctdef">{gen2}</span>
+                        </div>
+                    ))}
+                </div>
+                <pre className="codeblock">{`# 第2世代で Cloud Run をデプロイ（推奨）
+gcloud run deploy my-service \\
+  --image=gcr.io/PROJECT_ID/my-app:latest \\
+  --region=asia-northeast1 \\
+  --platform=managed \\
+  --execution-environment=gen2 \\
+  --vpc-egress=all-traffic \\
+  --network=my-vpc \\
+  --subnet=my-subnet`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">6.3</span>VPC 内のリソースへの接続</div>
+
+                <p className="stitle">Direct VPC Egress（第2世代・推奨）</p>
+                <pre className="codeblock">{`Cloud Run コンテナ
+    ↓ Direct VPC Egress（高速・低レイテンシ）
+VPC ネットワーク
+    ├── Cloud SQL（プライベート IP）
+    ├── Memorystore（Redis）
+    ├── GCE VM（内部 IP）
+    └── GKE サービス`}</pre>
+
+                <pre className="codeblock">{`# Direct VPC Egress で VPC 内リソースにアクセス
+gcloud run deploy my-service \\
+  --image=CONTAINER_IMAGE \\
+  --vpc-egress=private-ranges-only \\
+  --network=my-vpc \\
+  --subnet=my-subnet`}</pre>
+
+                <p className="stitle">旧: Serverless VPC Access コネクタ（第1世代）</p>
+                <pre className="codeblock">{`# Serverless VPC Access コネクタを作成（旧方式）
+gcloud compute networks vpc-access connectors create my-connector \\
+  --network=my-vpc \\
+  --region=asia-northeast1 \\
+  --range=10.8.0.0/28
+
+# Cloud Run にコネクタを設定
+gcloud run deploy my-service \\
+  --vpc-connector=my-connector`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">6.4</span>トラフィック分割（カナリアデプロイ）</div>
+                <p className="tcard-desc">Cloud Run はトラフィックを複数のリビジョン（バージョン）に分割できます。</p>
+                <pre className="codeblock">{`【カナリアデプロイの例】
+
+v1（安定版） ─────── 90% のトラフィック
+v2（新バージョン） ── 10% のトラフィック
+                      ↓
+              問題なければ 100% に切り替え
+              問題あればすぐ v1 に戻す`}</pre>
+
+                <pre className="codeblock">{`# v2 に 10% のトラフィックを向ける
+gcloud run services update-traffic my-service \\
+  --to-revisions=v1=90,v2=10
+
+# 問題なければ v2 に 100% 切り替え
+gcloud run services update-traffic my-service \\
+  --to-latest`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">6.5</span>Cloud Run の認証</div>
+                <pre className="codeblock">{`【外部からのアクセス制御】
+
+インターネット公開（認証不要）:
+  gcloud run deploy my-service --allow-unauthenticated
+
+認証必須（IAM で制御）:
+  gcloud run deploy my-service --no-allow-unauthenticated
+  → アクセスには roles/run.invoker ロールが必要
+
+サービス間認証:
+  Cloud Run サービス A → Cloud Run サービス B
+    サービス A のサービスアカウントに
+    サービス B の roles/run.invoker を付与`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">6.BP</span>ベストプラクティス: Cloud Run</div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス</div>
+                    <div className="ctable">
+                        <div className="ctable-head">
+                            <span className="cthead">#</span>
+                            <span className="cthead">ベストプラクティス</span>
+                            <span className="cthead">理由</span>
+                        </div>
+                        {[
+                            ['1', '第2世代実行環境 + Direct VPC Egress を使用', 'スループット向上・VPC コネクタ不要'],
+                            ['2', 'ステートレスな設計（状態は Cloud SQL・Firestore に保存）', 'スケーリングに対応するため'],
+                            ['3', '最小インスタンス数を設定してコールドスタートを削減', 'レイテンシの安定化'],
+                            ['4', '--no-allow-unauthenticated で IAM 認証を必須に', '意図せぬ公開を防止'],
+                            ['5', 'Secret Manager から環境変数を注入してシークレット管理', 'コードや環境変数にシークレットを直書きしない'],
+                            ['6', 'カナリアデプロイでリリースリスクを軽減', '問題を早期発見・即時ロールバック'],
+                        ].map(([num, bp, reason]) => (
+                            <div className="ctable-row" key={num}>
+                                <span className="ctval">{num}</span>
+                                <span className="ctval">{bp}</span>
+                                <span className="ctdef">{reason}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter7() {
+    return (
+        <div id="ch7" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn7">07</div>
+                <div className="sec-head-txt">
+                    <h2>Cloud Functions</h2>
+                    <p>イベント駆動サーバーレス — HTTP/GCS/Pub/Sub トリガーと Gen2 の完全ガイド</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">7.1</span>Cloud Functions とは？</div>
+                <pre className="codeblock">{`【Cloud Functions の特徴】
+
+サーバー管理不要:
+  コードだけ書けばOK
+  実行環境・スケーリングはGoogle が管理
+
+イベントドリブン:
+  ├── HTTP リクエスト
+  ├── Cloud Storage へのファイルアップロード
+  ├── Pub/Sub メッセージ
+  ├── Cloud Scheduler（定期実行）
+  └── Firestore の変更
+
+料金:
+  関数の呼び出し回数 + 実行時間の課金
+  月 200 万回まで無料`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">7.2</span>Cloud Functions の世代</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">項目</span>
+                        <span className="cthead">第1世代</span>
+                        <span className="cthead">第2世代（推奨）</span>
+                    </div>
+                    {[
+                        ['実行時間の上限', '9分', '60分'],
+                        ['並列性', '1リクエスト/インスタンス', '最大1000リクエスト/インスタンス'],
+                        ['メモリ', '最大 8GB', '最大 32GB'],
+                        ['CPU', 'リクエスト中のみ', '常時'],
+                        ['ベース', 'Cloud Functions', 'Cloud Run Functions（Cloud Run 上で動作）'],
+                    ].map(([item, gen1, gen2]) => (
+                        <div className="ctable-row" key={item}>
+                            <span className="ctval">{item}</span>
+                            <span className="ctdef">{gen1}</span>
+                            <span className="ctdef">{gen2}</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">7.3</span>Cloud Functions の代表的な使用例</div>
+
+                <p className="stitle">例1: HTTP トリガー（API エンドポイント）</p>
+                <pre className="codeblock">{`import functions_framework
+from flask import jsonify
+
+@functions_framework.http
+def hello_world(request):
+    name = request.args.get('name', 'World')
+    return jsonify({'message': f'Hello, {name}!'})`}</pre>
+
+                <p className="stitle">例2: Cloud Storage トリガー（画像アップロード時に処理）</p>
+                <pre className="codeblock">{`import functions_framework
+from google.cloud import storage, vision
+
+@functions_framework.cloud_event
+def process_image(cloud_event):
+    data = cloud_event.data
+    bucket_name = data["bucket"]
+    file_name = data["name"]
+
+    # Cloud Vision API で画像分析
+    client = vision.ImageAnnotatorClient()
+    image = vision.Image()
+    image.source.image_uri = f"gs://{bucket_name}/{file_name}"
+
+    response = client.label_detection(image=image)
+    print(f"Labels: {[l.description for l in response.label_annotations]}")`}</pre>
+
+                <p className="stitle">例3: Pub/Sub トリガー（予算アラートへの対応）</p>
+                <pre className="codeblock">{`import base64
+import json
+import googleapiclient.discovery
+
+def stop_billing(event, context):
+    """予算超過アラートを受けてリソースを停止"""
+    pubsub_data = base64.b64decode(event['data']).decode('utf-8')
+    data = json.loads(pubsub_data)
+
+    if data['costAmount'] >= data['budgetAmount']:
+        compute = googleapiclient.discovery.build('compute', 'v1')
+        # VM を停止
+        compute.instances().stop(
+            project='PROJECT_ID',
+            zone='asia-northeast1-a',
+            instance='my-vm'
+        ).execute()`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">7.4</span>Cloud Functions vs Cloud Run の使い分け</div>
+                <pre className="codeblock">{`【Cloud Functions を選ぶとき】
+  ├── 単純なイベント処理（数行〜数十行のコード）
+  ├── 各種 Google Cloud サービスのイベントに反応
+  ├── 定期バッチ（Cloud Scheduler + Functions）
+  └── プロトタイプ・PoC の素早い実装
+
+【Cloud Run を選ぶとき】
+  ├── 複数のエンドポイントを持つ REST API
+  ├── 既存のコンテナ化されたアプリ
+  ├── カスタムランタイム（Go・Rust など）
+  ├── 長時間実行が必要（60分以上）
+  └── 複雑なミドルウェアが必要なアプリ`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">7.BP</span>ベストプラクティス: Cloud Functions</div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス</div>
+                    <ul>
+                        <li><strong>第2世代を使用</strong>（実行時間60分・高並列性）</li>
+                        <li><strong>関数は単一責任の原則</strong>（1関数 = 1つのことだけ処理）</li>
+                        <li><strong>シークレットは Secret Manager から取得</strong>（環境変数に直書き禁止）</li>
+                        <li><strong>VPC コネクタ</strong>でプライベートリソースに接続</li>
+                        <li><strong>冪等性（Idempotency）の確保</strong>（同じイベントを複数回受けても安全）</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}
+
 function Chapter3() {
     return (
         <div id="ch3" className="sgap">
@@ -777,18 +1371,9 @@ export default function Domain2Page() {
                 <Chapter2 />
                 <Chapter3 />
                 <Chapter4 />
-                <div id="ch5" className="sgap">
-                    <h2>Google Kubernetes Engine (GKE)</h2>
-                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
-                </div>
-                <div id="ch6" className="sgap">
-                    <h2>Cloud Run</h2>
-                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
-                </div>
-                <div id="ch7" className="sgap">
-                    <h2>Cloud Functions</h2>
-                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
-                </div>
+                <Chapter5 />
+                <Chapter6 />
+                <Chapter7 />
                 <div id="ch8" className="sgap">
                     <h2>Cloud Storage</h2>
                     <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>

--- a/app/gcl/associate-cloud-engineer/domain2/page.tsx
+++ b/app/gcl/associate-cloud-engineer/domain2/page.tsx
@@ -387,6 +387,340 @@ gcloud compute firewall-rules create allow-ssh-bastion \\
     );
 }
 
+function Chapter3() {
+    return (
+        <div id="ch3" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn3">03</div>
+                <div className="sec-head-txt">
+                    <h2>Spot VM とプリエンプティブル VM</h2>
+                    <p>最大91%割引の余剰リソース活用 — チェックポイント設計とプリエンプション対応の完全ガイド</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.1</span>Spot VM とは？</div>
+                <p className="tcard-desc">
+                    Google のデータセンターには、常に余剰の計算リソースがあります。Spot VM はその余剰リソースを格安で提供する仕組みです。
+                </p>
+                <pre className="codeblock">{`【通常の VM】
+  ・確実に稼働し続ける
+  ・通常料金（例: n2-standard-4 = 約$0.19/時間）
+
+【Spot VM】
+  ・余剰リソースを利用するため最大 91% 割引
+  ・Google がリソースを必要としたら 30秒前通知で強制停止される
+  ・例: n2-standard-4 = 約$0.02/時間（約90%割引）`}</pre>
+                <div className="wb">
+                    <div className="wbt">重要</div>
+                    <p>Spot VM はいつでも停止される可能性があります。ステートフルなアプリや停止が許されないサービスには使用禁止！</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.2</span>Spot VM vs Preemptible VM</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">項目</span>
+                        <span className="cthead">Preemptible VM（旧）</span>
+                        <span className="cthead">Spot VM（現在推奨）</span>
+                    </div>
+                    {[
+                        ['最大稼働時間', '24時間（強制停止）', '制限なし'],
+                        ['停止通知', '30秒前', '30秒前'],
+                        ['価格', '最大80%割引', '最大91%割引'],
+                        ['推奨度', '❌ 非推奨（レガシー）', '✅ 推奨'],
+                    ].map(([item, old, current]) => (
+                        <div className="ctable-row" key={item}>
+                            <span className="ctval">{item}</span>
+                            <span className="ctdef">{old}</span>
+                            <span className="ctdef">{current}</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.3</span>Spot VM に適したワークロード</div>
+                <pre className="codeblock">{`✅ 向いているワークロード:
+  ├── バッチ処理（夜間の大量データ処理）
+  ├── ML/AI モデルのトレーニング
+  ├── 3D レンダリング、動画エンコード
+  ├── ゲノム解析などのサイエンティフィック計算
+  └── 継続的インテグレーション（CI）のビルド/テスト
+
+❌ 向いていないワークロード:
+  ├── Web サーバー（ユーザーへの影響大）
+  ├── データベース（データの整合性が壊れる可能性）
+  ├── ステートフルなアプリ（状態が失われる）
+  └── 停止が許されないミッションクリティカルなサービス`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.4</span>プリエンプション（強制停止）への対応設計</div>
+
+                <p className="stitle">① 終了アクションの設定</p>
+                <pre className="codeblock">{`# Spot VM 作成時に終了アクションを設定
+gcloud compute instances create my-spot-vm \\
+  --machine-type=n2-standard-4 \\
+  --provisioning-model=SPOT \\
+  --instance-termination-action=STOP  # STOP または DELETE
+
+# STOP: VM を停止状態にする（ローカルディスクのデータ保持）
+#   → キャパシティが戻った時に再起動可能
+# DELETE: VM を削除する（最小コスト・ローカルデータ消失）`}</pre>
+
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">終了アクション</span>
+                        <span className="cthead">ローカルSSDデータ</span>
+                        <span className="cthead">再起動</span>
+                        <span className="cthead">用途</span>
+                    </div>
+                    {[
+                        ['STOP', '✅ 保持', '自動（キャパシティ回復後）', 'データを保持したいバッチ'],
+                        ['DELETE', '❌ 消える', 'MIG が新規作成', '純粋なバッチ・ステートレス'],
+                    ].map(([action, data, restart, usage]) => (
+                        <div className="ctable-row" key={action}>
+                            <span className="ctval">{action}</span>
+                            <span className="ctdef">{data}</span>
+                            <span className="ctdef">{restart}</span>
+                            <span className="ctdef">{usage}</span>
+                        </div>
+                    ))}
+                </div>
+
+                <p className="stitle">② シャットダウンスクリプトの設定</p>
+                <pre className="codeblock">{`# 停止前に状態を Cloud Storage に保存するスクリプト
+#!/bin/bash
+# /etc/google-cloud/metadata/shutdown-scripts
+
+echo "Spot VM preemption detected. Saving checkpoint..."
+
+# 処理の進捗を Cloud Storage に保存
+gsutil cp /var/app/checkpoint.dat gs://my-batch-bucket/checkpoints/job-\${JOB_ID}.dat
+
+# 処理ログを保存
+gsutil cp /var/log/app.log gs://my-batch-bucket/logs/job-\${JOB_ID}.log
+
+echo "Checkpoint saved. Shutting down."`}</pre>
+
+                <pre className="codeblock">{`gcloud compute instances add-metadata VM_NAME \\
+  --metadata-from-file shutdown-script=shutdown.sh`}</pre>
+
+                <p className="stitle">③ チェックポイントの実装パターン</p>
+                <pre className="codeblock">{`# バッチ処理でのチェックポイント実装例（Python）
+import signal
+import json
+from google.cloud import storage
+
+checkpoint_file = "gs://my-bucket/checkpoints/job.json"
+is_preempted = False
+
+def handle_sigterm(signum, frame):
+    """SIGTERM を受け取ったら（プリエンプション通知）"""
+    global is_preempted
+    is_preempted = True
+    save_checkpoint(current_progress)
+    print("Checkpoint saved, shutting down gracefully")
+
+signal.signal(signal.SIGTERM, handle_sigterm)
+
+def save_checkpoint(progress):
+    """進捗を GCS に保存"""
+    client = storage.Client()
+    # ... チェックポイントをGCSに書き込み
+
+def load_checkpoint():
+    """前回の進捗を GCS から読み込み"""
+    # ... GCS からチェックポイントを読み込み
+    pass
+
+# メイン処理（チェックポイントから再開）
+last_checkpoint = load_checkpoint()
+for i in range(last_checkpoint, total_items):
+    if is_preempted:
+        break
+    process_item(i)
+    current_progress = i`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.5</span>Spot VM のコスト計算例</div>
+                <pre className="codeblock">{`通常の ML トレーニングジョブ:
+  A2 Ultra（8x A100 GPU） 通常料金: $32.77/時間
+  Spot VM 割引（約70%）:            $9.83/時間
+
+  10時間のトレーニング:
+    通常: $327.70
+    Spot: $98.30
+    節約: $229.40（約70%節約）！`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.BP</span>ベストプラクティス: Spot VM</div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス</div>
+                    <div className="ctable">
+                        <div className="ctable-head">
+                            <span className="cthead">#</span>
+                            <span className="cthead">ベストプラクティス</span>
+                            <span className="cthead">詳細</span>
+                        </div>
+                        {[
+                            ['1', 'MIG（Managed Instance Group）と組み合わせる', 'プリエンプト後に自動で新しい VM を作成'],
+                            ['2', 'チェックポイント機能を必ず実装', '処理を途中から再開できるよう設計'],
+                            ['3', '終了アクションは STOP を基本に', 'データを保持しキャパシティ回復後に再起動'],
+                            ['4', 'シャットダウンスクリプトを設定', '30秒の猶予でクリーンに終了処理'],
+                            ['5', '複数ゾーンにわたる MIG を構成', '特定ゾーンの Spot VM が全滅するリスクを分散'],
+                            ['6', 'gcloud compute operations describe でプリエンプション履歴を確認', 'Spot 利用率の最適化'],
+                        ].map(([num, bp, detail]) => (
+                            <div className="ctable-row" key={num}>
+                                <span className="ctval">{num}</span>
+                                <span className="ctval">{bp}</span>
+                                <span className="ctdef">{detail}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter4() {
+    return (
+        <div id="ch4" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn4">04</div>
+                <div className="sec-head-txt">
+                    <h2>Managed Instance Group (MIG)</h2>
+                    <p>自動ヒーリング・オートスケーリング・ローリングアップデート — 高可用性VM管理の完全ガイド</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">4.1</span>MIG とは？</div>
+                <p className="tcard-desc">
+                    MIG（Managed Instance Group）は、<strong>インスタンステンプレート</strong> から同一設定の VM を複数自動管理する機能です。
+                </p>
+                <pre className="codeblock">{`インスタンステンプレート（設計図）
+  ├── マシンタイプ: n2-standard-4
+  ├── OS イメージ: debian-11
+  ├── ディスクサイズ: 100GB
+  └── スタートアップスクリプト: install_app.sh
+
+       ↓ MIG が自動的に複数の VM を作成・管理
+
+VM1（asia-northeast1-a）
+VM2（asia-northeast1-b）
+VM3（asia-northeast1-c）`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">4.2</span>MIG の主要機能</div>
+
+                <p className="stitle">機能① 自動ヒーリング（Auto Healing）</p>
+                <pre className="codeblock">{`ヘルスチェックで VM の異常を検知
+    ↓
+異常な VM を自動的に削除
+    ↓
+新しい VM を自動作成
+
+→ 人間が介入しなくてもサービスを維持！`}</pre>
+
+                <p className="stitle">ヘルスチェックの設定</p>
+                <pre className="codeblock">{`# ヘルスチェックを作成
+gcloud compute health-checks create http my-health-check \\
+  --port=80 \\
+  --request-path=/health \\
+  --check-interval=30s \\
+  --timeout=10s \\
+  --healthy-threshold=1 \\
+  --unhealthy-threshold=3
+
+# MIG にヘルスチェックを設定
+gcloud compute instance-groups managed set-autohealing my-mig \\
+  --health-check=my-health-check \\
+  --initial-delay=300  # 起動後300秒は異常判定しない`}</pre>
+
+                <p className="stitle">機能② 自動スケーリング（Autoscaling）</p>
+                <pre className="codeblock">{`負荷が増加 → VM を自動追加（スケールアウト）
+負荷が減少 → VM を自動削除（スケールイン）
+
+スケーリングの指標:
+  ├── CPU 使用率（最もシンプル）
+  ├── HTTP リクエスト数（LB と連携）
+  ├── Cloud Monitoring カスタムメトリクス
+  └── Pub/Sub キューの深さ（バッチ処理に有効）`}</pre>
+
+                <pre className="codeblock">{`# CPU 使用率 60% を目標にオートスケールを設定
+gcloud compute instance-groups managed set-autoscaling my-mig \\
+  --max-num-replicas=10 \\
+  --min-num-replicas=2 \\
+  --target-cpu-utilization=0.6 \\
+  --cool-down-period=90`}</pre>
+
+                <p className="stitle">機能③ ローリングアップデート（Rolling Update）</p>
+                <pre className="codeblock">{`旧バージョンのインスタンステンプレート
+          ↓ ローリングアップデート
+新バージョンのインスタンステンプレート
+
+・1台ずつ順番に更新（サービスを止めない）
+・問題が発生したらロールバック可能`}</pre>
+
+                <pre className="codeblock">{`# ローリングアップデートを実行
+gcloud compute instance-groups managed rolling-action start-update my-mig \\
+  --version=template=new-template \\
+  --max-surge=1 \\
+  --max-unavailable=0    # 同時に停止できるVM数（0=サービス継続）`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">4.3</span>ゾーン MIG vs リージョン MIG</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">種類</span>
+                        <span className="cthead">展開範囲</span>
+                        <span className="cthead">耐障害性</span>
+                        <span className="cthead">用途</span>
+                    </div>
+                    {[
+                        ['ゾーン MIG', '1つのゾーン', '低（ゾーン障害で全停止）', '開発・テスト環境'],
+                        ['リージョン MIG', '3つのゾーンに均等分散', '高（1ゾーン障害でも継続）', '本番環境（推奨）'],
+                    ].map(([type, range, fault, usage]) => (
+                        <div className="ctable-row" key={type}>
+                            <span className="ctval">{type}</span>
+                            <span className="ctdef">{range}</span>
+                            <span className="ctdef">{fault}</span>
+                            <span className="ctdef">{usage}</span>
+                        </div>
+                    ))}
+                </div>
+                <pre className="codeblock">{`# リージョン MIG の作成（本番環境推奨）
+gcloud compute instance-groups managed create my-regional-mig \\
+  --template=my-template \\
+  --size=6 \\
+  --region=asia-northeast1  # ゾーンではなくリージョンを指定`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">4.BP</span>ベストプラクティス: MIG</div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス</div>
+                    <ul>
+                        <li>本番環境は<strong>リージョン MIG</strong> でゾーン障害に備える</li>
+                        <li><strong>ヘルスチェック + 自動ヒーリング</strong>を必ず設定する</li>
+                        <li>Spot VM との組み合わせでコスト削減（<code>--provisioning-model=SPOT</code>）</li>
+                        <li>オートスケーリングの <code>max-num-replicas</code> に上限を設ける（コスト暴走防止）</li>
+                        <li>ローリングアップデートで <code>max-unavailable=0</code> を設定してゼロダウンタイム更新</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}
+
 export default function Domain2Page() {
     return (
         <div className="d2-page">
@@ -441,14 +775,8 @@ export default function Domain2Page() {
                 <SectionIntro />
                 <Chapter1 />
                 <Chapter2 />
-                <div id="ch3" className="sgap">
-                    <h2>Spot VM の活用</h2>
-                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
-                </div>
-                <div id="ch4" className="sgap">
-                    <h2>Managed Instance Groups (MIG)</h2>
-                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
-                </div>
+                <Chapter3 />
+                <Chapter4 />
                 <div id="ch5" className="sgap">
                     <h2>Google Kubernetes Engine (GKE)</h2>
                     <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>

--- a/app/gcl/associate-cloud-engineer/domain2/page.tsx
+++ b/app/gcl/associate-cloud-engineer/domain2/page.tsx
@@ -387,6 +387,644 @@ gcloud compute firewall-rules create allow-ssh-bastion \\
     );
 }
 
+function Chapter8() {
+    return (
+        <div id="ch8" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn8">08</div>
+                <div className="sec-head-txt">
+                    <h2>Cloud Storage（オブジェクトストレージ）</h2>
+                    <p>4ストレージクラス・OLM・署名付きURL・データ保護 — 非構造化データ管理の完全ガイド</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">8.1</span>Cloud Storage とは？</div>
+                <pre className="codeblock">{`【Cloud Storage の特徴】
+  ├── 容量無制限（バケット単位で管理）
+  ├── 高い耐久性（99.999999999% = イレブンナイン）
+  ├── グローバルなアクセス
+  ├── バケット ─ オブジェクト の 2 層構造
+  └── HTTP/HTTPS でアクセス可能`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">8.2</span>4 つのストレージクラス</div>
+                <pre className="codeblock">{`アクセス頻度
+  高い ←──────────────────────────────────→ 低い
+
+Standard → Nearline → Coldline → Archive
+ ↑費用/GB    ↑費用/GB   ↑費用/GB   ↑費用/GB
+  高め        中         低め        最安値
+            ↑取り出し料金
+   無料      有料(安)    有料(中)    有料(高)`}</pre>
+
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">クラス</span>
+                        <span className="cthead">GB 単価</span>
+                        <span className="cthead">取り出し料金</span>
+                        <span className="cthead">最小保存期間</span>
+                        <span className="cthead">アクセス頻度の目安</span>
+                    </div>
+                    {[
+                        ['Standard', '$0.020/GB', '無料', 'なし', '頻繁（日次以上）'],
+                        ['Nearline', '$0.010/GB', '$0.01/GB', '30日', '月1回程度'],
+                        ['Coldline', '$0.004/GB', '$0.02/GB', '90日', '四半期1回程度'],
+                        ['Archive', '$0.0012/GB', '$0.05/GB', '365日', '年1回以下'],
+                    ].map(([cls, price, retrieve, minPeriod, freq]) => (
+                        <div className="ctable-row" key={cls}>
+                            <span className="ctval">{cls}</span>
+                            <span className="ctdef">{price}</span>
+                            <span className="ctdef">{retrieve}</span>
+                            <span className="ctdef">{minPeriod}</span>
+                            <span className="ctdef">{freq}</span>
+                        </div>
+                    ))}
+                </div>
+                <div className="wb">
+                    <div className="wbt">試験頻出</div>
+                    <p>最小保存期間より前に削除しても、最小保存期間分の料金が発生します！</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">8.3</span>バケットの作成とロケーション設定</div>
+                <pre className="codeblock">{`【Single Region（単一リージョン）】
+  例: asia-northeast1（東京）
+  → 最もコストが低い
+  → リージョン障害でデータにアクセス不可
+  → 同一リージョン内でのデータ転送が最速
+
+【Dual Region（デュアルリージョン）】
+  例: asia1（東京 + 大阪）
+  → 2リージョン間で自動レプリケーション
+  → 地理的冗長性あり
+  → コストは Multi-Region と同程度
+
+【Multi Region（マルチリージョン）】
+  例: asia（アジア全体）、us（米国全体）、eu（EU）
+  → 最高の可用性と地理分散
+  → コストは最も高い
+  → グローバルなコンテンツ配信に最適`}</pre>
+
+                <pre className="codeblock">{`# バケットの作成
+gcloud storage buckets create gs://my-app-bucket \\
+  --location=asia-northeast1 \\
+  --storage-class=STANDARD \\
+  --uniform-bucket-level-access`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">8.4</span>オブジェクトライフサイクル管理（OLM）</div>
+                <pre className="codeblock">{`オブジェクト作成（Standard）
+    │
+    ├── 30日後 → Nearline に自動移行
+    │
+    ├── 90日後 → Coldline に自動移行
+    │
+    ├── 365日後 → Archive に自動移行
+    │
+    └── 730日後 → 自動削除
+
+→ このルールを設定するだけでコスト最適化が自動化！`}</pre>
+
+                <pre className="codeblock">{`{
+  "lifecycle": {
+    "rule": [
+      {
+        "action": {"type": "SetStorageClass", "storageClass": "NEARLINE"},
+        "condition": {"age": 30}
+      },
+      {
+        "action": {"type": "SetStorageClass", "storageClass": "COLDLINE"},
+        "condition": {"age": 90}
+      },
+      {
+        "action": {"type": "SetStorageClass", "storageClass": "ARCHIVE"},
+        "condition": {"age": 365}
+      },
+      {
+        "action": {"type": "Delete"},
+        "condition": {"age": 730}
+      }
+    ]
+  }
+}`}</pre>
+
+                <pre className="codeblock">{`# OLM ポリシーをバケットに適用
+gcloud storage buckets update gs://my-bucket \\
+  --lifecycle-file=lifecycle.json`}</pre>
+
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">条件名</span>
+                        <span className="cthead">説明</span>
+                        <span className="cthead">例</span>
+                    </div>
+                    {[
+                        ['age', 'オブジェクトの作成からの日数', '30'],
+                        ['numNewerVersions', 'より新しいバージョンの数', '3（3つ以上の新バージョンがあれば）'],
+                        ['isLive', '最新バージョンかどうか', 'false（非最新のみ対象）'],
+                        ['matchesStorageClass', '特定ストレージクラスのみ対象', '["STANDARD"]'],
+                        ['createdBefore', '特定日付より前に作成', '2024-01-01'],
+                    ].map(([cond, desc, ex]) => (
+                        <div className="ctable-row" key={cond}>
+                            <span className="ctval">{cond}</span>
+                            <span className="ctdef">{desc}</span>
+                            <span className="ctdef">{ex}</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">8.5</span>バケットセキュリティのベストプラクティス</div>
+                <pre className="codeblock">{`【バケット名のルール】
+  ├── グローバルに一意（全世界で重複不可）
+  ├── 3〜63文字
+  ├── 小文字・数字・ハイフン・アンダースコアのみ
+  ├── 「goog」で始まる名前は予約済みで使用不可
+  ├── 「google」のスペルミス（googel など）も使用不可
+  └── バケット名は URL に含まれる！
+
+【バケット名の設計原則】
+  ❌ 悪い例: my-company-production-database-backups-tokyo
+    → 会社名・環境・内容が丸わかり
+
+  ✅ 良い例: bkt-a7f2k9-prod-bak
+    → 意味を推測しにくいランダムなサフィックス付き
+    → 個人情報・機密情報を一切含まない`}</pre>
+
+                <pre className="codeblock">{`【アクセス制御の 2 つのモデル】
+
+【1. ACL（Access Control List）】  ← 旧モデル・非推奨
+  オブジェクトごとに個別のアクセス制御が可能
+  管理が複雑になりがち
+
+【2. 統一バケットレベルアクセス（Uniform Bucket-Level Access）】 ← 推奨
+  バケット全体に IAM ポリシーを適用
+  オブジェクト個別の ACL は無効化
+  管理がシンプル・一貫性あり`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">8.6</span>署名付き URL（Signed URLs）</div>
+                <p className="tcard-desc">Google アカウントを持たないユーザーに一時的なアクセスを付与する仕組みです。</p>
+                <pre className="codeblock">{`【ユースケース】
+  ├── 外部パートナーへのデータ共有
+  ├── 顧客へのダウンロードリンク提供
+  └── 一時的なアップロード用 URL の生成
+
+【署名付き URL の構造】
+  https://storage.googleapis.com/BUCKET/OBJECT
+    ?X-Goog-Algorithm=GOOG4-RSA-SHA256
+    &X-Goog-Credential=...
+    &X-Goog-Date=20240101T000000Z
+    &X-Goog-Expires=3600         ← 有効期間（秒）
+    &X-Goog-Signature=...`}</pre>
+
+                <pre className="codeblock">{`# 1時間有効な署名付き URL を生成
+gcloud storage sign-url gs://my-bucket/my-file.pdf \\
+  --duration=1h \\
+  --service-account=my-sa@PROJECT.iam.gserviceaccount.com
+
+# 最大有効期間は 7日間（604800秒）`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">8.7</span>データ保護機能</div>
+
+                <p className="stitle">論理削除（Soft Delete）</p>
+                <pre className="codeblock">{`デフォルト設定: 有効（7日間保持）
+
+オブジェクト削除 → 7日間はリカバリ可能
+              → 8日目以降は完全削除（コストも発生）
+
+保持期間のカスタマイズ（0〜90日）:
+  gcloud storage buckets update gs://my-bucket \\
+    --soft-delete-duration=30d`}</pre>
+
+                <div className="wb">
+                    <div className="wbt">バケット再作成の仕様</div>
+                    <p>バケットを削除後 10 分以内に同名バケットを作成しようとすると 404 エラーが発生します。</p>
+                </div>
+
+                <p className="stitle">バケットロック（Bucket Lock）と保持ポリシー</p>
+                <pre className="codeblock">{`【用途】コンプライアンス・法規制対応
+
+保持ポリシー:
+  バケット内のすべてのオブジェクトを
+  指定期間（例: 7年間）削除・上書き不可にする
+
+バケットロック:
+  保持ポリシー自体を変更・削除不可にする
+  （取り消しができない操作！）
+
+gcloud storage buckets update gs://my-compliance-bucket \\
+  --retention-period=7y  # 7年間保持
+
+gcloud storage buckets lock gs://my-compliance-bucket  # ロック（不可逆！）`}</pre>
+
+                <p className="stitle">オブジェクトバージョニング</p>
+                <pre className="codeblock">{`# バージョニングを有効化
+gcloud storage buckets update gs://my-bucket --versioning
+
+# 非最新バージョンを確認
+gcloud storage objects list gs://my-bucket --all-versions
+
+# 特定バージョンを復元
+gsutil cp gs://my-bucket/file.txt#1234567890 gs://my-bucket/file.txt`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">8.BP</span>ベストプラクティス: Cloud Storage</div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス</div>
+                    <div className="ctable">
+                        <div className="ctable-head">
+                            <span className="cthead">#</span>
+                            <span className="cthead">ベストプラクティス</span>
+                            <span className="cthead">理由</span>
+                        </div>
+                        {[
+                            ['1', '統一バケットレベルアクセスを有効化', 'IAMで一元管理・ACLの複雑さを排除'],
+                            ['2', 'OLM を必ず設定してストレージクラスを自動移行', 'コスト最適化の自動化'],
+                            ['3', 'バケット名に機密情報を含めない', 'バケット名は URL に公開される'],
+                            ['4', 'バージョニングを有効化し、非最新版には OLM を設定', '誤削除対策・コスト管理'],
+                            ['5', 'Soft Delete は用途に応じて保持期間を設定', 'デフォルト7日では短すぎる場合も'],
+                            ['6', 'パブリックアクセスを原則禁止', '意図しないデータ公開を防止'],
+                        ].map(([num, bp, reason]) => (
+                            <div className="ctable-row" key={num}>
+                                <span className="ctval">{num}</span>
+                                <span className="ctval">{bp}</span>
+                                <span className="ctdef">{reason}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter9() {
+    return (
+        <div id="ch9" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn9">09</div>
+                <div className="sec-head-txt">
+                    <h2>ブロックストレージとファイルストレージ</h2>
+                    <p>Persistent Disk・リージョナルPD・Filestore — VM ストレージの完全ガイド</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">9.1</span>Persistent Disk（永続ディスク）</div>
+                <p className="tcard-desc">VM に接続するブロックストレージです。</p>
+                <pre className="codeblock">{`Persistent Disk の特徴:
+  ├── VM とは独立して存在（VM を削除してもディスクは残る設定可能）
+  ├── 複数のVMから読み取り専用で共有可能（マルチリーダー）
+  ├── 1つのVMへの読み書きと1つのVMへの共有（マルチライター）※Extreme除く
+  └── ゾーンPD と リージョンPD の2種類
+
+【ゾーン PD】
+  1つのゾーン内に存在
+  → そのゾーン障害でアクセス不可
+
+【リージョン PD（高可用性）】
+  2つのゾーンに同期レプリケーション
+  → 1ゾーン障害でも他ゾーンでアクセス継続
+  → 約2倍のコスト`}</pre>
+
+                <pre className="codeblock">{`# リージョン Persistent Disk の作成（高可用性）
+gcloud compute disks create my-regional-disk \\
+  --type=pd-balanced \\
+  --size=100GB \\
+  --region=asia-northeast1 \\
+  --replica-zones=asia-northeast1-a,asia-northeast1-b`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">9.2</span>Filestore（マネージドNFSファイルシステム）</div>
+                <p className="tcard-desc">複数の VM から同時にアクセスできるNFSファイルシステムです。</p>
+                <pre className="codeblock">{`【Filestore の用途】
+  ├── 複数の VM でファイルを共有（共有ホームディレクトリなど）
+  ├── レガシーアプリの NFS 依存を維持したまま移行
+  └── CMS（WordPress など）の共有ストレージ
+
+【Filestore 階層】
+  Basic HDD → Basic SSD → High Scale SSD → Enterprise
+  （コスト低←──────────────────────────→パフォーマンス高）`}</pre>
+            </div>
+        </div>
+    );
+}
+
+function Chapter10() {
+    return (
+        <div id="ch10" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn10">10</div>
+                <div className="sec-head-txt">
+                    <h2>データベースサービス完全選定ガイド</h2>
+                    <p>Cloud SQL / Spanner / AlloyDB / Firestore / Bigtable / Memorystore / BigQuery — 最適なDBを選ぶフレームワーク</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">10.1</span>データベース選定のフローチャート</div>
+                <pre className="codeblock">{`どんなデータを扱う？
+│
+├── 構造化データ（スキーマが決まっている）
+│   │
+│   └── SQL が必要？
+│       ├── YES → どんな規模・要件？
+│       │         ├── 標準的なWebアプリ → Cloud SQL
+│       │         ├── グローバル分散・99.999% → Cloud Spanner
+│       │         └── PostgreSQL 高性能（4倍）→ AlloyDB
+│       │
+│       └── NO（NoSQL）→ どんな特性が必要？
+│           ├── リアルタイム同期・モバイル → Firestore
+│           ├── 超大規模・低レイテンシ・時系列 → Cloud Bigtable
+│           └── マイクロ秒・キャッシュ → Memorystore
+│
+├── 分析・DWH → BigQuery
+│
+└── Oracle を移行したい → Bare Metal Solution`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">10.2</span>Cloud SQL</div>
+                <p className="tcard-desc">MySQL、PostgreSQL、SQL Server のフルマネージドサービスです。</p>
+                <pre className="codeblock">{`【Cloud SQL が管理してくれるもの】
+  ├── OS パッチ適用
+  ├── データベースマイナーバージョンアップ
+  ├── 自動バックアップ（日次）
+  ├── フェイルオーバーレプリカ（HA構成）
+  └── SSL/TLS 暗号化`}</pre>
+
+                <p className="stitle">アーキテクチャパターン</p>
+                <pre className="codeblock">{`【シングルインスタンス（開発環境）】
+  プライマリ DB ←── 読み書き
+  コスト: 安い、可用性: 低い
+
+【高可用性（HA）構成（本番環境）】
+  プライマリ DB（ゾーンA）
+       ↓ 同期レプリケーション
+  スタンバイ DB（ゾーンB）
+
+  プライマリ障害 → 自動フェイルオーバー（数十秒）
+  コスト: 2倍程度
+
+【リードレプリカ（読み取りスケール）】
+  プライマリ DB（書き込み）
+       ↓ 非同期レプリケーション
+  リードレプリカ 1（読み取り）
+  リードレプリカ 2（読み取り）
+
+  読み取り負荷を複数レプリカに分散`}</pre>
+
+                <p className="stitle">Cloud SQL への安全な接続</p>
+                <pre className="codeblock">{`【3つの接続方法】
+
+方法1: Cloud SQL Auth Proxy（推奨）
+  アプリ → Cloud SQL Auth Proxy（ローカル）→ Cloud SQL
+  → SSL/TLS を自動処理、IAM で認証
+  → DB のパスワードが不要
+
+  使用例:
+  # Auth Proxy を起動
+  ./cloud-sql-proxy PROJECT:REGION:INSTANCE_NAME
+
+方法2: プライベート IP（VPC 内から）
+  VPC 内のアプリ → プライベート IP → Cloud SQL
+  → インターネットを経由しない最も安全な方法
+  → Private Service Connect を使用
+
+方法3: 公開 IP（外部から）
+  外部アプリ → Cloud SQL（公開 IP）
+  → 許可された IP アドレスのみアクセス可能（許可リスト）
+  → 原則避けるべき`}</pre>
+
+                <pre className="codeblock">{`# Cloud SQL インスタンス作成（HA 構成）
+gcloud sql instances create my-postgres \\
+  --database-version=POSTGRES_15 \\
+  --tier=db-n1-standard-4 \\
+  --region=asia-northeast1 \\
+  --availability-type=REGIONAL \\
+  --backup-start-time=03:00 \\
+  --no-assign-ip \\
+  --network=my-vpc`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">10.3</span>Cloud Spanner</div>
+                <pre className="codeblock">{`Cloud Spanner = リレーショナル × グローバル分散 × 水平スケール
+
+【何が特別か】
+  通常の DB: スケールアップ（大きなマシンに変える）で対応
+  Cloud Spanner: ノードを追加するだけで水平スケール
+                 SQL/ACIDトランザクションを維持したまま！
+
+【SLA: 99.999%（ファイブナイン）】
+  年間ダウンタイム: 約 5.26 分
+  他の DB は通常 99.9%（年間 8.76 時間）
+
+【ユースケース】
+  ├── グローバルな金融システム（証券、決済）
+  ├── 大規模インベントリ管理
+  └── グローバルゲームのリーダーボード・状態管理`}</pre>
+
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">判断基準</span>
+                        <span className="cthead">Cloud SQL</span>
+                        <span className="cthead">Cloud Spanner</span>
+                    </div>
+                    {[
+                        ['規模', '中規模まで', '大規模・超大規模'],
+                        ['グローバル分散', '❌（リードレプリカは可能）', '✅'],
+                        ['水平スケール', '❌', '✅'],
+                        ['SQL 対応', '✅', '✅（方言あり）'],
+                        ['費用', '安い', '高い（ノード=$0.9/時間〜）'],
+                        ['移行コスト', '低い', '高い（スキーマ変更が必要）'],
+                    ].map(([criteria, sql, spanner]) => (
+                        <div className="ctable-row" key={criteria}>
+                            <span className="ctval">{criteria}</span>
+                            <span className="ctdef">{sql}</span>
+                            <span className="ctdef">{spanner}</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">10.4</span>AlloyDB</div>
+                <pre className="codeblock">{`AlloyDB = PostgreSQL 完全互換 + Google AI 最適化
+
+【性能】
+  標準 PostgreSQL の 4倍のトランザクション性能
+  分析クエリは 100倍速い（列指向ストレージを内部使用）
+
+【Cloud SQL PostgreSQL vs AlloyDB の使い分け】
+  Cloud SQL PostgreSQL:
+    → 標準的な Web アプリ・既存 PG アプリの移行
+    → 中規模まで
+
+  AlloyDB:
+    → OLTP と分析（HTAP）を同一 DB で処理したい
+    → 高性能が必要・AI/ML との統合が必要
+    → pgvector を使ったベクトル検索（AI 機能）`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">10.5</span>Firestore</div>
+                <pre className="codeblock">{`【Firestore の特徴】
+
+ドキュメント指向 NoSQL:
+  データ構造: コレクション → ドキュメント → フィールド
+
+  users（コレクション）
+    └── alice（ドキュメント）
+         ├── name: "Alice"
+         ├── age: 30
+         └── orders（サブコレクション）
+               └── order-001
+                    ├── item: "laptop"
+                    └── price: 150000
+
+リアルタイム同期:
+  データが変更されると全クライアントに即時反映
+  → モバイルアプリ・チャット・コラボツールに最適
+
+サーバーレス:
+  キャパシティプランニング不要・自動的にスケール`}</pre>
+
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">判断基準</span>
+                        <span className="cthead">Firestore</span>
+                        <span className="cthead">Cloud Bigtable</span>
+                    </div>
+                    {[
+                        ['データ規模', 'GB〜TB', 'TB〜PB'],
+                        ['アクセス', 'ドキュメント単位', '行/列単位'],
+                        ['クエリ', '豊富（複合クエリ可）', 'キーのみ（フィルタは限定的）'],
+                        ['リアルタイム同期', '✅', '❌'],
+                        ['レイテンシ', 'ミリ秒', 'ミリ秒未満'],
+                        ['ユースケース', 'モバイル・Web バックエンド', 'IoT・時系列・ML データ'],
+                    ].map(([criteria, fs, bt]) => (
+                        <div className="ctable-row" key={criteria}>
+                            <span className="ctval">{criteria}</span>
+                            <span className="ctdef">{fs}</span>
+                            <span className="ctdef">{bt}</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">10.6</span>Cloud Bigtable</div>
+                <pre className="codeblock">{`【Cloud Bigtable の特徴】
+
+ワイドカラム型 NoSQL:
+  数十億行 × 数百万列 のデータを処理
+  ミリ秒未満のレイテンシを維持
+
+  行キー（Row Key）でアクセス最適化:
+  例: "sensor_001#2024010112000000"（センサーID + タイムスタンプ）
+     → 時系列データの範囲スキャンが超高速
+
+HBase 互換:
+  Hadoop エコシステムとの統合が容易
+
+【ユースケース】
+  ├── IoT センサーデータ（秒間数百万レコード）
+  ├── 広告配信ログ
+  ├── 金融の取引履歴
+  └── ML フィーチャーストア`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">10.7</span>Memorystore</div>
+                <pre className="codeblock">{`【Memorystore の特徴】
+
+Redis / Memcached のフルマネージドサービス
+  → 自分で Redis を EC2 や GCE に立てる必要なし
+
+マイクロ秒レベルのレスポンス:
+  通常の DB（ミリ秒）の 1/1000 の速さ
+
+【用途】
+  ├── セッション管理（ユーザーのログイン状態）
+  ├── キャッシュ（頻繁にアクセスされるDBクエリ結果）
+  ├── リーダーボード（ゲームのランキング）
+  ├── レート制限（API の呼び出し回数制限）
+  └── Pub/Sub パターン（Redis の Pub/Sub 機能）
+
+【Memcached vs Redis の選択】
+  Memcached: シンプルなキャッシュ・マルチスレッド
+  Redis: データ永続化・複雑なデータ構造（Set, SortedSet など）
+         → ほとんどのケースで Redis を推奨`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">10.8</span>BigQuery</div>
+                <pre className="codeblock">{`【BigQuery の特徴】
+
+サーバーレス・フルマネージドのデータウェアハウス
+  → インフラ管理不要
+  → 数秒で数TB のデータを分析
+
+ストレージとコンピューティングの分離:
+  ストレージ: 安価（$0.02/GB/月）
+  クエリ: 処理したデータ量に課金（$5/TB）
+  → 必要な時だけクエリを実行（コスト効率高い）
+
+SQL で機械学習（BigQuery ML）:
+  CREATE MODEL でモデルをトレーニング
+  → データサイエンティストが Python 不要で ML を実施
+
+【ACE 試験での BigQuery の位置づけ】
+  ├── Cloud Billing データのエクスポート先（監査・分析）
+  ├── Cloud Logging のエクスポート先（長期ログ分析）
+  └── データウェアハウス・BI の基盤`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">10.BP</span>ベストプラクティス: データベース選定</div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス</div>
+                    <div className="ctable">
+                        <div className="ctable-head">
+                            <span className="cthead">ユースケース</span>
+                            <span className="cthead">推奨サービス</span>
+                            <span className="cthead">理由</span>
+                        </div>
+                        {[
+                            ['WordPress・EC サイト', 'Cloud SQL (MySQL/PG)', '標準的な RDBMS で移行コスト低'],
+                            ['グローバル金融システム', 'Cloud Spanner', '99.999% SLA・グローバル強整合性'],
+                            ['PostgreSQL で高性能が必要', 'AlloyDB', 'PG 互換のまま4倍の性能'],
+                            ['モバイルアプリのバックエンド', 'Firestore', 'リアルタイム同期・サーバーレス'],
+                            ['IoT・時系列データ', 'Cloud Bigtable', 'ペタバイトスケール・ミリ秒レイテンシ'],
+                            ['セッション・キャッシュ', 'Memorystore (Redis)', 'マイクロ秒レスポンス'],
+                            ['コスト分析・BI', 'BigQuery', 'サーバーレスDWH・SQL分析'],
+                            ['Oracle の移行', 'Bare Metal Solution', 'Oracle ライセンス・低レイテンシHW'],
+                        ].map(([usecase, svc, reason]) => (
+                            <div className="ctable-row" key={usecase}>
+                                <span className="ctval">{usecase}</span>
+                                <span className="ctval">{svc}</span>
+                                <span className="ctdef">{reason}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
 function Chapter5() {
     return (
         <div id="ch5" className="sgap">
@@ -1374,18 +2012,9 @@ export default function Domain2Page() {
                 <Chapter5 />
                 <Chapter6 />
                 <Chapter7 />
-                <div id="ch8" className="sgap">
-                    <h2>Cloud Storage</h2>
-                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
-                </div>
-                <div id="ch9" className="sgap">
-                    <h2>ブロック・ファイルストレージ</h2>
-                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
-                </div>
-                <div id="ch10" className="sgap">
-                    <h2>データベース選定</h2>
-                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
-                </div>
+                <Chapter8 />
+                <Chapter9 />
+                <Chapter10 />
                 <div id="ch11" className="sgap">
                     <h2>VPC 設計</h2>
                     <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>

--- a/app/gcl/associate-cloud-engineer/domain2/page.tsx
+++ b/app/gcl/associate-cloud-engineer/domain2/page.tsx
@@ -7,6 +7,386 @@ export const metadata: Metadata = {
         'Google Cloud ACE Domain 2 包括的解説。コンピューティング・ストレージ・ネットワーク・Terraform の計画と実装を詳解。',
 };
 
+function SectionIntro() {
+    return (
+        <div id="ch0" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn0">00</div>
+                <div className="sec-head-txt">
+                    <h2>Domain 2 全体マップ</h2>
+                    <p>クラウドソリューションの計画と実装 — 4つのサブドメインと16章の体系的学習ガイド</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">2.0</span>Domain 2 の構造</div>
+                <pre className="codeblock">{`Domain 2: クラウドソリューションの計画・実装（≈ 21%）
+│
+├── 2-A. コンピューティングリソースの計画と実装
+│   ├── Compute Engine (GCE)
+│   ├── Spot VM / プリエンプティブル VM
+│   ├── Managed Instance Group (MIG)
+│   ├── Google Kubernetes Engine (GKE)
+│   │   ├── Autopilot モード
+│   │   └── Standard モード
+│   ├── Cloud Run
+│   └── Cloud Functions
+│
+├── 2-B. データストレージの計画と実装
+│   ├── Cloud Storage（オブジェクトストレージ）
+│   ├── Persistent Disk / Filestore（ブロック・ファイルストレージ）
+│   └── データベースサービス選定
+│       ├── Cloud SQL / Cloud Spanner / AlloyDB
+│       ├── Firestore / Cloud Bigtable / Memorystore
+│       └── BigQuery / Bare Metal Solution
+│
+├── 2-C. ネットワークリソースの計画と実装
+│   ├── VPC・サブネット設計
+│   ├── Shared VPC / VPC Peering
+│   ├── Cloud NAT / Cloud DNS
+│   ├── Cloud VPN / Cloud Interconnect
+│   └── ロードバランサの選定
+│
+└── 2-D. Infrastructure as Code (IaC)
+    ├── Terraform の基本と State 管理
+    ├── CI/CD パイプラインとの統合
+    └── Cloud Deployment Manager`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">目次</span>章一覧</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">章</span>
+                        <span className="cthead">タイトル</span>
+                        <span className="cthead">主要トピック</span>
+                    </div>
+                    {[
+                        ['Ch1', 'コンピューティングサービス選定', 'GCE / Spot VM / GKE / Cloud Run / Cloud Functions 比較'],
+                        ['Ch2', 'Compute Engine 詳解', 'マシンファミリー・OS Login・ファイアウォール'],
+                        ['Ch3', 'Spot VM', 'プリエンプション・チェックポイント・コスト最適化'],
+                        ['Ch4', 'MIG', '自動ヒーリング・オートスケール・ローリングアップデート'],
+                        ['Ch5', 'GKE', 'Autopilot vs Standard・Workload Identity・HPA'],
+                        ['Ch6', 'Cloud Run', 'デプロイ・トラフィック分割・コンテナ設定'],
+                        ['Ch7', 'Cloud Functions', 'HTTP/GCS/Pub/Sub トリガー・Gen2 vs Gen1'],
+                        ['Ch8', 'Cloud Storage', 'ストレージクラス・OLM・署名付きURL'],
+                        ['Ch9', 'ブロック/ファイルストレージ', 'Persistent Disk 種類・リージョナルPD・Filestore'],
+                        ['Ch10', 'データベース選定', 'Cloud SQL / Spanner / Firestore / Bigtable / BigQuery'],
+                        ['Ch11', 'VPC 設計', 'VPC設計パターン・サブネット・ファイアウォール'],
+                        ['Ch12', 'Shared VPC と VPC Peering', '管理プロジェクト・サービスプロジェクト・ピアリング'],
+                        ['Ch13', 'Cloud NAT と Cloud DNS', 'Cloud Router・NAT・転送ゾーン・プライベートゾーン'],
+                        ['Ch14', 'ロードバランサ', 'LB種類選定・URLマップ・Cloud Armor・SSL'],
+                        ['Ch15', 'Terraform', 'State管理・モジュール・CI/CD・リモートバックエンド'],
+                        ['Ch16', '試験対策まとめ', '頻出パターン・重要用語・練習問題'],
+                    ].map(([ch, title, topics]) => (
+                        <div className="ctable-row" key={ch}>
+                            <span className="ctval">{ch}</span>
+                            <span className="ctval">{title}</span>
+                            <span className="ctdef">{topics}</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter1() {
+    return (
+        <div id="ch1" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn1">01</div>
+                <div className="sec-head-txt">
+                    <h2>コンピューティングサービスの選定</h2>
+                    <p>GCE・Spot VM・GKE・Cloud Run・Cloud Functions — どのサービスをいつ使うかを判断するフレームワーク</p>
+                </div>
+                <div className="pct-badge pb1">~21%</div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">1.1</span>サービス選定フローチャート</div>
+                <p className="tcard-desc">「どのコンピューティングサービスを使うか？」を判断するフローチャート</p>
+                <pre className="codeblock">{`アプリケーションをどのように動かしたい？
+│
+├── VM（仮想マシン）が必要？
+│   ├── 普通の VM → Compute Engine (GCE)
+│   └── コスト削減OK・停止されても大丈夫 → Spot VM + MIG
+│
+├── コンテナを使う？
+│   ├── Kubernetes でオーケストレーション → GKE
+│   │   ├── 運用を Google に任せたい → GKE Autopilot（推奨）
+│   │   └── カーネル設定など細かい制御が必要 → GKE Standard
+│   └── HTTP リクエストで動くステートレスなアプリ → Cloud Run
+│
+└── 関数（コードの断片）を実行したい？
+    └── イベント駆動の軽量処理 → Cloud Functions`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">1.2</span>コンピューティングサービス比較表</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">サービス</span>
+                        <span className="cthead">管理レベル</span>
+                        <span className="cthead">起動速度</span>
+                        <span className="cthead">コスト</span>
+                        <span className="cthead">最適なユースケース</span>
+                    </div>
+                    {[
+                        ['Compute Engine', 'フル制御（IaaS）', '遅い（数分）', 'vCPU/時間', 'レガシー移行・特定ライセンス・OS設定が必要'],
+                        ['Spot VM', 'フル制御（IaaS）', '遅い', '最大91%割引', 'バッチ・ML・レンダリング（停止OK）'],
+                        ['GKE Autopilot', 'フルマネージド', '中程度', 'Pod リソース単位', '大規模マイクロサービス・運用負荷を下げたい'],
+                        ['GKE Standard', '半マネージド', '中程度', 'ノード（VM）単位', '特権コンテナ・カーネル設定・DaemonSet'],
+                        ['Cloud Run', 'サーバーレス', '高速', 'リクエスト単位', 'HTTP API・ゼロスケール・イベント駆動'],
+                        ['Cloud Functions', 'サーバーレス', '高速', '呼び出し回数単位', '軽量グルーロジック・Webhook'],
+                    ].map(([svc, mgmt, speed, cost, usecase]) => (
+                        <div className="ctable-row" key={svc}>
+                            <span className="ctval">{svc}</span>
+                            <span className="ctdef">{mgmt}</span>
+                            <span className="ctdef">{speed}</span>
+                            <span className="ctdef">{cost}</span>
+                            <span className="ctdef">{usecase}</span>
+                        </div>
+                    ))}
+                </div>
+                <div className="src">
+                    参考: cloud.google.com/blog/topics/developers-practitioners/where-should-i-run-my-stuff-choosing-google-cloud-compute-option
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter2() {
+    return (
+        <div id="ch2" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn2">02</div>
+                <div className="sec-head-txt">
+                    <h2>Compute Engine (GCE) 詳解</h2>
+                    <p>マシンファミリー・ディスク種類・OS Login・ネットワーク設定 — IaaS の完全ガイド</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">2.1</span>Compute Engine とは？</div>
+                <p className="tcard-desc">
+                    Compute Engine は Google Cloud の IaaS（Infrastructure as a Service）です。Linux や Windows の仮想マシン（VM）を自由に作成・管理できます。
+                </p>
+                <pre className="codeblock">{`【Compute Engine でできること】
+・OS の完全な制御（カーネルパラメータの変更など）
+・カスタム VM サイズの設定
+・GPU/TPU の接続
+・静的 IP アドレスの割り当て
+・OS レベルのソフトウェアインストール
+・特定のライセンス（Windows Server, SQL Server 等）の利用`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">2.2</span>マシンファミリーとマシンタイプ</div>
+                <p className="stitle">マシンファミリーの選択基準</p>
+                <pre className="codeblock">{`汎用（General Purpose）: N2, N2D, E2, T2D
+    → 通常の Web サーバー、開発環境、中程度のワークロード
+    → E2 が最もコスト効率が高い（コスト重視ならまずE2）
+
+コンピューティング最適化（Compute Optimized）: C2, C2D
+    → CPU 性能が最優先（ゲーム、HPC、高スループット計算）
+
+メモリ最適化（Memory Optimized）: M2, M3
+    → 大容量 RAM が必要（SAP HANA、大型インメモリDB）
+    → 最大 12TB のメモリ
+
+アクセラレーター最適化（Accelerator Optimized）: A2, A3, G2
+    → GPU/TPU が必要（ML トレーニング、推論、3D レンダリング）`}</pre>
+
+                <p className="stitle">マシンタイプの命名規則</p>
+                <pre className="codeblock">{`例: n2-standard-4
+    │    │       └── vCPU 数（4コア）
+    │    └── シリーズ（standard = バランス型）
+    └── ファミリー（n2 = 第2世代汎用）
+
+シリーズの種類:
+  standard  = vCPU と メモリのバランス型（vCPU : メモリ = 1:4）
+  highmem   = メモリ多め（vCPU : メモリ = 1:8）
+  highcpu   = CPU 多め（vCPU : メモリ = 1:1）
+  micro/small = 最小構成（共有 vCPU）`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">2.3</span>ディスクの種類と選択基準</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span className="cthead">ディスク種別</span>
+                        <span className="cthead">特徴</span>
+                        <span className="cthead">IOPS</span>
+                        <span className="cthead">用途</span>
+                    </div>
+                    {[
+                        ['Balanced Persistent Disk', 'コストとパフォーマンスのバランス', '最大 80,000', '一般的なワークロード（デフォルト推奨）'],
+                        ['SSD Persistent Disk', '高 IOPS・低レイテンシ', '最大 100,000', '高負荷 DB、トランザクション処理'],
+                        ['Standard Persistent Disk', '最安価・低 IOPS', '最大 7,500', 'バッチ処理・コールドデータ'],
+                        ['Extreme Persistent Disk', '最高性能', '最大 120,000', 'SAP HANA・ミッションクリティカルDB'],
+                        ['Local SSD', '物理的に VM に接続・最速', '最大 2,400,000', 'キャッシュ・一時データ（VM停止で消える）'],
+                    ].map(([disk, feat, iops, usage]) => (
+                        <div className="ctable-row" key={disk}>
+                            <span className="ctval">{disk}</span>
+                            <span className="ctdef">{feat}</span>
+                            <span className="ctdef">{iops}</span>
+                            <span className="ctdef">{usage}</span>
+                        </div>
+                    ))}
+                </div>
+                <div className="wb">
+                    <div className="wbt">重要</div>
+                    <p>Local SSD のデータは VM が<strong>停止・削除されると消えます</strong>。永続化が必要なデータには使用しないこと。</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">2.4</span>VM へのセキュアなアクセス管理</div>
+
+                <p className="stitle">❌ アンチパターン: 静的 SSH 鍵の使用</p>
+                <pre className="codeblock">{`【問題のある旧来の方法】
+VM のメタデータに SSH 公開鍵を登録
+    ↓
+退職した社員の鍵が残り続ける
+    ↓
+不正アクセスのリスクが継続
+    ↓
+鍵の棚卸し作業が膨大`}</pre>
+
+                <p className="stitle">✅ 推奨: OS Login</p>
+                <p className="tcard-desc">OS Login は IAM を通じて SSH アクセスを管理します。</p>
+                <pre className="codeblock">{`【OS Login の仕組み】
+
+1. IAM で roles/compute.osLogin（一般ユーザー）
+   または roles/compute.osAdminLogin（sudo権限）を付与
+
+2. 社員が SSH 接続しようとする
+    ↓
+3. OS Login が IAM をリアルタイムに照会
+    ↓
+4. IAM でロールを持っていれば接続OK
+   IAM でロールを削除（退職処理）→ 即時アクセス不可
+
+【メリット】
+✓ IAM とライフサイクルを統合（退職 = アクセス消滅）
+✓ 個別の SSH キーをローテーションする必要なし
+✓ Linux アカウントを自動生成・管理
+✓ 詳細な監査ログが自動記録`}</pre>
+
+                <p className="stitle">OS Login の設定方法</p>
+                <pre className="codeblock">{`# プロジェクト全体に OS Login を有効化
+gcloud compute project-info add-metadata \\
+  --metadata enable-oslogin=TRUE
+
+# 特定の VM にのみ OS Login を有効化
+gcloud compute instances add-metadata VM_NAME \\
+  --metadata enable-oslogin=TRUE
+
+# 本番環境では 2FA を追加（強く推奨）
+gcloud compute project-info add-metadata \\
+  --metadata enable-oslogin-2fa=TRUE
+
+# ユーザーに OS Login ロールを付与
+gcloud projects add-iam-policy-binding PROJECT_ID \\
+  --member="user:alice@example.com" \\
+  --role="roles/compute.osLogin"
+
+# sudo 権限が必要な場合は osAdminLogin を使用
+gcloud projects add-iam-policy-binding PROJECT_ID \\
+  --member="user:alice@example.com" \\
+  --role="roles/compute.osAdminLogin"`}</pre>
+
+                <p className="stitle">JIT（Just-In-Time）アクセス</p>
+                <p className="tcard-desc">本番環境での一時的な特権アクセスには JIT を採用します。</p>
+                <pre className="codeblock">{`【JIT アクセスの流れ】
+
+1. エンジニアが緊急作業の必要性を検知
+2. JIT リクエストを送信（理由を記述）
+3. 承認者がリクエストを承認
+4. 一時的に sudo ロールを付与（例: 2時間）
+5. 作業完了後、自動的に権限が剥奪
+6. 全操作が監査ログに記録
+
+【なぜ重要か】
+常時 admin 権限を持つアカウントが侵害されると
+    → 取り返しのつかない被害
+JIT では権限は作業時間だけに限定される
+    → 被害を最小化できる`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">2.5</span>VM のネットワーク設定</div>
+
+                <p className="stitle">外部 IP アドレスの管理</p>
+                <pre className="codeblock">{`【一時的な外部 IP (Ephemeral)】
+  VM の起動時に自動割り当て
+  VM 停止時に解放される（再起動すると変わる）
+  コスト: 無料（使用中）
+
+【静的な外部 IP (Static)】
+  明示的に予約する
+  VM が停止しても保持される
+  コスト: 予約中は有料（VM に割り当て中は無料）
+
+【外部 IP なし（推奨: セキュリティ）】
+  プライベートネットワーク内のリソースだけからアクセス
+  Cloud NAT でインターネットへのアウトバウンドは可能
+  セキュリティ上のリスクを最小化`}</pre>
+
+                <p className="stitle">ファイアウォールルール</p>
+                <pre className="codeblock">{`# HTTP/HTTPS を許可するファイアウォールルール作成
+gcloud compute firewall-rules create allow-http-https \\
+  --network=my-vpc \\
+  --action=ALLOW \\
+  --rules=tcp:80,tcp:443 \\
+  --target-tags=web-server \\
+  --source-ranges=0.0.0.0/0
+
+# SSH を特定の IP からのみ許可
+gcloud compute firewall-rules create allow-ssh-bastion \\
+  --network=my-vpc \\
+  --action=ALLOW \\
+  --rules=tcp:22 \\
+  --target-tags=bastion \\
+  --source-ranges=203.0.113.0/24`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">2.BP</span>ベストプラクティス: Compute Engine</div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス</div>
+                    <div className="ctable">
+                        <div className="ctable-head">
+                            <span className="cthead">#</span>
+                            <span className="cthead">ベストプラクティス</span>
+                            <span className="cthead">理由</span>
+                        </div>
+                        {[
+                            ['1', 'OS Login + 2FA を有効化（静的 SSH 鍵は禁止）', 'キーの漏洩・管理コストを排除'],
+                            ['2', '外部 IP を持たない VM 構成（Cloud NAT でアウトバウンド）', '攻撃面（アタックサーフェス）を最小化'],
+                            ['3', '本番 VM への SSH は JIT アクセスで一時的に付与', '常時権限による被害を防止'],
+                            ['4', 'シールドド VM（Shielded VM）を有効化', 'UEFI セキュアブートで VM の完全性を保証'],
+                            ['5', 'メタデータサーバーへの不必要なアクセスを制限', '認証情報の不正取得を防止'],
+                            ['6', 'Confidential VM を検討（機密ワークロード）', 'メモリ上のデータも暗号化'],
+                        ].map(([num, bp, reason]) => (
+                            <div className="ctable-row" key={num}>
+                                <span className="ctval">{num}</span>
+                                <span className="ctval">{bp}</span>
+                                <span className="ctdef">{reason}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+                <div className="src">
+                    参考: cloud.google.com/blog/products/compute/top-compute-engine-documentation-pages/
+                </div>
+            </div>
+        </div>
+    );
+}
+
 export default function Domain2Page() {
     return (
         <div className="d2-page">
@@ -58,57 +438,64 @@ export default function Domain2Page() {
             </nav>
 
             <div className="wrapper">
-                <div id="ch0" className="sgap">
-                    <p style={{ color: 'var(--d2-text-muted)' }}>コンテンツ実装中...</p>
-                </div>
-                <div id="ch1" className="sgap">
-                    <h2>コンピューティングサービスの選定</h2>
-                </div>
-                <div id="ch2" className="sgap">
-                    <h2>Compute Engine 詳解</h2>
-                </div>
+                <SectionIntro />
+                <Chapter1 />
+                <Chapter2 />
                 <div id="ch3" className="sgap">
                     <h2>Spot VM の活用</h2>
+                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
                 </div>
                 <div id="ch4" className="sgap">
                     <h2>Managed Instance Groups (MIG)</h2>
+                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
                 </div>
                 <div id="ch5" className="sgap">
                     <h2>Google Kubernetes Engine (GKE)</h2>
+                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
                 </div>
                 <div id="ch6" className="sgap">
                     <h2>Cloud Run</h2>
+                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
                 </div>
                 <div id="ch7" className="sgap">
                     <h2>Cloud Functions</h2>
+                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
                 </div>
                 <div id="ch8" className="sgap">
                     <h2>Cloud Storage</h2>
+                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
                 </div>
                 <div id="ch9" className="sgap">
                     <h2>ブロック・ファイルストレージ</h2>
+                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
                 </div>
                 <div id="ch10" className="sgap">
                     <h2>データベース選定</h2>
+                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
                 </div>
                 <div id="ch11" className="sgap">
                     <h2>VPC 設計</h2>
+                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
                 </div>
                 <div id="ch12" className="sgap">
                     <h2>Shared VPC と VPC Peering</h2>
+                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
                 </div>
                 <div id="ch13" className="sgap">
                     <h2>Cloud NAT と Cloud DNS</h2>
+                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
                 </div>
                 <div id="ch14" className="sgap">
                     <h2>ロードバランサ</h2>
+                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
                 </div>
                 <div id="ch15" className="sgap">
                     <h2>Terraform による IaC</h2>
+                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>実装中...</p>
                 </div>
                 <div id="ch16" className="sgap">
                     <h2>試験対策まとめ</h2>
-                    <p style={{ color: 'var(--d2-text-muted)' }}>ベストプラクティス: コンテンツ実装中...</p>
+                    <p style={{ color: 'var(--d2-text-muted, #8899b0)' }}>ベストプラクティス: 実装中...</p>
                 </div>
             </div>
 

--- a/app/gcl/associate-cloud-engineer/domain3/domain3.css
+++ b/app/gcl/associate-cloud-engineer/domain3/domain3.css
@@ -1,0 +1,620 @@
+/* ===================================================================
+   Domain 3: Ensuring Successful Operation of a Cloud Solution
+   Control Room テーマ — SREダッシュボード・モニタリングコンソール
+   スコープクラス: .d3-page
+   =================================================================== */
+
+:root {
+    --d3-bg:          #060c0a;
+    --d3-surface:     #0b1510;
+    --d3-surface2:    #0f1d14;
+    --d3-surface3:    #142518;
+    --d3-border:      #1a3022;
+    --d3-border-bright: #2a5038;
+    --d3-green:       #10d070;
+    --d3-cyan:        #00e5cc;
+    --d3-amber:       #f59e0b;
+    --d3-blue:        #3b82f6;
+    --d3-purple:      #a855f7;
+    --d3-red:         #ef4444;
+    --d3-orange:      #f97316;
+    --d3-lime:        #84cc16;
+    --d3-text:        #b8ccc0;
+    --d3-text-muted:  #7a9485;
+    --d3-text-bright: #e0f0e8;
+    --d3-glow:        0 0 24px rgba(16, 208, 112, 0.20);
+    --d3-glow-sm:     0 0 10px rgba(16, 208, 112, 0.12);
+}
+
+/* ─── Reset & Base ─────────────────────────────────────────────── */
+.d3-page * {
+    box-sizing: border-box;
+}
+
+.d3-page {
+    background: var(--d3-bg, #060c0a);
+    color: var(--d3-text, #b8ccc0);
+    min-height: 100vh;
+    font-family: var(--font-body, 'Noto Sans JP', sans-serif);
+    line-height: 1.75;
+}
+
+/* ─── Hero Section ──────────────────────────────────────────────── */
+.d3-page .hero {
+    position: relative;
+    overflow: hidden;
+    padding: 72px 24px 56px;
+    text-align: center;
+    background:
+        radial-gradient(ellipse 70% 50% at 50% 0%, rgba(16, 208, 112, 0.16) 0%, transparent 70%),
+        linear-gradient(160deg, #060c0a 0%, #091410 45%, #0c1e14 75%, #060c0a 100%);
+    border-bottom: 1px solid var(--d3-border, #1a3022);
+}
+
+.d3-page .hero::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image:
+        linear-gradient(rgba(16, 208, 112, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(16, 208, 112, 0.03) 1px, transparent 1px);
+    background-size: 40px 40px;
+    pointer-events: none;
+}
+
+.d3-page .hero-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(16, 208, 112, 0.10);
+    border: 1px solid rgba(16, 208, 112, 0.25);
+    border-radius: 999px;
+    padding: 4px 16px;
+    font-size: 12px;
+    color: var(--d3-green, #10d070);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 20px;
+}
+
+.d3-page .hero h1 {
+    font-size: clamp(26px, 5vw, 44px);
+    font-weight: 900;
+    color: var(--d3-text-bright, #e0f0e8);
+    letter-spacing: -0.02em;
+    margin-bottom: 12px;
+    line-height: 1.2;
+}
+
+.d3-page .hero h1 span {
+    background: linear-gradient(135deg, var(--d3-green, #10d070), var(--d3-cyan, #00e5cc));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.d3-page .hero-sub {
+    font-size: 16px;
+    color: var(--d3-text-muted, #7a9485);
+    max-width: 640px;
+    margin: 0 auto 28px;
+}
+
+.d3-page .hero-meta {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 16px;
+    margin-top: 8px;
+}
+
+.d3-page .hero-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--d3-surface, #0b1510);
+    border: 1px solid var(--d3-border, #1a3022);
+    border-radius: 8px;
+    padding: 6px 14px;
+    font-size: 13px;
+    color: var(--d3-text, #b8ccc0);
+}
+
+.d3-page .hero-badge .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--d3-green, #10d070);
+    flex-shrink: 0;
+}
+
+.d3-page .hero-badge .dot-amber  { background: var(--d3-amber, #f59e0b); }
+.d3-page .hero-badge .dot-cyan   { background: var(--d3-cyan, #00e5cc); }
+.d3-page .hero-badge .dot-blue   { background: var(--d3-blue, #3b82f6); }
+
+/* ─── Sticky Nav ─────────────────────────────────────────────────── */
+.d3-page .snav {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    background: rgba(6, 12, 10, 0.92);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--d3-border, #1a3022);
+    overflow-x: auto;
+    scrollbar-width: none;
+}
+
+.d3-page .snav::-webkit-scrollbar { display: none; }
+
+.d3-page .snav-inner {
+    display: flex;
+    gap: 4px;
+    padding: 8px 16px;
+    width: max-content;
+    min-width: 100%;
+}
+
+.d3-page .snav-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 5px 12px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--d3-text-muted, #7a9485);
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background 0.15s, color 0.15s;
+}
+
+.d3-page .snav-link:hover {
+    background: var(--d3-surface2, #0f1d14);
+    color: var(--d3-text-bright, #e0f0e8);
+}
+
+.d3-page .snav-num {
+    font-size: 10px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    opacity: 0.7;
+}
+
+/* ─── Wrapper ─────────────────────────────────────────────────────── */
+.d3-page .wrapper {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 40px 20px 80px;
+}
+
+/* ─── Section Gap ─────────────────────────────────────────────────── */
+.d3-page .sgap {
+    margin-bottom: 64px;
+}
+
+/* ─── Section Header ──────────────────────────────────────────────── */
+.d3-page .sec-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+    margin-bottom: 28px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--d3-border, #1a3022);
+}
+
+.d3-page .sec-num {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 15px;
+    font-weight: 800;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    background: rgba(16, 208, 112, 0.12);
+    color: var(--d3-green, #10d070);
+    border: 1px solid rgba(16, 208, 112, 0.25);
+}
+
+.d3-page .sec-num.sn-cyan   { background: rgba(0, 229, 204, 0.12); color: var(--d3-cyan, #00e5cc); border-color: rgba(0, 229, 204, 0.25); }
+.d3-page .sec-num.sn-amber  { background: rgba(245, 158, 11, 0.12); color: var(--d3-amber, #f59e0b); border-color: rgba(245, 158, 11, 0.25); }
+.d3-page .sec-num.sn-blue   { background: rgba(59, 130, 246, 0.12); color: var(--d3-blue, #3b82f6); border-color: rgba(59, 130, 246, 0.25); }
+.d3-page .sec-num.sn-purple { background: rgba(168, 85, 247, 0.12); color: var(--d3-purple, #a855f7); border-color: rgba(168, 85, 247, 0.25); }
+.d3-page .sec-num.sn-orange { background: rgba(249, 115, 22, 0.12); color: var(--d3-orange, #f97316); border-color: rgba(249, 115, 22, 0.25); }
+
+.d3-page .sec-head-txt { flex: 1; }
+
+.d3-page .sec-head-txt h2 {
+    font-size: 20px;
+    font-weight: 800;
+    color: var(--d3-text-bright, #e0f0e8);
+    margin-bottom: 4px;
+    letter-spacing: -0.01em;
+}
+
+.d3-page .sec-head-txt p {
+    font-size: 13px;
+    color: var(--d3-text-muted, #7a9485);
+    margin: 0;
+}
+
+.d3-page .pct-badge {
+    flex-shrink: 0;
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 700;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    background: rgba(16, 208, 112, 0.12);
+    color: var(--d3-green, #10d070);
+    border: 1px solid rgba(16, 208, 112, 0.20);
+}
+
+/* ─── Topic Card ──────────────────────────────────────────────────── */
+.d3-page .tcard {
+    background: var(--d3-surface, #0b1510);
+    border: 1px solid var(--d3-border, #1a3022);
+    border-radius: 14px;
+    padding: 24px;
+    margin-bottom: 20px;
+    transition: border-color 0.2s;
+}
+
+.d3-page .tcard:hover {
+    border-color: var(--d3-border-bright, #2a5038);
+}
+
+.d3-page .ttitle {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--d3-text-bright, #e0f0e8);
+    margin-bottom: 14px;
+}
+
+.d3-page .tid {
+    font-size: 11px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    background: rgba(16, 208, 112, 0.12);
+    color: var(--d3-green, #10d070);
+    padding: 2px 8px;
+    border-radius: 4px;
+    flex-shrink: 0;
+}
+
+.d3-page .tcard > p {
+    font-size: 14px;
+    color: var(--d3-text, #b8ccc0);
+    margin-bottom: 16px;
+    line-height: 1.75;
+}
+
+/* ─── Term Grid ───────────────────────────────────────────────────── */
+.d3-page .tgrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 10px;
+    margin-bottom: 18px;
+}
+
+.d3-page .titem {
+    background: var(--d3-surface2, #0f1d14);
+    border: 1px solid var(--d3-border, #1a3022);
+    border-radius: 8px;
+    padding: 12px 14px;
+}
+
+.d3-page .tname {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--d3-green, #10d070);
+    margin-bottom: 5px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.d3-page .tdef {
+    font-size: 13px;
+    color: var(--d3-text, #b8ccc0);
+    line-height: 1.6;
+}
+
+/* ─── Comparison Table ────────────────────────────────────────────── */
+.d3-page .ctable-wrap {
+    overflow-x: auto;
+    margin-bottom: 18px;
+    border-radius: 10px;
+    border: 1px solid var(--d3-border, #1a3022);
+}
+
+.d3-page .ctable {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+}
+
+.d3-page .ctable th {
+    background: var(--d3-surface2, #0f1d14);
+    color: var(--d3-green, #10d070);
+    font-weight: 700;
+    padding: 10px 14px;
+    text-align: left;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 12px;
+    border-bottom: 1px solid var(--d3-border, #1a3022);
+    white-space: nowrap;
+}
+
+.d3-page .ctable td {
+    padding: 10px 14px;
+    color: var(--d3-text, #b8ccc0);
+    border-bottom: 1px solid var(--d3-border, #1a3022);
+    vertical-align: top;
+    line-height: 1.6;
+}
+
+.d3-page .ctable tr:last-child td { border-bottom: none; }
+
+.d3-page .ctable tr:hover td {
+    background: rgba(16, 208, 112, 0.04);
+}
+
+.d3-page .ctable td strong {
+    color: var(--d3-text-bright, #e0f0e8);
+    font-weight: 700;
+}
+
+/* ─── Best Practice Box ───────────────────────────────────────────── */
+.d3-page .bp {
+    background: rgba(16, 208, 112, 0.06);
+    border: 1px solid rgba(16, 208, 112, 0.20);
+    border-left: 3px solid var(--d3-green, #10d070);
+    border-radius: 8px;
+    padding: 16px 18px;
+    margin-bottom: 14px;
+}
+
+.d3-page .bpt {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--d3-green, #10d070);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 10px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.d3-page .bp ul {
+    margin: 0;
+    padding-left: 18px;
+}
+
+.d3-page .bp li {
+    font-size: 13px;
+    color: var(--d3-text, #b8ccc0);
+    margin-bottom: 6px;
+    line-height: 1.65;
+}
+
+.d3-page .bp li:last-child { margin-bottom: 0; }
+
+/* ─── Warning Box ─────────────────────────────────────────────────── */
+.d3-page .wb {
+    background: rgba(245, 158, 11, 0.06);
+    border: 1px solid rgba(245, 158, 11, 0.20);
+    border-left: 3px solid var(--d3-amber, #f59e0b);
+    border-radius: 8px;
+    padding: 14px 18px;
+    margin-bottom: 14px;
+}
+
+.d3-page .wbt {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--d3-amber, #f59e0b);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 8px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.d3-page .wb p,
+.d3-page .wb li {
+    font-size: 13px;
+    color: var(--d3-text, #b8ccc0);
+    line-height: 1.65;
+    margin: 0;
+}
+
+/* ─── Alert Box (SLO違反・障害) ────────────────────────────────────── */
+.d3-page .ab {
+    background: rgba(239, 68, 68, 0.06);
+    border: 1px solid rgba(239, 68, 68, 0.20);
+    border-left: 3px solid var(--d3-red, #ef4444);
+    border-radius: 8px;
+    padding: 14px 18px;
+    margin-bottom: 14px;
+}
+
+.d3-page .abt {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--d3-red, #ef4444);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 8px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.d3-page .ab p,
+.d3-page .ab li {
+    font-size: 13px;
+    color: var(--d3-text, #b8ccc0);
+    line-height: 1.65;
+    margin: 0;
+}
+
+/* ─── Code Block ──────────────────────────────────────────────────── */
+.d3-page .codeblock {
+    background: #040a06;
+    border: 1px solid var(--d3-border, #1a3022);
+    border-radius: 10px;
+    padding: 18px 20px;
+    margin-bottom: 14px;
+    overflow-x: auto;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 12.5px;
+    line-height: 1.75;
+    color: var(--d3-text, #b8ccc0);
+    white-space: pre;
+    scrollbar-width: thin;
+    scrollbar-color: var(--d3-border, #1a3022) transparent;
+}
+
+.d3-page .codeblock::-webkit-scrollbar { height: 4px; }
+.d3-page .codeblock::-webkit-scrollbar-track { background: transparent; }
+.d3-page .codeblock::-webkit-scrollbar-thumb { background: var(--d3-border, #1a3022); border-radius: 2px; }
+
+/* syntax highlighting */
+.d3-page .codeblock .comment { color: #3a6040; }
+.d3-page .codeblock .cmd     { color: var(--d3-green, #10d070); font-weight: 600; }
+.d3-page .codeblock .flag    { color: var(--d3-cyan, #00e5cc); }
+.d3-page .codeblock .val     { color: var(--d3-lime, #84cc16); }
+.d3-page .codeblock .str     { color: var(--d3-amber, #f59e0b); }
+.d3-page .codeblock .kw      { color: var(--d3-purple, #a855f7); font-weight: 600; }
+.d3-page .codeblock .fn      { color: var(--d3-orange, #f97316); }
+.d3-page .codeblock .cls     { color: var(--d3-blue, #3b82f6); }
+.d3-page .codeblock .num     { color: var(--d3-cyan, #00e5cc); }
+.d3-page .codeblock .out     { color: #3a6040; }
+.d3-page .codeblock .prompt  { color: #3a6040; user-select: none; }
+
+/* ─── Code Block Wrap+Label ───────────────────────────────────────── */
+.d3-page .cb-wrap {
+    margin-bottom: 14px;
+}
+
+.d3-page .cb-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--d3-surface2, #0f1d14);
+    border: 1px solid var(--d3-border, #1a3022);
+    border-bottom: none;
+    border-radius: 8px 8px 0 0;
+    padding: 6px 14px;
+    font-size: 11px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    color: var(--d3-text-muted, #7a9485);
+}
+
+.d3-page .cb-label .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+}
+
+.d3-page .cb-label .dot-red    { background: #ef4444; }
+.d3-page .cb-label .dot-yellow { background: #f59e0b; }
+.d3-page .cb-label .dot-green  { background: #10d070; }
+
+.d3-page .cb-wrap .codeblock {
+    border-radius: 0 0 10px 10px;
+    margin-bottom: 0;
+}
+
+/* ─── Subsection Title ────────────────────────────────────────────── */
+.d3-page .stitle {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--d3-cyan, #00e5cc);
+    margin: 20px 0 10px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.d3-page .stitle::before {
+    content: '';
+    width: 3px;
+    height: 14px;
+    background: var(--d3-cyan, #00e5cc);
+    border-radius: 2px;
+    flex-shrink: 0;
+}
+
+/* ─── Resource Links ──────────────────────────────────────────────── */
+.d3-page .src {
+    margin-top: 16px;
+    padding-top: 14px;
+    border-top: 1px solid var(--d3-border, #1a3022);
+}
+
+.d3-page .srct {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--d3-text-muted, #7a9485);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 8px;
+}
+
+.d3-page .src a {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--d3-green, #10d070);
+    text-decoration: none;
+    margin-right: 14px;
+    transition: opacity 0.15s;
+}
+
+.d3-page .src a:hover { opacity: 0.75; }
+
+/* ─── Page Footer ─────────────────────────────────────────────────── */
+.d3-page .page-footer {
+    text-align: center;
+    padding: 32px 20px;
+    border-top: 1px solid var(--d3-border, #1a3022);
+    font-size: 13px;
+    color: var(--d3-text-muted, #7a9485);
+}
+
+/* ─── Divider ─────────────────────────────────────────────────────── */
+.d3-page .sdivider {
+    border: none;
+    border-top: 1px solid var(--d3-border, #1a3022);
+    margin: 48px 0;
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+    .d3-page .tgrid {
+        grid-template-columns: 1fr;
+    }
+
+    .d3-page .sec-head {
+        flex-wrap: wrap;
+    }
+}
+
+@media (max-width: 640px) {
+    .d3-page .hero {
+        padding: 48px 16px 36px;
+    }
+
+    .d3-page .hero h1 {
+        font-size: 24px;
+    }
+
+    .d3-page .wrapper {
+        padding: 24px 14px 60px;
+    }
+
+    .d3-page .tcard {
+        padding: 16px;
+    }
+}

--- a/app/gcl/associate-cloud-engineer/domain3/domain3.css
+++ b/app/gcl/associate-cloud-engineer/domain3/domain3.css
@@ -4,12 +4,28 @@
    スコープクラス: .d3-page
    =================================================================== */
 
+/* Layer 3: Domain 3 固有テーマ — globals.css セマンティックトークンを上書き */
 :root {
-    --d3-bg:          #060c0a;
-    --d3-surface:     #0b1510;
+    --color-background:       #060c0a;
+    --color-foreground:       #b8ccc0;
+    --color-card:             #0b1510;
+    --color-card-foreground:  #b8ccc0;
+    --color-muted-foreground: #7a9485;
+    --color-border:           #1a3022;
+    --color-primary:          #10d070;
+}
+
+/* Domain 3 固有プリミティブ（グローバルセマンティックに対応するものがない値） */
+.d3-page {
+    /* セマンティックトークンへのエイリアス（ファイル内の var(--d3-*) 参照を維持） */
+    --d3-bg:          var(--color-background);
+    --d3-surface:     var(--color-card);
+    --d3-border:      var(--color-border);
+    --d3-text:        var(--color-foreground);
+    --d3-text-muted:  var(--color-muted-foreground);
+    /* page-specific プリミティブ */
     --d3-surface2:    #0f1d14;
     --d3-surface3:    #142518;
-    --d3-border:      #1a3022;
     --d3-border-bright: #2a5038;
     --d3-green:       #10d070;
     --d3-cyan:        #00e5cc;
@@ -19,8 +35,6 @@
     --d3-red:         #ef4444;
     --d3-orange:      #f97316;
     --d3-lime:        #84cc16;
-    --d3-text:        #b8ccc0;
-    --d3-text-muted:  #7a9485;
     --d3-text-bright: #e0f0e8;
     --d3-glow:        0 0 24px rgba(16, 208, 112, 0.20);
     --d3-glow-sm:     0 0 10px rgba(16, 208, 112, 0.12);
@@ -32,8 +46,8 @@
 }
 
 .d3-page {
-    background: var(--d3-bg, #060c0a);
-    color: var(--d3-text, #b8ccc0);
+    background: var(--color-background, #060c0a);
+    color: var(--color-foreground, #b8ccc0);
     min-height: 100vh;
     font-family: var(--font-body, 'Noto Sans JP', sans-serif);
     line-height: 1.75;

--- a/app/gcl/associate-cloud-engineer/domain3/layout.tsx
+++ b/app/gcl/associate-cloud-engineer/domain3/layout.tsx
@@ -1,0 +1,9 @@
+import './domain3.css';
+
+export default function Domain3Layout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return <>{children}</>;
+}

--- a/app/gcl/associate-cloud-engineer/domain3/page.tsx
+++ b/app/gcl/associate-cloud-engineer/domain3/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import './domain3.css';
 
 export const metadata: Metadata = {
     title: 'Domain 3: Ensuring Successful Operation of a Cloud Solution',

--- a/app/gcl/associate-cloud-engineer/domain3/page.tsx
+++ b/app/gcl/associate-cloud-engineer/domain3/page.tsx
@@ -7,6 +7,2300 @@ export const metadata: Metadata = {
         'Google Cloud ACE Domain 3 包括的解説。SRE・監視・ロギング・バックアップ・障害対応の運用管理を詳解。',
 };
 
+function SectionIntro() {
+    return (
+        <div id="ch0" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn0">00</div>
+                <div className="sec-head-txt">
+                    <h2>Domain 3 全体マップ</h2>
+                    <p>クラウドソリューションの正常なオペレーションの確保（≈ 22%）</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.0</span>Domain 3 の構造</div>
+                <pre className="codeblock">{`Domain 3: クラウドソリューションの正常なオペレーションの確保（≈ 22%）
+│
+├── 3-A. コンピュートリソースの管理と維持
+│   ├── Compute Engine のライフサイクル管理
+│   ├── ディスクスナップショットの管理
+│   ├── Managed Instance Group (MIG) の操作
+│   ├── GKE クラスタ・ノードの管理
+│   └── Cloud Run / Cloud Functions の管理
+│
+├── 3-B. ストレージとデータベースの管理
+│   ├── Cloud Storage のデータ保護・管理
+│   ├── Cloud SQL / Spanner のバックアップと復元
+│   └── BigQuery データ管理
+│
+├── 3-C. オブザーバビリティ（可観測性）の確立
+│   ├── Cloud Monitoring
+│   │   ├── Ops Agent（メトリクス・ログ収集）
+│   │   ├── カスタムダッシュボード
+│   │   ├── アラートポリシーの設定
+│   │   └── SLO（サービスレベル目標）の設定
+│   ├── Cloud Logging
+│   │   ├── 監査ログの種類と管理
+│   │   ├── ログの検索・フィルタリング
+│   │   ├── Log Router（シンク設定）
+│   │   └── BigQuery / Cloud Storage へのエクスポート
+│   ├── Cloud Trace / Cloud Profiler
+│   └── Error Reporting
+│
+└── 3-D. AI 駆動の運用最適化
+    ├── Gemini Cloud Assist
+    └── Cloud Asset Inventory`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.0</span>SRE の三本柱</div>
+                <div className="tgrid">
+                    <div className="titem"><div className="tname">信頼性（Reliability）</div><div className="tdef">スナップショット・MIG自動ヒーリング・SLOによるバックアップと自動復旧体制</div></div>
+                    <div className="titem"><div className="tname">可観測性（Observability）</div><div className="tdef">Cloud Monitoring・Cloud Logging・Cloud Traceによるシステム状態の把握</div></div>
+                    <div className="titem"><div className="tname">運用効率（Operational Efficiency）</div><div className="tdef">アラート自動通知・Gemini Cloud Assist・IaCでの運用負荷削減</div></div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.0</span>目次（全17章）</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>章</span><span>タイトル</span><span>カテゴリ</span>
+                    </div>
+                    <div className="ctable-row"><span>Ch1</span><span>SRE 的アプローチ</span><span>概念</span></div>
+                    <div className="ctable-row"><span>Ch2</span><span>Compute Engine ライフサイクル管理</span><span>3-A コンピュート</span></div>
+                    <div className="ctable-row"><span>Ch3</span><span>ディスクスナップショット</span><span>3-A コンピュート</span></div>
+                    <div className="ctable-row"><span>Ch4</span><span>MIG 運用管理</span><span>3-A コンピュート</span></div>
+                    <div className="ctable-row"><span>Ch5</span><span>GKE クラスタ運用</span><span>3-A コンピュート</span></div>
+                    <div className="ctable-row"><span>Ch6</span><span>Cloud Run / Cloud Functions 管理</span><span>3-A コンピュート</span></div>
+                    <div className="ctable-row"><span>Ch7</span><span>Cloud Storage データ管理</span><span>3-B ストレージ</span></div>
+                    <div className="ctable-row"><span>Ch8</span><span>Cloud SQL / Spanner バックアップ</span><span>3-B ストレージ</span></div>
+                    <div className="ctable-row"><span>Ch9</span><span>Cloud Monitoring</span><span>3-C 可観測性</span></div>
+                    <div className="ctable-row"><span>Ch10</span><span>Ops Agent 導入と設定</span><span>3-C 可観測性</span></div>
+                    <div className="ctable-row"><span>Ch11</span><span>アラートポリシーと SLO</span><span>3-C 可観測性</span></div>
+                    <div className="ctable-row"><span>Ch12</span><span>Cloud Logging</span><span>3-C 可観測性</span></div>
+                    <div className="ctable-row"><span>Ch13</span><span>監査ログ（Audit Logs）</span><span>3-C 可観測性</span></div>
+                    <div className="ctable-row"><span>Ch14</span><span>Log Router</span><span>3-C 可観測性</span></div>
+                    <div className="ctable-row"><span>Ch15</span><span>Cloud Trace / Profiler / Error Reporting</span><span>3-C 可観測性</span></div>
+                    <div className="ctable-row"><span>Ch16</span><span>Gemini Cloud Assist + Cloud Asset Inventory</span><span>3-D AI 運用</span></div>
+                    <div className="ctable-row"><span>Ch17</span><span>試験対策まとめ</span><span>試験対策</span></div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter1() {
+    return (
+        <div id="ch1" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn1">01</div>
+                <div className="sec-head-txt">
+                    <h2>SRE 的アプローチ — オペレーション管理の考え方</h2>
+                    <p>Site Reliability Engineering の基本概念と SLI/SLO/SLA の関係</p>
+                </div>
+                <div className="pct-badge pb1">~22%</div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">1.1</span>「正常なオペレーション」とは？</div>
+                <pre className="codeblock">{`【クラウド運用の 3 つの柱】
+
+①  信頼性（Reliability）
+   └── システムが期待通りに動き続けること
+       ・スナップショットによるバックアップ
+       ・MIG の自動ヒーリング
+       ・SLO による目標の定義と監視
+
+②  可観測性（Observability）
+   └── システムの「今何が起きているか」を把握できること
+       ・Cloud Monitoring でメトリクスを収集
+       ・Cloud Logging でログを集約・分析
+       ・Cloud Trace で処理の遅延を特定
+
+③  運用効率（Operational Efficiency）
+   └── 手作業を減らし、問題を自動で検知・解決すること
+       ・アラートで異常を自動通知
+       ・Gemini Cloud Assist で障害の根本原因を AI が分析
+       ・IaC でインフラをコードで管理`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">1.2</span>SRE（Site Reliability Engineering）の基本概念</div>
+                <pre className="codeblock">{`【SRE の核心概念】
+
+SLI（Service Level Indicator）= 測定値
+  例: 「過去 30 日間のリクエスト成功率は 99.95% だった」
+
+SLO（Service Level Objective）= 目標
+  例: 「リクエスト成功率を 99.9% 以上に保つ」
+
+SLA（Service Level Agreement）= 契約
+  例: 「99.9% を下回った場合、料金を返金する」
+
+エラーバジェット（Error Budget）= 許容できる失敗量
+  例: SLO が 99.9% なら
+      エラーバジェット = 0.1% = 月間約 43.8 分のダウンタイム許容`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">1.2</span>SRE vs DevOps — ACE 試験の観点</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>項目</span><span>SRE</span><span>DevOps</span>
+                    </div>
+                    <div className="ctable-row"><span>発祥</span><span>Google（2003年〜）</span><span>業界全体の運動</span></div>
+                    <div className="ctable-row"><span>焦点</span><span>信頼性の定量化（SLO・エラーバジェット）</span><span>開発と運用の文化的統合</span></div>
+                    <div className="ctable-row"><span>ツール</span><span>Cloud Monitoring・SLO・エラーバジェット</span><span>CI/CD パイプライン・IaC</span></div>
+                    <div className="ctable-row"><span>スケーリング</span><span>信頼性のスケール（自動化でトイルを排除）</span><span>デプロイ速度のスケール</span></div>
+                </div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: SRE の原則</div>
+                    <ul>
+                        <li>エラーバジェットを使い切らない限り新機能リリースを優先する</li>
+                        <li>エラーバジェットを使い切ったら信頼性向上作業を最優先にする</li>
+                        <li>ポストモーテム（障害レビュー）を blame-free（非難なし）で実施する</li>
+                        <li>トイル（手動・反復作業）を自動化して排除する</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">1.3</span>4 つのゴールデンシグナル（Four Golden Signals）</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>シグナル</span><span>説明</span><span>GCP での収集手段</span>
+                    </div>
+                    <div className="ctable-row"><span>レイテンシ（Latency）</span><span>リクエストの応答時間（成功 vs 失敗を区別）</span><span>Cloud Trace・LB メトリクス</span></div>
+                    <div className="ctable-row"><span>トラフィック（Traffic）</span><span>システムへの需要量（RPS・帯域幅など）</span><span>Cloud Monitoring メトリクス</span></div>
+                    <div className="ctable-row"><span>エラー（Errors）</span><span>失敗したリクエストの割合</span><span>Error Reporting・LB メトリクス</span></div>
+                    <div className="ctable-row"><span>飽和度（Saturation）</span><span>リソースの利用率（CPU・メモリ・ディスク）</span><span>Ops Agent・Cloud Monitoring</span></div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter2() {
+    return (
+        <div id="ch2" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn2">02</div>
+                <div className="sec-head-txt">
+                    <h2>Compute Engine のライフサイクル管理</h2>
+                    <p>VM の状態管理・基本操作・スタートアップスクリプト・デバッグ</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">2.1</span>VM のライフサイクルと状態管理</div>
+                <pre className="codeblock">{`【VM のライフサイクル】
+
+PROVISIONING（プロビジョニング中）
+    ↓ リソース割り当て完了
+STAGING（起動準備中）
+    ↓ ブート完了
+RUNNING（実行中）← 通常の稼働状態
+    │
+    ├── gcloud compute instances stop → STOPPING → TERMINATED（停止）
+    │   ※ TERMINATED でもディスクのデータは保持される
+    │   ※ TERMINATED 中も静的 IP・永続ディスクには課金が継続
+    │
+    ├── gcloud compute instances suspend → SUSPENDED（サスペンド）
+    │   ※ メモリ状態を保持したまま停止（Hibernation）
+    │   ※ 停止より再起動が速い
+    │
+    └── gcloud compute instances delete → STOPPING → DELETED
+        ※ ディスクの削除設定に依存`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">2.2</span>VM の基本操作コマンド</div>
+                <pre className="codeblock">{`# ===== VM の起動・停止・再起動 =====
+
+# VM を停止（ディスクデータ保持・課金一部停止）
+gcloud compute instances stop VM_NAME \\
+  --zone=asia-northeast1-a
+
+# VM を起動
+gcloud compute instances start VM_NAME \\
+  --zone=asia-northeast1-a
+
+# VM を再起動
+gcloud compute instances reset VM_NAME \\
+  --zone=asia-northeast1-a
+
+# VM を一時停止（メモリ状態保持）
+gcloud compute instances suspend VM_NAME \\
+  --zone=asia-northeast1-a
+
+# ===== VM の情報確認 =====
+
+# VM の一覧表示
+gcloud compute instances list
+
+# 特定プロジェクトの全リージョンの VM を表示
+gcloud compute instances list --project=PROJECT_ID
+
+# VM の詳細情報
+gcloud compute instances describe VM_NAME \\
+  --zone=asia-northeast1-a \\
+  --format=json
+
+# ===== VM の設定変更 =====
+
+# VM のマシンタイプを変更（停止中のみ可能）
+gcloud compute instances set-machine-type VM_NAME \\
+  --machine-type=n2-standard-8 \\
+  --zone=asia-northeast1-a
+
+# VM にラベルを追加
+gcloud compute instances add-labels VM_NAME \\
+  --labels=env=production,team=backend \\
+  --zone=asia-northeast1-a
+
+# VM のメタデータを更新
+gcloud compute instances add-metadata VM_NAME \\
+  --metadata=startup-script-url=gs://my-bucket/startup.sh \\
+  --zone=asia-northeast1-a`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">2.3</span>スタートアップスクリプトとシャットダウンスクリプト</div>
+                <pre className="codeblock">{`# スタートアップスクリプト（VM 起動時に実行）
+#!/bin/bash
+# startup.sh
+apt-get update -y
+apt-get install -y nginx
+systemctl start nginx
+systemctl enable nginx
+echo "Startup complete: $(date)" >> /var/log/startup.log
+
+# スタートアップスクリプトを VM に設定
+gcloud compute instances create VM_NAME \\
+  --metadata-from-file startup-script=startup.sh \\
+  --zone=asia-northeast1-a
+
+# GCS からスタートアップスクリプトを読み込む
+gcloud compute instances create VM_NAME \\
+  --metadata=startup-script-url=gs://my-bucket/startup.sh \\
+  --zone=asia-northeast1-a`}</pre>
+                <pre className="codeblock">{`# シャットダウンスクリプト（VM 停止前に実行、最大 90 秒）
+#!/bin/bash
+# shutdown.sh
+echo "Shutdown initiated: $(date)" >> /var/log/shutdown.log
+
+# 処理中のデータをバックアップ
+gsutil cp /var/app/data/*.json gs://my-backup-bucket/$(date +%Y%m%d%H%M%S)/
+
+# アプリを graceful に停止
+systemctl stop my-app
+echo "Shutdown complete: $(date)" >> /var/log/shutdown.log`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">2.4</span>Serial Console（シリアルコンソール）デバッグ</div>
+                <p className="tcard-desc">SSH でアクセスできない障害時のデバッグ手段。OS ブート中の問題やネットワーク障害時に活用します。</p>
+                <pre className="codeblock">{`# シリアルコンソールへのアクセスを有効化
+gcloud compute instances add-metadata VM_NAME \\
+  --metadata=serial-port-enable=TRUE \\
+  --zone=asia-northeast1-a
+
+# シリアルコンソールに接続
+gcloud compute connect-to-serial-port VM_NAME \\
+  --zone=asia-northeast1-a
+
+# シリアルポートのログを確認（最後の 100 行）
+gcloud compute instances get-serial-port-output VM_NAME \\
+  --zone=asia-northeast1-a \\
+  --port=1 \\
+  --start=0 | tail -100`}</pre>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: Compute Engine ライフサイクル管理</div>
+                    <ul>
+                        <li><strong>停止・起動の自動化</strong>（Cloud Scheduler + Cloud Functions）で開発 VM を夜間停止 → コスト削減</li>
+                        <li><strong>ラベルを必ず付けて</strong>管理（env, team, cost-center）→ 棚卸し・コスト分析の基盤</li>
+                        <li><strong>シリアルコンソールは必要時だけ有効化</strong>（通常は無効）→ 不正アクセスのリスク低減</li>
+                        <li><strong>停止前にスナップショットを自動取得</strong>（スナップショットスケジュール）→ データ保護</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">補足</span>IAP（Identity-Aware Proxy）による安全な SSH 接続</div>
+                <p className="tcard-desc">パブリック IP を持たない VM へのセキュアなアクセス手段。IAM 権限（roles/iap.tunnelResourceAccessor）を確認してトンネルを構築します。</p>
+                <pre className="codeblock">{`# IAP トンネル経由で SSH（VM にパブリック IP 不要）
+gcloud compute ssh VM_NAME \\
+  --tunnel-through-iap \\
+  --zone=asia-northeast1-a
+
+# IAP トンネルの権限を付与
+gcloud projects add-iam-policy-binding PROJECT_ID \\
+  --member="user:alice@example.com" \\
+  --role="roles/iap.tunnelResourceAccessor"`}</pre>
+            </div>
+        </div>
+    );
+}
+
+function Chapter3() {
+    return (
+        <div id="ch3" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn3">03</div>
+                <div className="sec-head-txt">
+                    <h2>ディスクスナップショットの管理</h2>
+                    <p>増分バックアップ・整合性レベル・スケジュール・復元・コスト管理</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.1</span>スナップショットとは？（増分バックアップの仕組み）</div>
+                <pre className="codeblock">{`【スナップショットの仕組み】
+
+時刻 T1: スナップショット A（完全バックアップ）
+    ↓ 差分データだけ保存
+時刻 T2: スナップショット B（増分バックアップ）
+    ↓ さらに差分データだけ保存
+時刻 T3: スナップショット C（増分バックアップ）
+
+【増分バックアップの特徴】
+  ✓ 初回以降は差分のみ → ストレージコストが少ない
+  ✓ どのスナップショットからでも完全復元が可能
+  ✓ 古いスナップショットを削除しても
+    依存する新しいスナップショットは引き続き有効`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.2</span>スナップショットの整合性レベル（試験頻出）</div>
+                <pre className="codeblock">{`【クラッシュ整合性スナップショット（Crash-Consistent）】
+アプリを停止せず、そのままスナップショットを取得
+
+メリット:
+  ✓ アプリを停止する必要がない（無停止で取得）
+  ✓ 取得が素早い
+
+デメリット:
+  ✗ メモリ上のデータ（未書き込みバッファ）はキャプチャされない
+  ✗ 復元後、OS がクラッシュ後の起動と同じプロセスを実行する
+
+適切なユースケース:
+  ├── OS ディスク（Linux / Windows ともに対応）
+  └── ステートレスなアプリのディスク`}</pre>
+                <pre className="codeblock">{`【アプリケーション整合性スナップショット（Application-Consistent）】
+1. アプリに「書き込みを一時停止して」と指示（Freeze）
+2. メモリ上のデータをディスクにフラッシュ
+3. スナップショットを取得
+4. アプリの書き込みを再開（Thaw）
+
+メリット:
+  ✓ メモリ上のデータも含めた完全な整合性
+  ✓ 復元後のデータ整合性が保証される
+
+デメリット:
+  ✗ アプリ側のサポートが必要（VSS、fsfreeze など）
+  ✗ 取得中に書き込み I/O が一時停止される
+
+適切なユースケース:
+  ├── データベース（MySQL、PostgreSQL など）
+  └── トランザクション処理をしているアプリ`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.3</span>スナップショットの取得方法</div>
+                <pre className="codeblock">{`# 基本的なスナップショット取得（手動）
+gcloud compute disks snapshot DISK_NAME \\
+  --snapshot-names=my-snapshot-$(date +%Y%m%d%H%M%S) \\
+  --zone=asia-northeast1-a \\
+  --description="Manual backup before maintenance"
+
+# 別リージョンに保存（DR 対策）
+gcloud compute disks snapshot DISK_NAME \\
+  --snapshot-names=my-snapshot-cross-region \\
+  --zone=asia-northeast1-a \\
+  --storage-location=us-central1
+
+# 複数ディスクを同時にスナップショット
+gcloud compute disks snapshot DISK1 DISK2 DISK3 \\
+  --zone=asia-northeast1-a`}</pre>
+                <pre className="codeblock">{`# ===== スナップショットスケジュール（定期自動取得）=====
+
+# 1時間ごとのスナップショットスケジュールを作成
+gcloud compute resource-policies create snapshot-schedule hourly-backup \\
+  --region=asia-northeast1 \\
+  --max-retention-days=7 \\
+  --start-time=00:00 \\
+  --hourly-schedule=1 \\
+  --on-source-disk-delete=keep-auto-snapshots
+
+# ディスクにスケジュールを適用
+gcloud compute disks add-resource-policies DISK_NAME \\
+  --resource-policies=hourly-backup \\
+  --zone=asia-northeast1-a`}</pre>
+                <pre className="codeblock">{`# 毎日深夜 2 時にスナップショットを取得（日次バックアップ）
+gcloud compute resource-policies create snapshot-schedule daily-backup \\
+  --region=asia-northeast1 \\
+  --max-retention-days=30 \\
+  --start-time=17:00 \\
+  --daily-schedule`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.4</span>Linux でのスナップショット最適化（fstrim + fsfreeze）</div>
+                <pre className="codeblock">{`# スナップショット取得前に fstrim を実行
+# 効果: スナップショットのサイズ削減 + 作成速度向上
+sudo fstrim -v /
+# 出力例: /: 50 GiB (53687091200 bytes) trimmed
+
+# マウントオプションで定期的に discard を有効化
+# /etc/fstab:
+# /dev/sdb /data ext4 defaults,discard 0 0`}</pre>
+                <pre className="codeblock">{`# アプリケーション整合性スナップショット（Linux / fsfreeze）
+# ステップ1: ファイルシステムをフリーズ（書き込み停止）
+sudo fsfreeze --freeze /data
+
+# ステップ2: スナップショット取得
+gcloud compute disks snapshot DISK_NAME \\
+  --zone=asia-northeast1-a \\
+  --snapshot-names=app-consistent-snap
+
+# ステップ3: フリーズ解除（必ず実行！忘れると書き込み不可になる）
+sudo fsfreeze --unfreeze /data
+
+# MySQL でのアプリケーション整合性スナップショット
+mysql -u root -e "FLUSH TABLES WITH READ LOCK;"
+gcloud compute disks snapshot DISK_NAME --zone=asia-northeast1-a
+mysql -u root -e "UNLOCK TABLES;"`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.5</span>スナップショットからの復元</div>
+                <pre className="codeblock">{`# スナップショットの一覧確認
+gcloud compute snapshots list
+
+# スナップショットの詳細確認
+gcloud compute snapshots describe SNAPSHOT_NAME
+
+# スナップショットから新しいディスクを作成
+gcloud compute disks create new-disk-from-snapshot \\
+  --source-snapshot=SNAPSHOT_NAME \\
+  --zone=asia-northeast1-a \\
+  --size=100GB \\
+  --type=pd-balanced
+
+# 作成したディスクを VM にアタッチ
+gcloud compute instances attach-disk VM_NAME \\
+  --disk=new-disk-from-snapshot \\
+  --zone=asia-northeast1-a`}</pre>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: スナップショット管理</div>
+                    <ul>
+                        <li><strong>スナップショットスケジュールで 1 時間ごとに自動取得</strong> → RPO（目標復旧時点）を最大 1 時間以内に</li>
+                        <li><strong>本番 DB は必ずアプリケーション整合性スナップショット</strong> → データ整合性を保証</li>
+                        <li><strong>Linux では fstrim を事前実行</strong>（または discard マウントオプション）→ スナップショットサイズ削減</li>
+                        <li><strong>別リージョンに DR コピー</strong>（--storage-location 指定）→ リージョン障害からの復旧</li>
+                        <li><strong>--max-retention-days で古いスナップショットを自動削除</strong> → ストレージコストの最適化</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.6</span>スナップショットのコスト管理</div>
+                <pre className="codeblock">{`【スナップショットの料金】
+  ストレージ料金: $0.026/GB/月（マルチリージョン）
+                 $0.020/GB/月（リージョン）
+
+【コスト最適化】
+  ├── 増分スナップショット活用（初回以降は差分のみ）
+  ├── 保持期間を適切に設定（古いスナップショットを自動削除）
+  ├── fstrim でスナップショットサイズを削減
+  └── DR 要件がなければ同一リージョン内に保存`}</pre>
+            </div>
+        </div>
+    );
+}
+
+function Chapter4() {
+    return (
+        <div id="ch4" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn4">04</div>
+                <div className="sec-head-txt">
+                    <h2>Managed Instance Group (MIG) の運用管理</h2>
+                    <p>ローリングアップデート・カナリアデプロイ・自動ヒーリング・スケーリング</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">4.1</span>MIG のアップデート戦略 — ローリングアップデート</div>
+                <pre className="codeblock">{`【ローリングアップデートの流れ】
+
+現在の状態: [v1][v1][v1][v1][v1][v1] (6台)
+
+Step 1: 1台を v2 に更新
+        [v2][v1][v1][v1][v1][v1]
+        ↓ ヘルスチェック通過を確認
+
+Step 2: さらに 1 台を更新
+        [v2][v2][v1][v1][v1][v1]
+        ↓ ...
+
+Step N: 全台更新完了
+        [v2][v2][v2][v2][v2][v2]
+
+キーパラメータ:
+  --max-surge=2       → 同時に追加できる新バージョンの台数
+  --max-unavailable=0 → 同時に停止できる台数（0 = ゼロダウンタイム）`}</pre>
+                <pre className="codeblock">{`# インスタンステンプレートを v2 に更新（ローリング）
+gcloud compute instance-groups managed rolling-action start-update my-mig \\
+  --version=template=my-template-v2 \\
+  --max-surge=1 \\
+  --max-unavailable=0 \\
+  --region=asia-northeast1
+
+# アップデートの進捗を確認
+gcloud compute instance-groups managed describe my-mig \\
+  --region=asia-northeast1
+
+# アップデートをキャンセル（進行中の場合）
+gcloud compute instance-groups managed rolling-action stop-proactive-update my-mig \\
+  --region=asia-northeast1`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">4.1</span>カナリアデプロイ（段階的ロールアウト）</div>
+                <pre className="codeblock">{`# v2 を 10% のインスタンスだけに適用
+gcloud compute instance-groups managed rolling-action start-update my-mig \\
+  --version=template=my-template-v1,name=stable \\
+  --canary-version=template=my-template-v2,target-size=10%,name=canary \\
+  --region=asia-northeast1
+
+# 問題なければ v2 を 100% に拡大
+gcloud compute instance-groups managed rolling-action start-update my-mig \\
+  --version=template=my-template-v2 \\
+  --region=asia-northeast1
+
+# 問題があれば v1 にロールバック
+gcloud compute instance-groups managed rolling-action start-update my-mig \\
+  --version=template=my-template-v1 \\
+  --region=asia-northeast1`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">4.2</span>MIG の手動スケーリングと緊急操作</div>
+                <pre className="codeblock">{`# MIG のサイズを手動で変更
+gcloud compute instance-groups managed resize my-mig \\
+  --size=10 \\
+  --region=asia-northeast1
+
+# 特定のインスタンスを再作成（問題のある VM をリフレッシュ）
+gcloud compute instance-groups managed recreate-instances my-mig \\
+  --instances=my-mig-abc1,my-mig-def2 \\
+  --region=asia-northeast1
+
+# 特定のインスタンスを MIG から削除（スケールイン）
+gcloud compute instance-groups managed delete-instances my-mig \\
+  --instances=my-mig-abc1 \\
+  --region=asia-northeast1
+
+# オートスケーリングの一時無効化（メンテナンス時）
+gcloud compute instance-groups managed set-autoscaling my-mig \\
+  --mode=off \\
+  --region=asia-northeast1
+
+# オートスケーリングを再有効化
+gcloud compute instance-groups managed set-autoscaling my-mig \\
+  --mode=on \\
+  --region=asia-northeast1`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">4.3</span>MIG のヘルスチェックと自動ヒーリング</div>
+                <pre className="codeblock">{`# HTTP ヘルスチェックの作成
+gcloud compute health-checks create http my-health-check \\
+  --port=8080 \\
+  --request-path=/healthz \\
+  --check-interval=30s \\
+  --timeout=10s \\
+  --healthy-threshold=1 \\
+  --unhealthy-threshold=3
+
+# MIG に自動ヒーリングを設定
+gcloud compute instance-groups managed set-autohealing my-mig \\
+  --health-check=my-health-check \\
+  --initial-delay=300s \\
+  --region=asia-northeast1
+
+# ヘルスチェックの状態を確認
+gcloud compute backend-services get-health my-backend-service \\
+  --global`}</pre>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: MIG 運用</div>
+                    <ul>
+                        <li><strong>--max-unavailable=0 でゼロダウンタイムアップデート</strong>を実現する</li>
+                        <li><strong>カナリアデプロイで段階的ロールアウト</strong>し、問題検出時にすぐロールバックできる体制を整える</li>
+                        <li><strong>--initial-delay を適切に設定</strong>（起動時間 + アプリ初期化時間）し、起動中の VM が誤ってヒーリングされないようにする</li>
+                        <li><strong>リージョナル MIG を使用</strong>して複数ゾーンに分散させ、ゾーン障害に対応する</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter5() {
+    return (
+        <div id="ch5" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn5">05</div>
+                <div className="sec-head-txt">
+                    <h2>GKE クラスタの運用管理</h2>
+                    <p>バージョン管理・ノード管理・kubectl 操作・オートスケーリング</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.1</span>GKE クラスタのバージョン管理とアップグレード</div>
+                <pre className="codeblock">{`GKE のバージョン形式: MAJOR.MINOR.PATCH-gke.N
+例: 1.29.3-gke.1200
+
+サポートポリシー:
+  ├── GKE は常に 3 つのマイナーバージョンをサポート
+  │   例: 1.27, 1.28, 1.29
+  ├── サポート終了バージョンは自動アップグレードされる
+  └── リリースチャンネルで自動アップグレードを管理
+
+リリースチャンネル:
+  ├── Rapid: 最新版（プレビュー機能あり）→ テスト環境向け
+  ├── Regular: バランス型 → 本番推奨
+  └── Stable: 安定版（遅め）→ ミッションクリティカル向け`}</pre>
+                <pre className="codeblock">{`# クラスタのバージョンを確認
+gcloud container clusters describe my-cluster \\
+  --region=asia-northeast1 \\
+  --format="value(currentMasterVersion,currentNodeVersion)"
+
+# クラスタのコントロールプレーンをアップグレード
+gcloud container clusters upgrade my-cluster \\
+  --master \\
+  --cluster-version=1.29 \\
+  --region=asia-northeast1
+
+# ノードプールをアップグレード
+gcloud container clusters upgrade my-cluster \\
+  --node-pool=default-pool \\
+  --cluster-version=1.29 \\
+  --region=asia-northeast1`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.2</span>GKE のノード管理</div>
+                <pre className="codeblock">{`# ノードプールの一覧確認
+gcloud container node-pools list \\
+  --cluster=my-cluster \\
+  --region=asia-northeast1
+
+# ノードプールのサイズ変更（手動スケーリング）
+gcloud container clusters resize my-cluster \\
+  --node-pool=default-pool \\
+  --num-nodes=5 \\
+  --region=asia-northeast1
+
+# ノードのドレイン（安全に Pod を退避してからメンテナンス）
+kubectl drain NODE_NAME \\
+  --ignore-daemonsets \\
+  --delete-emptydir-data
+
+# メンテナンス後にノードを再稼働
+kubectl uncordon NODE_NAME`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.3</span>kubectl による Pod・Deployment の管理</div>
+                <pre className="codeblock">{`# ===== Pod の管理 =====
+# Pod の一覧確認
+kubectl get pods -n my-namespace -o wide
+
+# Pod の詳細確認（障害調査）
+kubectl describe pod POD_NAME -n my-namespace
+
+# Pod のログ確認
+kubectl logs POD_NAME -n my-namespace
+kubectl logs POD_NAME -n my-namespace -c CONTAINER_NAME  # 複数コンテナ時
+kubectl logs POD_NAME -n my-namespace --previous          # 前回クラッシュのログ
+
+# Pod 内でコマンド実行（デバッグ）
+kubectl exec -it POD_NAME -n my-namespace -- /bin/bash
+
+# Pod の強制削除（Terminating で止まった場合）
+kubectl delete pod POD_NAME -n my-namespace --grace-period=0 --force
+
+# ===== Deployment の管理 =====
+# Deployment の状況確認
+kubectl get deployments -n my-namespace
+kubectl rollout status deployment/my-app -n my-namespace
+
+# Deployment のスケーリング
+kubectl scale deployment/my-app --replicas=5 -n my-namespace
+
+# Deployment のイメージ更新（ローリングアップデート）
+kubectl set image deployment/my-app \\
+  my-container=gcr.io/PROJECT/my-app:v2 \\
+  -n my-namespace
+
+# アップデートのロールバック
+kubectl rollout undo deployment/my-app -n my-namespace
+
+# 特定バージョンにロールバック
+kubectl rollout undo deployment/my-app \\
+  --to-revision=2 \\
+  -n my-namespace
+
+# ロールアウト履歴の確認
+kubectl rollout history deployment/my-app -n my-namespace`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.4</span>GKE の Workload 診断</div>
+                <pre className="codeblock">{`# クラスタ全体のリソース使用状況
+kubectl top nodes
+kubectl top pods -n my-namespace
+
+# イベントの確認（障害の手がかり）
+kubectl get events -n my-namespace --sort-by=.lastTimestamp
+
+# Pod の再起動回数を確認（クラッシュループの検出）
+kubectl get pods -n my-namespace \\
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.containerStatuses[0].restartCount}{"\n"}{end}'`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">補足</span>GKE のオートスケーリング 3 層構造</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>機能</span><span>略称</span><span>対象</span><span>動作</span>
+                    </div>
+                    <div className="ctable-row"><span>Horizontal Pod Autoscaler</span><span>HPA</span><span>Pod の数</span><span>CPU・カスタムメトリクスでレプリカ数を増減</span></div>
+                    <div className="ctable-row"><span>Vertical Pod Autoscaler</span><span>VPA</span><span>Pod のリソース</span><span>Requests/Limits を実使用量に合わせて自動最適化</span></div>
+                    <div className="ctable-row"><span>Cluster Autoscaler</span><span>CA</span><span>ノード数</span><span>Pending Pod があればノード追加、余剰があれば削除</span></div>
+                </div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: GKE 運用管理</div>
+                    <ul>
+                        <li><strong>リリースチャンネルを設定</strong>して Kubernetes バージョンを自動管理</li>
+                        <li><strong>kubectl rollout undo</strong> ですぐにロールバックできる体制を整える</li>
+                        <li><strong>kubectl drain</strong> でノードをメンテナンスモードにしてから作業</li>
+                        <li><strong>Managed Service for Prometheus</strong> で GKE メトリクスを収集</li>
+                        <li><strong>Pod の restartCount を監視</strong>してクラッシュループを早期検知</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter6() {
+    return (
+        <div id="ch6" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn6">06</div>
+                <div className="sec-head-txt">
+                    <h2>Cloud Run / Cloud Functions の管理</h2>
+                    <p>リビジョン管理・トラフィック分割・スケーリング設定・カナリアリリース</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">6.1</span>Cloud Run の運用管理</div>
+                <pre className="codeblock">{`# Cloud Run サービスの一覧確認
+gcloud run services list --region=asia-northeast1
+
+# サービスの詳細確認
+gcloud run services describe my-service \\
+  --region=asia-northeast1
+
+# サービスのリビジョン（バージョン）一覧
+gcloud run revisions list \\
+  --service=my-service \\
+  --region=asia-northeast1
+
+# トラフィック分割の確認・変更
+gcloud run services describe my-service \\
+  --region=asia-northeast1 \\
+  --format="value(status.traffic)"
+
+# リビジョン v2 に 100% 切り替え
+gcloud run services update-traffic my-service \\
+  --to-revisions=my-service-v2=100 \\
+  --region=asia-northeast1
+
+# 前のリビジョンにロールバック
+gcloud run services update-traffic my-service \\
+  --to-latest \\
+  --region=asia-northeast1`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">6.2</span>Cloud Run のスケーリング設定</div>
+                <pre className="codeblock">{`# 最小・最大インスタンス数の設定
+gcloud run services update my-service \\
+  --min-instances=1 \\
+  --max-instances=100 \\
+  --region=asia-northeast1
+
+# 同時実行数の設定（1インスタンスあたりの最大リクエスト数）
+gcloud run services update my-service \\
+  --concurrency=80 \\
+  --region=asia-northeast1
+
+# タイムアウトの設定
+gcloud run services update my-service \\
+  --timeout=300s \\
+  --region=asia-northeast1`}</pre>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: Cloud Run</div>
+                    <ul>
+                        <li><strong>--max-instances でコスト上限を設定</strong> → バズや攻撃による予期せぬ高額請求を防ぐ</li>
+                        <li><strong>--min-instances=1 でコールドスタートを防ぐ</strong> → レイテンシ要件が厳しい場合</li>
+                        <li><strong>--no-traffic でカナリアリリース</strong> → 新リビジョンをトラフィックなしでデプロイし段階的に切り替え</li>
+                        <li><strong>concurrency を最適化</strong> → インスタンス数を削減してコストを最適化</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">6.3</span>Cloud Functions の管理</div>
+                <pre className="codeblock">{`# Cloud Functions の一覧確認
+gcloud functions list --region=asia-northeast1
+
+# 関数のデプロイ
+gcloud functions deploy my-function \\
+  --runtime=python311 \\
+  --trigger-http \\
+  --entry-point=main \\
+  --region=asia-northeast1 \\
+  --memory=256MB \\
+  --timeout=60s \\
+  --set-env-vars=ENV=production
+
+# 関数のログ確認
+gcloud functions logs read my-function \\
+  --region=asia-northeast1 \\
+  --limit=50
+
+# 関数の削除
+gcloud functions delete my-function \\
+  --region=asia-northeast1`}</pre>
+            </div>
+        </div>
+    );
+}
+
+function Chapter7() {
+    return (
+        <div id="ch7" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn7">07</div>
+                <div className="sec-head-txt">
+                    <h2>Cloud Storage のデータ管理と保護</h2>
+                    <p>オブジェクト操作・バケットロック・バージョニング・OLM・署名付きURL</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">7.1</span>Cloud Storage の基本操作</div>
+                <pre className="codeblock">{`# ===== オブジェクト操作 =====
+
+# バケットの一覧
+gcloud storage buckets list
+
+# オブジェクトのコピー
+gcloud storage cp local-file.txt gs://my-bucket/path/
+
+# ディレクトリ全体をコピー（再帰的）
+gcloud storage cp -r ./local-dir/ gs://my-bucket/backup/
+
+# オブジェクトの移動（別バケットへ）
+gcloud storage mv gs://source-bucket/file.txt gs://dest-bucket/file.txt
+
+# オブジェクトの削除
+gcloud storage rm gs://my-bucket/old-file.txt
+
+# バケット内全オブジェクトの削除
+gcloud storage rm -r gs://my-bucket/**
+
+# オブジェクトのメタデータ確認
+gcloud storage objects describe gs://my-bucket/file.txt
+
+# ===== アクセス制御 =====
+
+# バケットの IAM ポリシー確認
+gcloud storage buckets get-iam-policy gs://my-bucket
+
+# ユーザーに読み取り権限を付与
+gcloud storage buckets add-iam-policy-binding gs://my-bucket \\
+  --member="user:alice@example.com" \\
+  --role="roles/storage.objectViewer"`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">7.2</span>バケットロックと保持ポリシー（コンプライアンス）</div>
+                <pre className="codeblock">{`【保持ポリシーとは？】
+
+例: 金融規制により「7年間はログを削除・変更禁止」
+
+バケットにポリシーを設定:
+  gcloud storage buckets update gs://my-compliance-bucket \\
+    --retention-period=7y
+
+効果:
+  ├── バケット内のすべてのオブジェクトが
+  │   7 年間（設定日から）削除・上書き不可になる
+  └── 新しくアップロードしたオブジェクトも
+      アップロード時点から 7 年間保護される
+
+【バケットロック（取り消し不可！）】
+  保持ポリシーを永久に変更できないようにロック
+
+  gcloud storage buckets lock gs://my-compliance-bucket
+
+  ⚠️ バケットロックは一度かけると絶対に解除できません！
+     本当に必要な場合のみ実行してください。`}</pre>
+                <pre className="codeblock">{`# オブジェクト単位での保持ロック設定
+gcloud storage objects update gs://my-bucket/important-file.txt \\
+  --retain-until=2031-12-31T23:59:59Z \\
+  --retention-mode=LOCKED`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">7.3</span>バージョニングとライフサイクル管理（OLM）</div>
+                <pre className="codeblock">{`# バージョニングの有効化
+gcloud storage buckets update gs://my-bucket --versioning
+
+# 非最新バージョンの一覧確認
+gcloud storage objects list gs://my-bucket --all-versions
+
+# 特定バージョンを最新バージョンとして復元
+gcloud storage cp gs://my-bucket/file.txt#GENERATION \\
+  gs://my-bucket/file.txt
+
+# ライフサイクルポリシーを適用
+gcloud storage buckets update gs://my-bucket \\
+  --lifecycle-file=lifecycle.json`}</pre>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: Cloud Storage データ管理</div>
+                    <ul>
+                        <li><strong>コンプライアンスデータには保持ポリシー + バケットロック</strong>を設定（規制要件の確実な遵守）</li>
+                        <li><strong>バケット名に機密情報や推測可能な名前を使わない</strong>（ランダムな文字列を推奨）</li>
+                        <li><strong>一時アクセスは署名付きURL</strong>で有効期限・操作を厳密に制限する</li>
+                        <li><strong>OLMルールの優先順位を理解する</strong>（Delete {`>`} SetStorageClass、より安価なクラスが優先）</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter8() {
+    return (
+        <div id="ch8" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn8">08</div>
+                <div className="sec-head-txt">
+                    <h2>Cloud SQL / Spanner のバックアップと復元</h2>
+                    <p>自動バックアップ・PITR・リードレプリカ・Spannerバックアップ</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">8.1</span>Cloud SQL の自動バックアップ</div>
+                <pre className="codeblock">{`# 自動バックアップの有効化（新規インスタンス作成時）
+gcloud sql instances create my-postgres \\
+  --database-version=POSTGRES_15 \\
+  --tier=db-n1-standard-4 \\
+  --region=asia-northeast1 \\
+  --backup-start-time=02:00 \\
+  --backup-location=asia-northeast1 \\
+  --retained-backups-count=14 \\
+  --retained-transaction-log-days=7
+
+# 既存インスタンスの自動バックアップを更新
+gcloud sql instances patch my-postgres \\
+  --backup-start-time=02:00 \\
+  --retained-backups-count=30`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">8.1</span>Cloud SQL の手動バックアップと復元</div>
+                <pre className="codeblock">{`# 手動バックアップを即時作成
+gcloud sql backups create \\
+  --instance=my-postgres \\
+  --description="Pre-maintenance backup $(date +%Y%m%d)"
+
+# バックアップ一覧の確認
+gcloud sql backups list --instance=my-postgres
+
+# バックアップから同じインスタンスに復元
+gcloud sql backups restore BACKUP_ID \\
+  --restore-instance=my-postgres
+
+# バックアップから別インスタンスに復元（本番データを壊さずテスト）
+gcloud sql backups restore BACKUP_ID \\
+  --restore-instance=my-postgres-restore-test
+
+# PITR（ポイントインタイムリカバリ）
+gcloud sql instances clone my-postgres my-postgres-pitr \\
+  --point-in-time=2024-01-15T10:30:00Z`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">8.2</span>Cloud SQL のリードレプリカ管理</div>
+                <pre className="codeblock">{`# リードレプリカの作成
+gcloud sql instances create my-postgres-replica \\
+  --master-instance-name=my-postgres \\
+  --region=us-central1 \\
+  --tier=db-n1-standard-4
+
+# リードレプリカのプロモート（プライマリに昇格）
+# 障害時や計画的な移行時に使用
+gcloud sql instances promote-replica my-postgres-replica
+
+# レプリカのラグ（遅延）確認
+gcloud sql instances describe my-postgres-replica \\
+  --format="value(replicaConfiguration.mysqlReplicaConfiguration.masterHeartbeatPeriod)"`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">8.3</span>Cloud Spanner のバックアップ</div>
+                <pre className="codeblock">{`# Spanner のバックアップ作成
+gcloud spanner backups create my-backup \\
+  --instance=my-spanner-instance \\
+  --database=my-database \\
+  --expiration-date=2024-04-01T00:00:00Z
+
+# バックアップ一覧確認
+gcloud spanner backups list \\
+  --instance=my-spanner-instance
+
+# バックアップから復元
+gcloud spanner databases restore \\
+  --destination-instance=my-spanner-instance \\
+  --destination-database=my-database-restored \\
+  --source-backup=projects/PROJECT/instances/my-spanner-instance/backups/my-backup`}</pre>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: ストレージとDB管理</div>
+                    <ul>
+                        <li><strong>Cloud SQL の自動バックアップ + PITR を有効化</strong>（最低 7 日間のトランザクションログ保持）</li>
+                        <li><strong>本番環境は Cloud SQL HA 構成</strong>（リージョナル可用性タイプを選択）</li>
+                        <li><strong>定期的にバックアップからの復元テストを実施</strong>（復元できることを確認）</li>
+                        <li><strong>Spanner バックアップは有効期限を設定</strong>（コスト管理）</li>
+                        <li><strong>規制データには Cloud Storage の保持ポリシー + バケットロック</strong></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter9() {
+    return (
+        <div id="ch9" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn9">09</div>
+                <div className="sec-head-txt">
+                    <h2>Cloud Monitoring — メトリクスと可視化</h2>
+                    <p>自動収集メトリクス・カスタムダッシュボード・MQL・Ops Agent との違い</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">9.1</span>Cloud Monitoring の全体像</div>
+                <pre className="codeblock">{`【Cloud Monitoring でできること】
+
+メトリクスの収集:
+  ├── GCP サービスのメトリクス（自動収集）
+  │   例: CPU 使用率、ネットワーク I/O、HTTP リクエスト数
+  ├── VM 内部のメトリクス（Ops Agent が必要）
+  │   例: メモリ使用量、ディスク使用率、プロセス数
+  └── カスタムメトリクス（アプリが送信）
+      例: キューの長さ、ビジネスKPI
+
+可視化:
+  └── カスタムダッシュボードでグラフを作成
+
+アラート:
+  └── 閾値超過時に Email / PagerDuty / Slack / Pub/Sub に通知
+
+SLO モニタリング:
+  └── サービスレベル目標の達成状況を可視化・管理`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">9.2</span>GCP サービスが自動収集するメトリクス（試験頻出）</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>リソース</span><span>メトリクス名</span><span>説明</span>
+                    </div>
+                    <div className="ctable-row"><span>Compute Engine</span><span>compute.googleapis.com/instance/cpu/utilization</span><span>CPU 使用率（0〜1.0）</span></div>
+                    <div className="ctable-row"><span>Compute Engine</span><span>compute.googleapis.com/instance/network/sent_bytes_count</span><span>送信バイト数</span></div>
+                    <div className="ctable-row"><span>Cloud SQL</span><span>cloudsql.googleapis.com/database/cpu/utilization</span><span>DB の CPU 使用率</span></div>
+                    <div className="ctable-row"><span>Cloud SQL</span><span>cloudsql.googleapis.com/database/disk/bytes_used</span><span>ディスク使用量</span></div>
+                    <div className="ctable-row"><span>GKE</span><span>container.googleapis.com/container/cpu/usage_time</span><span>コンテナ CPU 使用量</span></div>
+                    <div className="ctable-row"><span>Cloud Run</span><span>run.googleapis.com/request_count</span><span>リクエスト数</span></div>
+                    <div className="ctable-row"><span>Cloud Load Balancing</span><span>loadbalancing.googleapis.com/https/request_count</span><span>LB へのリクエスト数</span></div>
+                </div>
+                <div className="wb">
+                    <div className="wbt">⚠️ 試験頻出: メモリ使用量は Ops Agent が必要</div>
+                    <p>compute.googleapis.com/instance/cpu/utilization はエージェントなしで取得可能ですが、
+                    agent.googleapis.com/memory/percent_used は Ops Agent が必要です。</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">9.3</span>カスタムダッシュボードの作成</div>
+                <pre className="codeblock">{`# gcloud でダッシュボードを作成（JSON定義）
+gcloud monitoring dashboards create \\
+  --config-from-file=dashboard.json
+
+# ダッシュボードの一覧確認
+gcloud monitoring dashboards list`}</pre>
+                <pre className="codeblock">{`// ダッシュボードの JSON 定義例
+{
+  "displayName": "My Application Dashboard",
+  "gridLayout": {
+    "columns": "2",
+    "widgets": [
+      {
+        "title": "CPU Utilization",
+        "xyChart": {
+          "dataSets": [
+            {
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\\"compute.googleapis.com/instance/cpu/utilization\\" resource.type=\\"gce_instance\\"",
+                  "aggregation": {
+                    "alignmentPeriod": "60s",
+                    "perSeriesAligner": "ALIGN_MEAN"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">9.4</span>MQL（Monitoring Query Language）の基本</div>
+                <pre className="codeblock">{`# 基本構文
+fetch リソースタイプ
+| metric 'メトリクス名'
+| filter フィルタ条件
+| align アライメント
+| every 集計間隔
+| group_by グループキー, 集計関数
+
+# 例1: プロジェクト内の全 VM の平均 CPU 使用率
+fetch gce_instance
+| metric 'compute.googleapis.com/instance/cpu/utilization'
+| align mean_aligner()
+| every 1m
+| group_by [], mean(val())
+
+# 例2: HTTP 5xx エラー率
+fetch https_lb_rule
+| metric 'loadbalancing.googleapis.com/https/request_count'
+| filter (metric.labels.response_code_class == '500')
+| align rate(1m)
+| every 1m
+
+# 例3: GKE ノードのメモリ使用率（Ops Agent 経由）
+fetch k8s_node
+| metric 'kubernetes.io/node/memory/used_bytes'
+| align mean_aligner()
+| every 1m`}</pre>
+            </div>
+        </div>
+    );
+}
+
+function Chapter10() {
+    return (
+        <div id="ch10" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn10">10</div>
+                <div className="sec-head-txt">
+                    <h2>Ops Agent の導入と設定</h2>
+                    <p>インストール方法・config.yaml・PodMonitoring・Managed Prometheus</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">10.1</span>Ops Agent とは？</div>
+                <pre className="codeblock">{`【Ops Agent の内部構成】
+
+Ops Agent
+├── Fluent Bit（ログ収集コンポーネント）
+│   └── ログを Cloud Logging に転送
+└── OpenTelemetry Collector（メトリクス収集コンポーネント）
+    └── メトリクスを Cloud Monitoring に転送
+
+【Ops Agent が収集するもの（旧エージェントとの違い）】
+
+従来の Stackdriver エージェント:
+  └── メモリ・ディスクなどの基本システムメトリクス
+
+Ops Agent（現在の推奨）:
+  ├── メモリ使用量（%）
+  ├── ディスク使用率（%）
+  ├── ネットワーク接続数
+  ├── プロセスごとの CPU・メモリ
+  ├── アプリケーションログ（nginx, mysql, apache など）
+  └── カスタムログファイル`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">10.2</span>Ops Agent のインストール</div>
+                <pre className="codeblock">{`# ===== 方法 1: VM に SSH して手動インストール =====
+
+# インストールスクリプトをダウンロードして実行
+curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+sudo bash add-google-cloud-ops-agent-repo.sh --also-install
+
+# インストール確認
+sudo systemctl status google-cloud-ops-agent`}</pre>
+                <pre className="codeblock">{`# ===== 方法 2: gcloud でリモートインストール（SSH 不要）=====
+
+gcloud compute instances ops-agents policies create my-ops-agent-policy \\
+  --agent-rules="type=ops-agent,version=current-major,package-state=installed,enable-autoupgrade=true" \\
+  --os-types=short-name=debian,version=11 \\
+  --instances=zones/asia-northeast1-a/instances/my-vm`}</pre>
+                <pre className="codeblock">{`# ===== 方法 3: VM 作成時にスタートアップスクリプトでインストール =====
+
+#!/bin/bash
+# startup.sh
+curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+sudo bash add-google-cloud-ops-agent-repo.sh --also-install`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">10.3</span>Ops Agent の設定カスタマイズ（config.yaml）</div>
+                <pre className="codeblock">{`# /etc/google-cloud-ops-agent/config.yaml
+
+logging:
+  receivers:
+    nginx_access_log:
+      type: files
+      include_paths:
+        - /var/log/nginx/access.log
+    nginx_error_log:
+      type: files
+      include_paths:
+        - /var/log/nginx/error.log
+    my_app_log:
+      type: files
+      include_paths:
+        - /var/log/my-app/*.log
+
+  processors:
+    parse_json:
+      type: parse_json
+      field: message
+      time_key: timestamp
+      time_format: '%Y-%m-%dT%H:%M:%S.%L%Z'
+
+  exporters:
+    google:
+      type: google_cloud_logging
+
+  service:
+    pipelines:
+      nginx_pipeline:
+        receivers: [nginx_access_log, nginx_error_log]
+        exporters: [google]
+      app_pipeline:
+        receivers: [my_app_log]
+        processors: [parse_json]
+        exporters: [google]
+
+metrics:
+  receivers:
+    hostmetrics:
+      type: hostmetrics
+      collection_interval: 60s
+    mysql:
+      type: mysql
+      endpoint: localhost:3306
+      username: monitoring_user
+      password: \${MYSQL_MONITORING_PASSWORD}
+
+  exporters:
+    google:
+      type: google_cloud_monitoring
+
+  service:
+    pipelines:
+      host_pipeline:
+        receivers: [hostmetrics]
+        exporters: [google]
+      mysql_pipeline:
+        receivers: [mysql]
+        exporters: [google]`}</pre>
+                <pre className="codeblock">{`# 設定ファイルの検証
+sudo google-cloud-ops-agent \\
+  --config=/etc/google-cloud-ops-agent/config.yaml \\
+  --check
+
+# Ops Agent を再起動して設定を反映
+sudo systemctl restart google-cloud-ops-agent
+
+# ログで動作確認
+sudo journalctl -u google-cloud-ops-agent -n 50`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">10.4</span>Kubernetes / GKE での Prometheus 監視</div>
+                <pre className="codeblock">{`【なぜ Managed Service for Prometheus？】
+
+通常の Prometheus:
+  ├── Prometheus サーバーを自分でデプロイ・管理
+  ├── ストレージの管理が必要
+  └── スケーリングを手動で対応
+
+Google Cloud Managed Service for Prometheus:
+  ├── Prometheus 互換の API（既存の設定を流用可能）
+  ├── ストレージは Cloud Monitoring が管理
+  ├── 自動スケーリング
+  └── PodMonitoring / ClusterPodMonitoring CRD で設定`}</pre>
+                <pre className="codeblock">{`# PodMonitoring - 特定の Pod のメトリクスを収集
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: my-app-monitoring
+  namespace: my-app
+spec:
+  selector:
+    matchLabels:
+      app: my-app
+  endpoints:
+  - port: metrics
+    interval: 30s
+    path: /metrics`}</pre>
+                <pre className="codeblock">{`# Managed Service for Prometheus を有効化
+gcloud container clusters update my-cluster \\
+  --enable-managed-prometheus \\
+  --region=asia-northeast1`}</pre>
+            </div>
+        </div>
+    );
+}
+
+function Chapter11() {
+    return (
+        <div id="ch11" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn11">11</div>
+                <div className="sec-head-txt">
+                    <h2>アラートポリシーと SLO の設定</h2>
+                    <p>アラート設計・通知チャネル・SLO 定義・バーンレートアラート</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">11.1</span>良いアラートの条件</div>
+                <pre className="codeblock">{`【良いアラートの条件】
+
+1. 重要なものだけアラートにする
+   → アラートが多すぎると「アラート疲れ」になり
+     本当に重要な通知を見逃す
+
+2. ユーザーへの影響を基準にする
+   → CPU 90% より「エラーレート 1% 超過」の方が重要
+
+3. アクションできるアラートだけにする
+   → 通知を受けたエンジニアが何か対応できるものだけ`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">11.2</span>アラートポリシーの設定（YAML 定義）</div>
+                <pre className="codeblock">{`# alert-policy.yaml（CPU 使用率アラート）
+displayName: "High CPU Utilization - Compute Engine"
+conditions:
+  - displayName: "CPU utilization over 80%"
+    conditionThreshold:
+      filter: >
+        metric.type="compute.googleapis.com/instance/cpu/utilization"
+        AND resource.type="gce_instance"
+      comparison: COMPARISON_GT
+      thresholdValue: 0.8
+      duration: 300s
+      aggregations:
+        - alignmentPeriod: 60s
+          perSeriesAligner: ALIGN_MEAN
+alertStrategy:
+  notificationRateLimit:
+    period: 3600s
+notificationChannels:
+  - projects/PROJECT_ID/notificationChannels/CHANNEL_ID
+documentation:
+  content: "CPU使用率が80%を超えています。スケールアップまたはオートスケール設定を確認してください。"
+  mimeType: text/markdown`}</pre>
+                <pre className="codeblock">{`# HTTP 5xx エラーレートアラート
+displayName: "High HTTP Error Rate - Load Balancer"
+conditions:
+  - displayName: "HTTP 5xx error rate > 1%"
+    conditionThreshold:
+      filter: >
+        metric.type="loadbalancing.googleapis.com/https/request_count"
+        AND metric.labels.response_code_class="500"
+      comparison: COMPARISON_GT
+      thresholdValue: 0.01
+      duration: 60s
+alertStrategy:
+  autoClose: 1800s
+notificationChannels:
+  - projects/PROJECT_ID/notificationChannels/CHANNEL_ID`}</pre>
+                <pre className="codeblock">{`# CLI でアラートポリシーを作成
+gcloud alpha monitoring policies create \\
+  --policy-from-file=alert-policy.yaml
+
+# アラートポリシーの一覧確認
+gcloud alpha monitoring policies list
+
+# メンテナンス時に一時無効化
+gcloud alpha monitoring policies update POLICY_ID --no-enabled`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">11.3</span>通知チャネルの設定</div>
+                <pre className="codeblock">{`# メール通知チャネルの作成
+gcloud alpha monitoring channels create \\
+  --display-name="Ops Team Email" \\
+  --type=email \\
+  --channel-labels=email_address=ops-team@example.com
+
+# Slack 通知チャネルの作成
+gcloud alpha monitoring channels create \\
+  --display-name="#alerts Slack Channel" \\
+  --type=slack \\
+  --channel-labels=channel_name=#alerts,url=https://hooks.slack.com/...
+
+# PagerDuty 通知チャネルの作成
+gcloud alpha monitoring channels create \\
+  --display-name="PagerDuty On-call" \\
+  --type=pagerduty \\
+  --channel-labels=service_key=YOUR_PAGERDUTY_SERVICE_KEY
+
+# 通知チャネルの確認
+gcloud alpha monitoring channels list`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">11.4</span>SLO（サービスレベル目標）の設定</div>
+                <pre className="codeblock">{`SLO の設計プロセス:
+
+Step 1: SLI（測定指標）を定義
+  └── リクエスト成功率、レイテンシ p99、可用性
+
+Step 2: SLO（目標値）を設定
+  └── 99.9% のリクエストが成功する
+
+Step 3: エラーバジェットを計算
+  月間の許容ダウン時間 = (1 - SLO) × 月間時間
+  └── 99.9% SLO = 43.8 分/月
+
+Step 4: Cloud Monitoring に SLO を設定して監視`}</pre>
+                <pre className="codeblock">{`// SLO の定義例（Cloud Monitoring API）
+{
+  "displayName": "99.9% Availability SLO",
+  "goal": 0.999,
+  "rollingPeriod": "2592000s",
+  "requestBased": {
+    "goodTotalRatio": {
+      "goodServiceFilter": "metric.type=\\"loadbalancing.googleapis.com/https/request_count\\" AND metric.labels.response_code_class!=\\"500\\"",
+      "totalServiceFilter": "metric.type=\\"loadbalancing.googleapis.com/https/request_count\\""
+    }
+  }
+}`}</pre>
+                <pre className="codeblock">{`【SLO バーンレートアラートの種類】
+
+バーンレートアラート（Burn Rate Alert）:
+  エラーバジェットの消費速度を監視
+
+  バーンレート = 1.0 → エラーバジェットを通常速度で消費中
+  バーンレート = 2.0 → 2倍の速度でエラーバジェットを消費中
+                        → このままでは SLO を達成できない！
+
+推奨アラート設定:
+  Fast Burn（高速消費）: バーンレート > 14.4、1時間
+  Slow Burn（低速消費）: バーンレート > 1.0、6時間`}</pre>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: モニタリングと SLO</div>
+                    <ul>
+                        <li><strong>VM のメモリ監視には Ops Agent を必ずインストール</strong>（デフォルトではメモリ取得不可）</li>
+                        <li><strong>GKE には Managed Service for Prometheus を使用</strong>（Prometheus 互換・運用負荷ゼロ）</li>
+                        <li><strong>SLO ベースのアラートを優先</strong>（CPU アラートより重要 — ユーザー体験に直結）</li>
+                        <li><strong>アラートには runbook のリンクを含める</strong>（受け取った人が迷わず対応できる）</li>
+                        <li><strong>ダッシュボードは用途別に整理</strong>（サービス別・チーム別 — 障害時の素早い状況把握）</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter12() {
+    return (
+        <div id="ch12" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn12">12</div>
+                <div className="sec-head-txt">
+                    <h2>Cloud Logging — ログ管理の基本</h2>
+                    <p>データフロー・保持期間・ログクエリ・構造化ログ・アプリケーションから送信</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">12.1</span>Cloud Logging の全体像</div>
+                <pre className="codeblock">{`【Cloud Logging のデータフロー】
+
+ログの発生源:
+  ├── GCP サービス（自動収集）
+  │   例: GKE、Cloud SQL、Cloud Run、Load Balancer
+  ├── Compute Engine VM（Ops Agent 経由）
+  │   例: syslog、アプリケーションログ
+  └── アプリケーション（Cloud Logging API / ライブラリ）
+      例: Python の google-cloud-logging ライブラリ
+         ↓
+Cloud Logging（受信・保存・インデックス作成）
+         ↓
+Log Router（ルーティング）
+  ├── Cloud Logging バケット（デフォルト 30 日保持）
+  ├── BigQuery（長期保存・SQL 分析）
+  ├── Cloud Storage（アーカイブ保存）
+  └── Pub/Sub（リアルタイムストリーミング）`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">12.2</span>Cloud Logging のデフォルト保持期間</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>ログバケット</span><span>デフォルト保持期間</span><span>変更可否</span>
+                    </div>
+                    <div className="ctable-row"><span>_Required（必須バケット）</span><span>400 日（変更不可）</span><span>❌</span></div>
+                    <div className="ctable-row"><span>_Default（デフォルトバケット）</span><span>30 日</span><span>✅（最大 3650 日）</span></div>
+                    <div className="ctable-row"><span>カスタムバケット</span><span>設定値</span><span>✅</span></div>
+                </div>
+                <div className="wb">
+                    <div className="wbt">⚠️ 重要</div>
+                    <p>_Required バケットには管理アクティビティ監査ログと Data Access 監査ログが含まれ、削除・変更不可。</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">12.3</span>ログの検索（ログクエリ言語）</div>
+                <pre className="codeblock">{`# 基本構文
+resource.type = "リソースタイプ"
+resource.labels.instance_id = "VM_ID"
+severity >= ERROR
+textPayload: "エラーメッセージ"
+timestamp >= "2024-01-01T00:00:00Z"
+
+# 例1: 特定 VM の ERROR 以上のログ
+resource.type = "gce_instance"
+AND resource.labels.zone = "asia-northeast1-a"
+AND severity >= ERROR
+
+# 例2: Cloud SQL の接続エラー
+resource.type = "cloudsql_database"
+AND severity = ERROR
+AND textPayload =~ "connection"
+
+# 例3: HTTP 5xx エラーのアクセスログ
+resource.type = "http_load_balancer"
+AND httpRequest.status >= 500
+
+# 例4: GKE の特定 Pod のログ
+resource.type = "k8s_container"
+AND resource.labels.namespace_name = "production"
+AND resource.labels.pod_name =~ "my-app-.*"
+AND severity = ERROR
+
+# 例5: IAM 権限変更が行われたログ（管理者調査用）
+resource.type = "project"
+AND proto_payload.method_name = "SetIamPolicy"
+AND timestamp >= "2024-01-01T00:00:00Z"`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">12.4</span>Python でのログ出力（Cloud Logging ライブラリ）</div>
+                <pre className="codeblock">{`import google.cloud.logging
+import logging
+
+# Cloud Logging クライアントの初期化
+client = google.cloud.logging.Client()
+
+# Python の標準 logging と統合（推奨）
+client.setup_logging()
+
+# 使用例
+logger = logging.getLogger(__name__)
+logger.info("Application started")
+logger.warning("Low memory: %d MB remaining", free_memory)
+logger.error("Database connection failed", extra={
+    "json_fields": {
+        "database": "production-db",
+        "error_code": "CONNECTION_TIMEOUT",
+        "retry_count": 3
+    }
+})`}</pre>
+                <pre className="codeblock">{`# 構造化ログ（JSON ログ）の活用
+import json
+import sys
+
+def log_structured(severity, message, **fields):
+    entry = {
+        "severity": severity,
+        "message": message,
+        **fields
+    }
+    print(json.dumps(entry), file=sys.stdout)
+
+# 使用例
+log_structured(
+    "INFO",
+    "Order processed",
+    order_id="ORD-12345",
+    user_id="USER-67890",
+    amount=15000,
+    payment_method="credit_card"
+)
+# → Cloud Logging で jsonPayload として自動パース`}</pre>
+            </div>
+        </div>
+    );
+}
+
+function Chapter13() {
+    return (
+        <div id="ch13" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn13">13</div>
+                <div className="sec-head-txt">
+                    <h2>監査ログ（Audit Logs）の完全解説</h2>
+                    <p>3 種類の監査ログ・データアクセス有効化・セキュリティ調査・GKE 監査ログ</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">13.1</span>監査ログの 3 種類（試験最頻出）</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>種類</span><span>内容の例</span><span>デフォルト</span><span>料金</span><span>保持期間</span>
+                    </div>
+                    <div className="ctable-row">
+                        <span>管理アクティビティ（Admin Activity）</span>
+                        <span>VM 作成・削除、IAM 変更、バケット操作、FW ルール変更</span>
+                        <span>有効（無効化不可）</span>
+                        <span>無料</span>
+                        <span>400 日（_Required）</span>
+                    </div>
+                    <div className="ctable-row">
+                        <span>データアクセス（Data Access）</span>
+                        <span>GCS オブジェクト読取、BigQuery クエリ、Cloud SQL クエリ、Secret 読取</span>
+                        <span>無効（手動で有効化）</span>
+                        <span>有料</span>
+                        <span>デフォルト 30 日</span>
+                    </div>
+                    <div className="ctable-row">
+                        <span>システムイベント（System Event）</span>
+                        <span>ライブマイグレーション、自動スケーリング、Google 定期メンテナンス</span>
+                        <span>有効（無効化不可）</span>
+                        <span>無料</span>
+                        <span>400 日（_Required）</span>
+                    </div>
+                    <div className="ctable-row">
+                        <span>ポリシー拒否（Policy Denied）</span>
+                        <span>IAM 権限不足でアクセスが拒否されたケース</span>
+                        <span>有効</span>
+                        <span>有料</span>
+                        <span>30 日</span>
+                    </div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">13.1</span>データアクセス監査ログの有効化</div>
+                <pre className="codeblock">{`# 組織レベルで BigQuery のデータアクセスログを有効化
+cat > policy.json <<EOF
+{
+  "auditConfigs": [
+    {
+      "service": "bigquery.googleapis.com",
+      "auditLogConfigs": [
+        {"logType": "DATA_READ"},
+        {"logType": "DATA_WRITE"},
+        {"logType": "ADMIN_READ"}
+      ]
+    }
+  ]
+}
+EOF
+
+gcloud organizations set-iam-policy ORG_ID policy.json`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">13.2</span>監査ログの活用例（セキュリティインシデント調査）</div>
+                <pre className="codeblock">{`【セキュリティインシデント調査】
+
+「昨夜 AM 2 時頃、Cloud Storage バケットが削除された。誰がやったか？」
+
+→ 管理アクティビティ監査ログで調査:
+
+resource.type = "gcs_bucket"
+AND proto_payload.method_name = "storage.buckets.delete"
+AND timestamp >= "2024-01-15T17:00:00Z"  # UTC 17:00 = JST 02:00
+AND timestamp < "2024-01-15T18:00:00Z"
+
+→ principal_email: "malicious-user@example.com" が記録されている！
+→ このユーザーの操作履歴を追跡できる`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">13.3</span>GKE の監査ログ</div>
+                <pre className="codeblock">{`【GKE の特別なルール】
+
+GKE の監査ログは無効化できません！
+  → セキュリティ上の強制仕様
+
+Container-Optimized OS (COS) での auditd:
+  GKE の COS ノードでは Linux auditd を有効化することで
+  ・バイナリの実行履歴
+  ・ファイルシステムへのアクセス
+  ・ネットワーク接続の詳細
+  などを記録できる
+
+有効化方法:
+  GKE Standard クラスタのノードプールで設定
+  → セキュリティインシデントの詳細調査に不可欠`}</pre>
+            </div>
+        </div>
+    );
+}
+
+function Chapter14() {
+    return (
+        <div id="ch14" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn14">14</div>
+                <div className="sec-head-txt">
+                    <h2>Log Router（ログのルーティングとエクスポート）</h2>
+                    <p>シンク設定・BigQuery/Cloud Storage/Pub/Sub へのエクスポート・BigQuery ログ分析</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">14.1</span>Log Router（ログシンク）の仕組み</div>
+                <pre className="codeblock">{`【Log Router の仕組み】
+
+すべてのログが Cloud Logging に到達
+         ↓
+Log Router（シンクのフィルタで振り分け）
+    │
+    ├── _Default バケット（デフォルト 30 日保持）
+    │   └── フィルタに一致しないすべてのログ
+    │
+    ├── BigQuery データセット
+    │   └── フィルタ: 長期保存・SQL 分析が必要なログ
+    │
+    ├── Cloud Storage バケット
+    │   └── フィルタ: アーカイブ保存が必要なログ
+    │
+    └── Pub/Sub トピック
+        └── フィルタ: リアルタイム処理が必要なログ
+                        └── SIEM ツール、Cloud Functions など`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">14.2</span>BigQuery へのシンクを作成</div>
+                <pre className="codeblock">{`# 1. BigQuery データセットを作成
+bq mk --location=asia-northeast1 --dataset PROJECT_ID:logging_archive
+
+# 2. BigQuery シンクを作成（監査ログのみエクスポート）
+gcloud logging sinks create bigquery-audit-sink \\
+  bigquery.googleapis.com/projects/PROJECT_ID/datasets/logging_archive \\
+  --log-filter='protoPayload.@type="type.googleapis.com/google.cloud.audit.AuditLog"' \\
+  --description="Export audit logs to BigQuery for analysis"
+
+# 3. シンクのサービスアカウントに BigQuery への書き込み権限を付与
+SINK_SA=$(gcloud logging sinks describe bigquery-audit-sink \\
+  --format="value(writerIdentity)")
+
+bq add-iam-policy-binding \\
+  --project=PROJECT_ID \\
+  --dataset=logging_archive \\
+  --member="$SINK_SA" \\
+  --role="roles/bigquery.dataEditor"`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">14.2</span>Cloud Storage へのシンク（長期アーカイブ）</div>
+                <pre className="codeblock">{`# 1. ログアーカイブ用バケットを作成
+gcloud storage buckets create gs://my-log-archive-bucket \\
+  --location=asia-northeast1 \\
+  --storage-class=coldline
+
+# 2. Cloud Storage シンクを作成
+gcloud logging sinks create storage-long-term-sink \\
+  storage.googleapis.com/my-log-archive-bucket \\
+  --log-filter='severity >= WARNING' \\
+  --description="Archive WARNING+ logs to Cold Storage for 7 years"
+
+# 3. シンクのサービスアカウントに書き込み権限を付与
+SINK_SA=$(gcloud logging sinks describe storage-long-term-sink \\
+  --format="value(writerIdentity)")
+
+gcloud storage buckets add-iam-policy-binding gs://my-log-archive-bucket \\
+  --member="$SINK_SA" \\
+  --role="roles/storage.objectCreator"`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">14.2</span>Pub/Sub へのシンク（SIEM 連携・リアルタイム処理）</div>
+                <pre className="codeblock">{`# 1. Pub/Sub トピックを作成
+gcloud pubsub topics create security-events-topic
+
+# 2. Pub/Sub シンクを作成（セキュリティ関連ログのみ）
+gcloud logging sinks create pubsub-security-sink \\
+  pubsub.googleapis.com/projects/PROJECT_ID/topics/security-events-topic \\
+  --log-filter='protoPayload.@type="type.googleapis.com/google.cloud.audit.AuditLog" AND severity >= WARNING' \\
+  --description="Stream security events to SIEM"
+
+# 3. 権限付与
+SINK_SA=$(gcloud logging sinks describe pubsub-security-sink \\
+  --format="value(writerIdentity)")
+
+gcloud pubsub topics add-iam-policy-binding security-events-topic \\
+  --member="$SINK_SA" \\
+  --role="roles/pubsub.publisher"`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">14.3</span>シンクの確認と管理</div>
+                <pre className="codeblock">{`# シンクの一覧確認
+gcloud logging sinks list
+
+# シンクの詳細確認
+gcloud logging sinks describe SINK_NAME
+
+# シンクの更新（フィルタを変更）
+gcloud logging sinks update SINK_NAME \\
+  --log-filter='severity >= ERROR'
+
+# シンクの削除
+gcloud logging sinks delete SINK_NAME`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">14.4</span>BigQuery でのログ分析クエリ例</div>
+                <pre className="codeblock">{`-- 過去 7 日間の管理アクティビティ上位 10 操作
+SELECT
+  proto_payload.auth_info[0].principal AS user_email,
+  proto_payload.method_name AS operation,
+  COUNT(*) AS operation_count
+FROM
+  \`my_project.logging_archive.cloudaudit_googleapis_com_activity_*\`
+WHERE
+  _TABLE_SUFFIX >= FORMAT_DATE('%Y%m%d', DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY))
+GROUP BY
+  user_email, operation
+ORDER BY
+  operation_count DESC
+LIMIT 10;`}</pre>
+                <pre className="codeblock">{`-- 特定ユーザーの操作履歴（セキュリティ調査）
+SELECT
+  timestamp,
+  proto_payload.auth_info[0].principal AS user_email,
+  proto_payload.method_name AS operation,
+  proto_payload.resource_name AS resource
+FROM
+  \`my_project.logging_archive.cloudaudit_googleapis_com_activity_*\`
+WHERE
+  _TABLE_SUFFIX >= '20240101'
+  AND proto_payload.auth_info[0].principal = 'suspicious@example.com'
+ORDER BY
+  timestamp DESC;`}</pre>
+                <pre className="codeblock">{`-- HTTP 5xx エラーの時系列分析
+SELECT
+  TIMESTAMP_TRUNC(timestamp, HOUR) AS hour,
+  COUNT(*) AS error_count,
+  http_request.request_url AS url
+FROM
+  \`my_project.logging_archive.requests_*\`
+WHERE
+  _TABLE_SUFFIX >= FORMAT_DATE('%Y%m%d', DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY))
+  AND http_request.status >= 500
+GROUP BY
+  hour, url
+ORDER BY
+  hour, error_count DESC;`}</pre>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: Cloud Logging</div>
+                    <ul>
+                        <li><strong>管理アクティビティ監査ログを BigQuery にエクスポート</strong>（長期保存・詳細分析・監査証跡）</li>
+                        <li><strong>機密データを扱う API はデータアクセス監査ログを有効化</strong>（コンプライアンス・インシデント対応）</li>
+                        <li><strong>GKE の auditd ログを有効化</strong>（COS ノード — バイナリ実行履歴の追跡）</li>
+                        <li><strong>Cloud Storage の Coldline にアーカイブシンクを設定</strong>（低コストで長期保管）</li>
+                        <li><strong>_Default バケットの保持期間を要件に合わせて延長</strong>（デフォルト 30 日では監査に不十分な場合）</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter15() {
+    return (
+        <div id="ch15" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn15">15</div>
+                <div className="sec-head-txt">
+                    <h2>Cloud Trace / Profiler / Error Reporting</h2>
+                    <p>分散トレーシング・継続プロファイリング・エラー自動集計・4 シグナル</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">15.1</span>Cloud Trace（分散トレーシング）</div>
+                <pre className="codeblock">{`【Cloud Trace の目的】
+
+マイクロサービス環境での問題:
+  ユーザーのリクエストが遅い！でもどのサービスが原因？
+
+  User → API Gateway → Service A → Service B → Database
+
+  → 全体で 3 秒かかっているが、どのステップが遅いか不明
+
+Cloud Trace の効果:
+  User → API Gateway(50ms) → Service A(200ms) → Service B(2500ms!) → Database(150ms)
+
+  → Service B に問題があることを特定！`}</pre>
+                <pre className="codeblock">{`# Python での Cloud Trace 設定（OpenTelemetry）
+from opentelemetry import trace
+from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+provider = TracerProvider()
+cloud_trace_exporter = CloudTraceSpanExporter()
+provider.add_span_processor(BatchSpanProcessor(cloud_trace_exporter))
+trace.set_tracer_provider(provider)
+
+tracer = trace.get_tracer(__name__)
+
+# スパン（処理区間）を計測
+with tracer.start_as_current_span("process-order"):
+    with tracer.start_as_current_span("validate-payment"):
+        validate_payment(order)
+    with tracer.start_as_current_span("save-to-database"):
+        save_order(order)`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">15.2</span>Cloud Profiler（継続的プロファイリング）</div>
+                <pre className="codeblock">{`【Cloud Profiler の目的】
+
+「どのコードがCPU/メモリを消費しているか？」を
+本番環境で継続的に測定する
+
+特徴:
+  ├── 本番環境に影響を与えずに継続プロファイリング
+  ├── CPU 時間・ヒープメモリ・スレッド使用量を可視化
+  ├── フレームグラフ（Flame Graph）で視覚化
+  └── Go, Java, Python, Node.js に対応
+
+典型的な発見:
+  ├── 不要なデータベースクエリがループ内で実行されている
+  ├── JSON シリアライズが想定外に重い
+  └── メモリリークの原因関数を特定`}</pre>
+                <pre className="codeblock">{`# Python での Cloud Profiler 設定
+import googlecloudprofiler
+
+# アプリ起動時に初期化するだけで自動プロファイリング開始
+googlecloudprofiler.start(
+    service='my-service',
+    service_version='1.0.0',
+    verbose=3,
+)`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">15.3</span>Error Reporting（エラー追跡）</div>
+                <pre className="codeblock">{`【Error Reporting の目的】
+
+アプリケーションで発生した例外・エラーを
+自動集計して重要なものを通知する
+
+機能:
+  ├── Cloud Logging に記録された例外・エラーを自動検出
+  ├── 同じエラーをグループ化（重複を排除）
+  ├── 新しいエラーが出たら即時通知
+  ├── エラーの発生頻度・傾向を表示
+  └── スタックトレースで原因箇所を特定`}</pre>
+                <pre className="codeblock">{`# Python アプリでエラーを Error Reporting に送信
+from google.cloud import error_reporting
+
+client = error_reporting.Client()
+
+try:
+    result = process_order(order_id)
+except Exception:
+    # エラーを Error Reporting に送信（スタックトレース付き）
+    client.report_exception()
+    raise`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">15.4</span>4 つのオブザーバビリティシグナル（まとめ）</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>シグナル</span><span>GCP ツール</span><span>問いに答える</span><span>例</span>
+                    </div>
+                    <div className="ctable-row"><span>Metrics（メトリクス）</span><span>Cloud Monitoring</span><span>「何が」起きているか（定量的）</span><span>CPU 80%、エラーレート 0.5%</span></div>
+                    <div className="ctable-row"><span>Logs（ログ）</span><span>Cloud Logging</span><span>「何が」起きたか（イベント記録）</span><span>"Error: DB connection refused"</span></div>
+                    <div className="ctable-row"><span>Traces（トレース）</span><span>Cloud Trace</span><span>「どこで」遅延が発生しているか</span><span>Service B が 2.5 秒かかっている</span></div>
+                    <div className="ctable-row"><span>Profiles（プロファイル）</span><span>Cloud Profiler</span><span>「なぜ」遅いか（コードレベル）</span><span>process_large_array() が CPU の 60% を消費</span></div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Chapter16() {
+    return (
+        <div id="ch16" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn16">16</div>
+                <div className="sec-head-txt">
+                    <h2>Gemini Cloud Assist と Cloud Asset Inventory</h2>
+                    <p>根本原因分析・IaC 自動生成・FinOps 提案・全リソース検索・IAM ポリシー分析</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">16.1</span>Gemini Cloud Assist</div>
+                <pre className="codeblock">{`【Gemini Cloud Assist とは？】
+
+Google Cloud の AI アシスタント
+  → Cloud Console の右上「?」ボタンから利用
+
+できること:
+  ├── 自然言語で GCP の操作をサポート
+  ├── アーキテクチャ図を自動生成
+  ├── Terraform テンプレートを自動生成
+  ├── 障害の根本原因（RCA）分析
+  └── コスト最適化の提案`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">16.2</span>根本原因分析（Root Cause Analysis）</div>
+                <pre className="codeblock">{`【Gemini によるトラブルシューティング例】
+
+エンジニアが入力:
+  「us-central1 の Cloud Run サービスが今朝 9 時から
+   503 エラーを返しています。原因を調べてください。」
+
+Gemini が自動分析:
+  ┌── Cloud Logging のエラーログを横断分析
+  ├── Cloud Monitoring のメトリクスを確認
+  │   （CPU 急上昇、メモリ不足など）
+  ├── Cloud Asset Inventory の設定変更履歴を確認
+  │   （デプロイ・設定変更がなかったか）
+  └── 分析結果を自然言語で提示
+
+Gemini の回答例:
+  「8:55 AM に新しいリビジョンがデプロイされました。
+   そのリビジョンから OOMKilled（メモリ不足）が多発しています。
+   メモリ上限を 256MB から 512MB に増やすことを推奨します。」`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">16.3</span>Cloud Asset Inventory</div>
+                <pre className="codeblock">{`【Cloud Asset Inventory の目的】
+
+「組織全体に何があるか、誰がアクセスできるか」を一元的に把握
+
+機能:
+  ├── 全リソースの検索・エクスポート
+  ├── IAM ポリシーの変更履歴
+  ├── リソースへのアクセス権分析
+  └── 組織ポリシーとの整合性確認`}</pre>
+                <pre className="codeblock">{`# 組織内の全 GKE クラスタを検索
+gcloud asset search-all-resources \\
+  --asset-types='container.googleapis.com/Cluster' \\
+  --scope='organizations/ORG_ID' \\
+  --format="table(name,location,displayName)"
+
+# 外部 IP を持つ VM を検索（セキュリティ監査）
+gcloud asset search-all-resources \\
+  --asset-types='compute.googleapis.com/Instance' \\
+  --scope='organizations/ORG_ID' \\
+  --query='networkInterfaces.accessConfigs.natIP:*'`}</pre>
+                <pre className="codeblock">{`# IAM ポリシーの変更履歴を確認
+gcloud asset list \\
+  --organization=ORG_ID \\
+  --asset-types='iam.googleapis.com/Policy' \\
+  --content-type=iam-policy \\
+  --snapshot-time=$(date -d '1 day ago' -u +%Y-%m-%dT%H:%M:%SZ)
+
+# 特定のリソースにアクセスできる全 Identity を分析
+gcloud asset analyze-iam-policy \\
+  --organization=ORG_ID \\
+  --full-resource-name='//storage.googleapis.com/projects/_/buckets/my-sensitive-bucket'`}</pre>
+            </div>
+        </div>
+    );
+}
+
+function Chapter17() {
+    return (
+        <div id="ch17" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn17">17</div>
+                <div className="sec-head-txt">
+                    <h2>Domain 3 試験対策まとめ</h2>
+                    <p>頻出パターン・重要用語チェックリスト・推奨学習リソース</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">17.1</span>試験頻出パターン</div>
+                <pre className="codeblock">{`【パターン①】メモリメトリクスに関する問題
+
+問題文: 「Compute Engine VM のメモリ使用量を監視したい。どうすればよいか？」
+
+正解: Ops Agent をインストールして設定する
+
+よくある不正解:
+「Cloud Monitoring コンソールで自動的に確認できる」
+→ ❌ メモリ使用量はデフォルトでは取得されない
+   CPU/ネットワーク I/O は自動取得だが、メモリは Ops Agent が必要`}</pre>
+                <pre className="codeblock">{`【パターン②】スナップショットの整合性に関する問題
+
+問題文: 「MySQL データベースが動作している VM のディスクの
+ 完全な整合性を保ったバックアップを取得したい。」
+
+正解: アプリケーション整合性スナップショット
+  → MySQL で FLUSH TABLES WITH READ LOCK を実行してから
+    スナップショットを取得
+
+クラッシュ整合性との違い:
+  クラッシュ整合性: アプリ無停止、メモリのフラッシュなし
+  アプリケーション整合性: 書き込みを停止してからスナップショット`}</pre>
+                <pre className="codeblock">{`【パターン③】監査ログの種類に関する問題
+
+問題文 1: 「IAM ポリシーの変更を記録したい。どのログを使うか？」
+→ 管理アクティビティ監査ログ（常に有効）
+
+問題文 2: 「Cloud Storage バケットのオブジェクト読み取りを監査したい。どうすればよいか？」
+→ データアクセス監査ログを有効化（デフォルトは無効）
+
+3 種類の使い分け:
+  管理アクティビティ: リソースの作成・変更・削除（常に有効・無料）
+  データアクセス:     データの読み書き（手動で有効化・有料）
+  システムイベント:   Google の自動操作（常に有効・無料）`}</pre>
+                <pre className="codeblock">{`【パターン④】ログのエクスポート先に関する問題
+
+問題文: 「ログを 7 年間保持してコンプライアンス要件を満たしたい。
+ コストを最小化する方法は？」
+
+正解: Cloud Storage の Coldline ストレージへのシンクを設定
+  → 低コストな長期アーカイブ
+
+各エクスポート先の使い分け:
+  BigQuery: 長期保存 + SQL で柔軟な分析
+  Cloud Storage: 純粋なアーカイブ（コスト最安）
+  Pub/Sub: リアルタイムで SIEM や外部システムに連携`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">17.2</span>Domain 3 重要用語チェックリスト</div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: コンピュートリソースの管理</div>
+                    <ul>
+                        <li>スナップショットスケジュールで 1時間ごとに自動取得できることを知っている</li>
+                        <li>クラッシュ整合性 vs アプリケーション整合性の違いを説明できる</li>
+                        <li>Linux では fstrim でスナップショットを最適化できることを知っている</li>
+                        <li>MIG のローリングアップデートで --max-unavailable=0 がゼロダウンタイムを意味することを知っている</li>
+                        <li>kubectl rollout undo で Deployment をロールバックできることを知っている</li>
+                    </ul>
+                </div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: Cloud Monitoring</div>
+                    <ul>
+                        <li>メモリ使用量には Ops Agent が必要（デフォルトでは取得不可）</li>
+                        <li>Ops Agent = Fluent Bit（ログ）+ OpenTelemetry（メトリクス）の統合エージェント</li>
+                        <li>GKE の Prometheus 監視は Managed Service for Prometheus を使用</li>
+                        <li>SLO = 目標値、SLI = 測定値、エラーバジェット = 許容失敗量を説明できる</li>
+                        <li>バーンレートアラートでエラーバジェットの消費速度を監視できることを知っている</li>
+                    </ul>
+                </div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: Cloud Logging</div>
+                    <ul>
+                        <li>監査ログの 3種類（管理アクティビティ・データアクセス・システムイベント）を説明できる</li>
+                        <li>データアクセス監査ログはデフォルトで無効（手動で有効化が必要）</li>
+                        <li>管理アクティビティ監査ログは無効化不可・無料</li>
+                        <li>_Required バケットは 400 日保持・変更不可</li>
+                        <li>Log Router シンクで BigQuery/Cloud Storage/Pub/Sub にログをエクスポートできる</li>
+                        <li>GKE の監査ログは無効化できない</li>
+                    </ul>
+                </div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: Gemini Cloud Assist</div>
+                    <ul>
+                        <li>根本原因分析（ログ + メトリクス + 設定変更履歴を横断分析）ができることを知っている</li>
+                        <li>Cloud Asset Inventory で組織全体のリソースを一元検索できることを知っている</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">17.3</span>推奨学習リソース</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>リソース</span><span>URL</span>
+                    </div>
+                    <div className="ctable-row"><span>ACE 試験公式ページ</span><span>cloud.google.com/learn/certification/cloud-engineer</span></div>
+                    <div className="ctable-row"><span>スナップショットベストプラクティス</span><span>docs.cloud.google.com/compute/docs/disks/snapshot-best-practices</span></div>
+                    <div className="ctable-row"><span>Ops Agent の概要</span><span>docs.cloud.google.com/monitoring/agent/ops-agent</span></div>
+                    <div className="ctable-row"><span>Cloud Monitoring ドキュメント</span><span>cloud.google.com/monitoring</span></div>
+                    <div className="ctable-row"><span>オブザーバビリティ概要</span><span>cloud.google.com/products/observability</span></div>
+                    <div className="ctable-row"><span>Gemini Cloud Assist</span><span>cloud.google.com/products/gemini/cloud-assist</span></div>
+                    <div className="ctable-row"><span>Cloud Asset Inventory</span><span>cloud.google.com/asset-inventory/docs/overview</span></div>
+                    <div className="ctable-row"><span>Managed Service for Prometheus</span><span>cloud.google.com/stackdriver/docs/managed-prometheus</span></div>
+                </div>
+                <div className="wb">
+                    <div className="wbt">Domain 3 学習の最終アドバイス</div>
+                    <p>Domain 3 は「デプロイ後の運用・監視」がテーマです。</p>
+                    <p><strong>最頻出トピック TOP 5:</strong></p>
+                    <ul>
+                        <li>① Ops Agent → メモリ・ディスク使用率の取得</li>
+                        <li>② 監査ログの 3 種類（管理アクティビティ / データアクセス / システムイベント）</li>
+                        <li>③ スナップショット整合性（クラッシュ整合性 vs アプリケーション整合性）</li>
+                        <li>④ Log Router シンクのエクスポート先の使い分け（BigQuery / GCS / Pub/Sub）</li>
+                        <li>⑤ SLO / SLI / エラーバジェットの概念</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}
+
 export default function Domain3Page() {
     return (
         <div className="d3-page">
@@ -59,10 +2353,24 @@ export default function Domain3Page() {
             </nav>
 
             <div className="wrapper">
-                {/* 章は順次追加予定 */}
-                <div id="ch0" className="sgap">
-                    <p style={{ color: 'var(--d3-text-muted)' }}>コンテンツ実装中...</p>
-                </div>
+                <SectionIntro />
+                <Chapter1 />
+                <Chapter2 />
+                <Chapter3 />
+                <Chapter4 />
+                <Chapter5 />
+                <Chapter6 />
+                <Chapter7 />
+                <Chapter8 />
+                <Chapter9 />
+                <Chapter10 />
+                <Chapter11 />
+                <Chapter12 />
+                <Chapter13 />
+                <Chapter14 />
+                <Chapter15 />
+                <Chapter16 />
+                <Chapter17 />
             </div>
 
             <footer className="page-footer">

--- a/app/gcl/associate-cloud-engineer/domain3/page.tsx
+++ b/app/gcl/associate-cloud-engineer/domain3/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from 'next';
+import './domain3.css';
+
+export const metadata: Metadata = {
+    title: 'Domain 3: Ensuring Successful Operation of a Cloud Solution',
+    description:
+        'Google Cloud ACE Domain 3 包括的解説。SRE・監視・ロギング・バックアップ・障害対応の運用管理を詳解。',
+};
+
+export default function Domain3Page() {
+    return (
+        <div className="d3-page">
+            <section className="hero">
+                <div className="hero-eyebrow">ACE Domain 3 · ~22%</div>
+                <h1>
+                    Ensuring Successful Operation{' '}
+                    <span>of a Cloud Solution</span>
+                </h1>
+                <p className="hero-sub">
+                    クラウドソリューションの運用管理 — SRE・監視・ロギング・障害対応を詳細解説
+                </p>
+                <div className="hero-meta">
+                    <span className="hero-badge">
+                        <span className="dot dot-green" />
+                        試験配点 ~22%
+                    </span>
+                    <span className="hero-badge">
+                        <span className="dot dot-cyan" />
+                        全17章
+                    </span>
+                    <span className="hero-badge">
+                        <span className="dot" />
+                        コードブロック 190個
+                    </span>
+                </div>
+            </section>
+
+            <nav className="snav" role="navigation" aria-label="章ナビゲーション">
+                <div className="snav-inner">
+                    <a href="#ch0" className="snav-link"><span className="snav-num">00</span>全体マップ</a>
+                    <a href="#ch1" className="snav-link"><span className="snav-num">01</span>SRE的アプローチ</a>
+                    <a href="#ch2" className="snav-link"><span className="snav-num">02</span>GCEライフサイクル</a>
+                    <a href="#ch3" className="snav-link"><span className="snav-num">03</span>スナップショット</a>
+                    <a href="#ch4" className="snav-link"><span className="snav-num">04</span>MIG運用</a>
+                    <a href="#ch5" className="snav-link"><span className="snav-num">05</span>GKEクラスタ運用</a>
+                    <a href="#ch6" className="snav-link"><span className="snav-num">06</span>Cloud Run/Functions</a>
+                    <a href="#ch7" className="snav-link"><span className="snav-num">07</span>Storageデータ管理</a>
+                    <a href="#ch8" className="snav-link"><span className="snav-num">08</span>SQL/Spannerバックアップ</a>
+                    <a href="#ch9" className="snav-link"><span className="snav-num">09</span>Cloud Monitoring</a>
+                    <a href="#ch10" className="snav-link"><span className="snav-num">10</span>Ops Agent</a>
+                    <a href="#ch11" className="snav-link"><span className="snav-num">11</span>アラートとSLO</a>
+                    <a href="#ch12" className="snav-link"><span className="snav-num">12</span>Cloud Logging</a>
+                    <a href="#ch13" className="snav-link"><span className="snav-num">13</span>監査ログ</a>
+                    <a href="#ch14" className="snav-link"><span className="snav-num">14</span>Log Router</a>
+                    <a href="#ch15" className="snav-link"><span className="snav-num">15</span>Trace/Profiler</a>
+                    <a href="#ch16" className="snav-link"><span className="snav-num">16</span>Gemini Cloud Assist</a>
+                    <a href="#ch17" className="snav-link"><span className="snav-num">17</span>試験対策</a>
+                </div>
+            </nav>
+
+            <div className="wrapper">
+                {/* 章は順次追加予定 */}
+                <div id="ch0" className="sgap">
+                    <p style={{ color: 'var(--d3-text-muted)' }}>コンテンツ実装中...</p>
+                </div>
+            </div>
+
+            <footer className="page-footer">
+                <p>Domain 3: Ensuring Successful Operation of a Cloud Solution</p>
+            </footer>
+        </div>
+    );
+}

--- a/app/gcl/cloud-digital-leader/cdl.css
+++ b/app/gcl/cloud-digital-leader/cdl.css
@@ -4,7 +4,7 @@
    スコープクラス: .cdl-page
    =================================================================== */
 
-:root {
+.cdl-page {
     /* CDL page-specific palette */
     --cdl-bg:          #060810;
     --cdl-surface:     #0b0f1e;

--- a/app/gcl/cloud-digital-leader/cdl.css
+++ b/app/gcl/cloud-digital-leader/cdl.css
@@ -5,6 +5,7 @@
    =================================================================== */
 
 :root {
+    /* CDL page-specific palette */
     --cdl-bg:          #060810;
     --cdl-surface:     #0b0f1e;
     --cdl-surface2:    #10152a;
@@ -24,6 +25,15 @@
     --cdl-text-muted:  #8890a8;
     --cdl-text-bright: #e8ecf8;
     --cdl-glow:        0 0 24px rgba(66, 133, 244, 0.20);
+
+    /* Layer 3: globals.css セマンティックトークンを上書き（Header 等グローバルコンポーネント対応） */
+    --color-background:       var(--cdl-bg);
+    --color-foreground:       var(--cdl-text);
+    --color-card:             var(--cdl-surface);
+    --color-card-foreground:  var(--cdl-text);
+    --color-muted-foreground: var(--cdl-text-muted);
+    --color-border:           var(--cdl-border);
+    --color-primary:          var(--cdl-blue);
 }
 
 /* ─── Reset & Base ─────────────────────────────────────────────── */
@@ -32,8 +42,8 @@
 }
 
 .cdl-page {
-    background: var(--cdl-bg, #060810);
-    color: var(--cdl-text, #c8d0e4);
+    background: var(--color-background, #060810);
+    color: var(--color-foreground, #c8d0e4);
     min-height: 100vh;
     font-family: var(--font-body, 'Noto Sans JP', sans-serif);
     line-height: 1.75;

--- a/app/gcl/cloud-digital-leader/cdl.css
+++ b/app/gcl/cloud-digital-leader/cdl.css
@@ -1,0 +1,580 @@
+/* ===================================================================
+   Cloud Digital Leader 認定試験
+   Executive テーマ — Google Cloud 公式4色ベース・ビジネスエグゼクティブ感
+   スコープクラス: .cdl-page
+   =================================================================== */
+
+:root {
+    --cdl-bg:          #060810;
+    --cdl-surface:     #0b0f1e;
+    --cdl-surface2:    #10152a;
+    --cdl-surface3:    #151c34;
+    --cdl-border:      #1e2a4a;
+    --cdl-border-bright: #2e3e6a;
+    /* Google Cloud 公式4色 */
+    --cdl-blue:        #4285f4;
+    --cdl-red:         #ea4335;
+    --cdl-yellow:      #fbbc04;
+    --cdl-green:       #34a853;
+    /* 追加アクセント */
+    --cdl-cyan:        #00bcd4;
+    --cdl-purple:      #9c27b0;
+    --cdl-indigo:      #5c6bc0;
+    --cdl-text:        #c8d0e4;
+    --cdl-text-muted:  #8890a8;
+    --cdl-text-bright: #e8ecf8;
+    --cdl-glow:        0 0 24px rgba(66, 133, 244, 0.20);
+}
+
+/* ─── Reset & Base ─────────────────────────────────────────────── */
+.cdl-page * {
+    box-sizing: border-box;
+}
+
+.cdl-page {
+    background: var(--cdl-bg, #060810);
+    color: var(--cdl-text, #c8d0e4);
+    min-height: 100vh;
+    font-family: var(--font-body, 'Noto Sans JP', sans-serif);
+    line-height: 1.75;
+}
+
+/* ─── Hero Section ──────────────────────────────────────────────── */
+.cdl-page .hero {
+    position: relative;
+    overflow: hidden;
+    padding: 72px 24px 56px;
+    text-align: center;
+    background:
+        radial-gradient(ellipse 60% 45% at 20% 50%, rgba(66, 133, 244, 0.12) 0%, transparent 60%),
+        radial-gradient(ellipse 60% 45% at 80% 50%, rgba(52, 168, 83, 0.10) 0%, transparent 60%),
+        linear-gradient(135deg, #060810 0%, #0a1020 50%, #0c1530 100%);
+    border-bottom: 1px solid var(--cdl-border, #1e2a4a);
+}
+
+.cdl-page .hero-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(66, 133, 244, 0.10);
+    border: 1px solid rgba(66, 133, 244, 0.25);
+    border-radius: 999px;
+    padding: 4px 16px;
+    font-size: 12px;
+    color: var(--cdl-blue, #4285f4);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 20px;
+}
+
+.cdl-page .hero h1 {
+    font-size: clamp(26px, 5vw, 44px);
+    font-weight: 900;
+    color: var(--cdl-text-bright, #e8ecf8);
+    letter-spacing: -0.02em;
+    margin-bottom: 12px;
+    line-height: 1.2;
+}
+
+.cdl-page .hero h1 span {
+    background: linear-gradient(135deg, var(--cdl-blue, #4285f4), var(--cdl-cyan, #00bcd4));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.cdl-page .hero-sub {
+    font-size: 16px;
+    color: var(--cdl-text-muted, #8890a8);
+    max-width: 640px;
+    margin: 0 auto 28px;
+}
+
+.cdl-page .hero-meta {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 12px;
+    margin-top: 8px;
+}
+
+.cdl-page .hero-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--cdl-surface, #0b0f1e);
+    border: 1px solid var(--cdl-border, #1e2a4a);
+    border-radius: 8px;
+    padding: 6px 14px;
+    font-size: 13px;
+    color: var(--cdl-text, #c8d0e4);
+}
+
+.cdl-page .hero-badge .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.cdl-page .hero-badge .dot-blue   { background: var(--cdl-blue, #4285f4); }
+.cdl-page .hero-badge .dot-red    { background: var(--cdl-red, #ea4335); }
+.cdl-page .hero-badge .dot-yellow { background: var(--cdl-yellow, #fbbc04); }
+.cdl-page .hero-badge .dot-green  { background: var(--cdl-green, #34a853); }
+
+/* ─── Google 4色ロゴ装飾 ─────────────────────────────────────────── */
+.cdl-page .g-dots {
+    display: flex;
+    justify-content: center;
+    gap: 6px;
+    margin-bottom: 16px;
+}
+
+.cdl-page .g-dots span {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+}
+
+/* ─── Sticky Nav ─────────────────────────────────────────────────── */
+.cdl-page .snav {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    background: rgba(6, 8, 16, 0.92);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--cdl-border, #1e2a4a);
+    overflow-x: auto;
+    scrollbar-width: none;
+}
+
+.cdl-page .snav::-webkit-scrollbar { display: none; }
+
+.cdl-page .snav-inner {
+    display: flex;
+    gap: 4px;
+    padding: 8px 16px;
+    width: max-content;
+    min-width: 100%;
+}
+
+.cdl-page .snav-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 5px 12px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--cdl-text-muted, #8890a8);
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background 0.15s, color 0.15s;
+}
+
+.cdl-page .snav-link:hover {
+    background: var(--cdl-surface2, #10152a);
+    color: var(--cdl-text-bright, #e8ecf8);
+}
+
+/* ─── Wrapper ─────────────────────────────────────────────────────── */
+.cdl-page .wrapper {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 40px 20px 80px;
+}
+
+/* ─── Section Gap ─────────────────────────────────────────────────── */
+.cdl-page .sgap {
+    margin-bottom: 64px;
+}
+
+/* ─── Section Header ──────────────────────────────────────────────── */
+.cdl-page .sec-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+    margin-bottom: 28px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--cdl-border, #1e2a4a);
+}
+
+.cdl-page .sec-num {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 15px;
+    font-weight: 800;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    background: rgba(66, 133, 244, 0.12);
+    color: var(--cdl-blue, #4285f4);
+    border: 1px solid rgba(66, 133, 244, 0.25);
+}
+
+.cdl-page .sec-num.sn-red    { background: rgba(234, 67, 53, 0.12); color: var(--cdl-red, #ea4335); border-color: rgba(234, 67, 53, 0.25); }
+.cdl-page .sec-num.sn-yellow { background: rgba(251, 188, 4, 0.12); color: var(--cdl-yellow, #fbbc04); border-color: rgba(251, 188, 4, 0.25); }
+.cdl-page .sec-num.sn-green  { background: rgba(52, 168, 83, 0.12); color: var(--cdl-green, #34a853); border-color: rgba(52, 168, 83, 0.25); }
+.cdl-page .sec-num.sn-cyan   { background: rgba(0, 188, 212, 0.12); color: var(--cdl-cyan, #00bcd4); border-color: rgba(0, 188, 212, 0.25); }
+.cdl-page .sec-num.sn-purple { background: rgba(156, 39, 176, 0.12); color: var(--cdl-purple, #9c27b0); border-color: rgba(156, 39, 176, 0.25); }
+
+.cdl-page .sec-head-txt { flex: 1; }
+
+.cdl-page .sec-head-txt h2 {
+    font-size: 20px;
+    font-weight: 800;
+    color: var(--cdl-text-bright, #e8ecf8);
+    margin-bottom: 4px;
+    letter-spacing: -0.01em;
+}
+
+.cdl-page .sec-head-txt p {
+    font-size: 13px;
+    color: var(--cdl-text-muted, #8890a8);
+    margin: 0;
+}
+
+.cdl-page .pct-badge {
+    flex-shrink: 0;
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 700;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    background: rgba(66, 133, 244, 0.12);
+    color: var(--cdl-blue, #4285f4);
+    border: 1px solid rgba(66, 133, 244, 0.20);
+}
+
+/* ─── Topic Card ──────────────────────────────────────────────────── */
+.cdl-page .tcard {
+    background: var(--cdl-surface, #0b0f1e);
+    border: 1px solid var(--cdl-border, #1e2a4a);
+    border-radius: 14px;
+    padding: 24px;
+    margin-bottom: 20px;
+    transition: border-color 0.2s;
+}
+
+.cdl-page .tcard:hover {
+    border-color: var(--cdl-border-bright, #2e3e6a);
+}
+
+.cdl-page .ttitle {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--cdl-text-bright, #e8ecf8);
+    margin-bottom: 14px;
+}
+
+.cdl-page .tid {
+    font-size: 11px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    background: rgba(66, 133, 244, 0.12);
+    color: var(--cdl-blue, #4285f4);
+    padding: 2px 8px;
+    border-radius: 4px;
+    flex-shrink: 0;
+}
+
+.cdl-page .tcard > p {
+    font-size: 14px;
+    color: var(--cdl-text, #c8d0e4);
+    margin-bottom: 16px;
+    line-height: 1.75;
+}
+
+/* ─── Term Grid ───────────────────────────────────────────────────── */
+.cdl-page .tgrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 10px;
+    margin-bottom: 18px;
+}
+
+.cdl-page .titem {
+    background: var(--cdl-surface2, #10152a);
+    border: 1px solid var(--cdl-border, #1e2a4a);
+    border-radius: 8px;
+    padding: 12px 14px;
+}
+
+.cdl-page .tname {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--cdl-blue, #4285f4);
+    margin-bottom: 5px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.cdl-page .tdef {
+    font-size: 13px;
+    color: var(--cdl-text, #c8d0e4);
+    line-height: 1.6;
+}
+
+/* ─── Comparison Table ────────────────────────────────────────────── */
+.cdl-page .ctable-wrap {
+    overflow-x: auto;
+    margin-bottom: 18px;
+    border-radius: 10px;
+    border: 1px solid var(--cdl-border, #1e2a4a);
+}
+
+.cdl-page .ctable {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+}
+
+.cdl-page .ctable th {
+    background: var(--cdl-surface2, #10152a);
+    color: var(--cdl-blue, #4285f4);
+    font-weight: 700;
+    padding: 10px 14px;
+    text-align: left;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 12px;
+    border-bottom: 1px solid var(--cdl-border, #1e2a4a);
+    white-space: nowrap;
+}
+
+.cdl-page .ctable td {
+    padding: 10px 14px;
+    color: var(--cdl-text, #c8d0e4);
+    border-bottom: 1px solid var(--cdl-border, #1e2a4a);
+    vertical-align: top;
+    line-height: 1.6;
+}
+
+.cdl-page .ctable tr:last-child td { border-bottom: none; }
+
+.cdl-page .ctable tr:hover td {
+    background: rgba(66, 133, 244, 0.04);
+}
+
+.cdl-page .ctable td strong {
+    color: var(--cdl-text-bright, #e8ecf8);
+    font-weight: 700;
+}
+
+/* ─── Best Practice Box ───────────────────────────────────────────── */
+.cdl-page .bp {
+    background: rgba(52, 168, 83, 0.06);
+    border: 1px solid rgba(52, 168, 83, 0.20);
+    border-left: 3px solid var(--cdl-green, #34a853);
+    border-radius: 8px;
+    padding: 16px 18px;
+    margin-bottom: 14px;
+}
+
+.cdl-page .bpt {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--cdl-green, #34a853);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 10px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.cdl-page .bp ul {
+    margin: 0;
+    padding-left: 18px;
+}
+
+.cdl-page .bp li {
+    font-size: 13px;
+    color: var(--cdl-text, #c8d0e4);
+    margin-bottom: 6px;
+    line-height: 1.65;
+}
+
+.cdl-page .bp li:last-child { margin-bottom: 0; }
+
+/* ─── Warning / Info Box ──────────────────────────────────────────── */
+.cdl-page .wb {
+    background: rgba(251, 188, 4, 0.06);
+    border: 1px solid rgba(251, 188, 4, 0.20);
+    border-left: 3px solid var(--cdl-yellow, #fbbc04);
+    border-radius: 8px;
+    padding: 14px 18px;
+    margin-bottom: 14px;
+}
+
+.cdl-page .wbt {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--cdl-yellow, #fbbc04);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 8px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.cdl-page .wb p,
+.cdl-page .wb li {
+    font-size: 13px;
+    color: var(--cdl-text, #c8d0e4);
+    line-height: 1.65;
+    margin: 0;
+}
+
+.cdl-page .ib {
+    background: rgba(66, 133, 244, 0.06);
+    border: 1px solid rgba(66, 133, 244, 0.20);
+    border-left: 3px solid var(--cdl-blue, #4285f4);
+    border-radius: 8px;
+    padding: 14px 18px;
+    margin-bottom: 14px;
+}
+
+.cdl-page .ibt {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--cdl-blue, #4285f4);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 8px;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.cdl-page .ib p,
+.cdl-page .ib li {
+    font-size: 13px;
+    color: var(--cdl-text, #c8d0e4);
+    line-height: 1.65;
+    margin: 0;
+}
+
+/* ─── Code Block ──────────────────────────────────────────────────── */
+.cdl-page .codeblock {
+    background: #04060e;
+    border: 1px solid var(--cdl-border, #1e2a4a);
+    border-radius: 10px;
+    padding: 18px 20px;
+    margin-bottom: 14px;
+    overflow-x: auto;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 12.5px;
+    line-height: 1.75;
+    color: var(--cdl-text, #c8d0e4);
+    white-space: pre;
+    scrollbar-width: thin;
+    scrollbar-color: var(--cdl-border, #1e2a4a) transparent;
+}
+
+.cdl-page .codeblock::-webkit-scrollbar { height: 4px; }
+.cdl-page .codeblock::-webkit-scrollbar-track { background: transparent; }
+.cdl-page .codeblock::-webkit-scrollbar-thumb { background: var(--cdl-border, #1e2a4a); border-radius: 2px; }
+
+/* syntax highlighting */
+.cdl-page .codeblock .comment { color: #3a4880; }
+.cdl-page .codeblock .cmd     { color: var(--cdl-blue, #4285f4); font-weight: 600; }
+.cdl-page .codeblock .flag    { color: var(--cdl-cyan, #00bcd4); }
+.cdl-page .codeblock .val     { color: var(--cdl-green, #34a853); }
+.cdl-page .codeblock .str     { color: var(--cdl-yellow, #fbbc04); }
+.cdl-page .codeblock .kw      { color: var(--cdl-purple, #9c27b0); font-weight: 600; }
+.cdl-page .codeblock .fn      { color: var(--cdl-red, #ea4335); }
+.cdl-page .codeblock .num     { color: var(--cdl-cyan, #00bcd4); }
+
+/* ─── Subsection Title ────────────────────────────────────────────── */
+.cdl-page .stitle {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--cdl-cyan, #00bcd4);
+    margin: 20px 0 10px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.cdl-page .stitle::before {
+    content: '';
+    width: 3px;
+    height: 14px;
+    background: var(--cdl-cyan, #00bcd4);
+    border-radius: 2px;
+    flex-shrink: 0;
+}
+
+/* ─── Resource Links ──────────────────────────────────────────────── */
+.cdl-page .src {
+    margin-top: 16px;
+    padding-top: 14px;
+    border-top: 1px solid var(--cdl-border, #1e2a4a);
+}
+
+.cdl-page .srct {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--cdl-text-muted, #8890a8);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 8px;
+}
+
+.cdl-page .src a {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--cdl-blue, #4285f4);
+    text-decoration: none;
+    margin-right: 14px;
+    transition: opacity 0.15s;
+}
+
+.cdl-page .src a:hover { opacity: 0.75; }
+
+/* ─── Page Footer ─────────────────────────────────────────────────── */
+.cdl-page .page-footer {
+    text-align: center;
+    padding: 32px 20px;
+    border-top: 1px solid var(--cdl-border, #1e2a4a);
+    font-size: 13px;
+    color: var(--cdl-text-muted, #8890a8);
+}
+
+/* ─── Divider ─────────────────────────────────────────────────────── */
+.cdl-page .sdivider {
+    border: none;
+    border-top: 1px solid var(--cdl-border, #1e2a4a);
+    margin: 48px 0;
+}
+
+/* ─── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+    .cdl-page .tgrid {
+        grid-template-columns: 1fr;
+    }
+
+    .cdl-page .sec-head {
+        flex-wrap: wrap;
+    }
+}
+
+@media (max-width: 640px) {
+    .cdl-page .hero {
+        padding: 48px 16px 36px;
+    }
+
+    .cdl-page .hero h1 {
+        font-size: 24px;
+    }
+
+    .cdl-page .wrapper {
+        padding: 24px 14px 60px;
+    }
+
+    .cdl-page .tcard {
+        padding: 16px;
+    }
+}

--- a/app/gcl/cloud-digital-leader/cdl.css
+++ b/app/gcl/cloud-digital-leader/cdl.css
@@ -59,7 +59,7 @@
         radial-gradient(ellipse 60% 45% at 20% 50%, rgba(66, 133, 244, 0.12) 0%, transparent 60%),
         radial-gradient(ellipse 60% 45% at 80% 50%, rgba(52, 168, 83, 0.10) 0%, transparent 60%),
         linear-gradient(135deg, #060810 0%, #0a1020 50%, #0c1530 100%);
-    border-bottom: 1px solid var(--cdl-border, #1e2a4a);
+    border-bottom: 1px solid var(--color-border, #1e2a4a);
 }
 
 .cdl-page .hero-eyebrow {
@@ -71,7 +71,7 @@
     border-radius: 999px;
     padding: 4px 16px;
     font-size: 12px;
-    color: var(--cdl-blue, #4285f4);
+    color: var(--color-primary, #4285f4);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     margin-bottom: 20px;
@@ -87,7 +87,7 @@
 }
 
 .cdl-page .hero h1 span {
-    background: linear-gradient(135deg, var(--cdl-blue, #4285f4), var(--cdl-cyan, #00bcd4));
+    background: linear-gradient(135deg, var(--color-primary, #4285f4), var(--cdl-cyan, #00bcd4));
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -95,7 +95,7 @@
 
 .cdl-page .hero-sub {
     font-size: 16px;
-    color: var(--cdl-text-muted, #8890a8);
+    color: var(--color-muted-foreground, #8890a8);
     max-width: 640px;
     margin: 0 auto 28px;
 }
@@ -112,12 +112,12 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    background: var(--cdl-surface, #0b0f1e);
-    border: 1px solid var(--cdl-border, #1e2a4a);
+    background: var(--color-card, #0b0f1e);
+    border: 1px solid var(--color-border, #1e2a4a);
     border-radius: 8px;
     padding: 6px 14px;
     font-size: 13px;
-    color: var(--cdl-text, #c8d0e4);
+    color: var(--color-foreground, #c8d0e4);
 }
 
 .cdl-page .hero-badge .dot {
@@ -127,7 +127,7 @@
     flex-shrink: 0;
 }
 
-.cdl-page .hero-badge .dot-blue   { background: var(--cdl-blue, #4285f4); }
+.cdl-page .hero-badge .dot-blue   { background: var(--color-primary, #4285f4); }
 .cdl-page .hero-badge .dot-red    { background: var(--cdl-red, #ea4335); }
 .cdl-page .hero-badge .dot-yellow { background: var(--cdl-yellow, #fbbc04); }
 .cdl-page .hero-badge .dot-green  { background: var(--cdl-green, #34a853); }
@@ -154,7 +154,7 @@
     background: rgba(6, 8, 16, 0.92);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
-    border-bottom: 1px solid var(--cdl-border, #1e2a4a);
+    border-bottom: 1px solid var(--color-border, #1e2a4a);
     overflow-x: auto;
     scrollbar-width: none;
 }
@@ -177,7 +177,7 @@
     border-radius: 6px;
     font-size: 12px;
     font-weight: 600;
-    color: var(--cdl-text-muted, #8890a8);
+    color: var(--color-muted-foreground, #8890a8);
     text-decoration: none;
     white-space: nowrap;
     transition: background 0.15s, color 0.15s;
@@ -207,7 +207,7 @@
     gap: 16px;
     margin-bottom: 28px;
     padding-bottom: 20px;
-    border-bottom: 1px solid var(--cdl-border, #1e2a4a);
+    border-bottom: 1px solid var(--color-border, #1e2a4a);
 }
 
 .cdl-page .sec-num {
@@ -222,7 +222,7 @@
     font-weight: 800;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     background: rgba(66, 133, 244, 0.12);
-    color: var(--cdl-blue, #4285f4);
+    color: var(--color-primary, #4285f4);
     border: 1px solid rgba(66, 133, 244, 0.25);
 }
 
@@ -244,7 +244,7 @@
 
 .cdl-page .sec-head-txt p {
     font-size: 13px;
-    color: var(--cdl-text-muted, #8890a8);
+    color: var(--color-muted-foreground, #8890a8);
     margin: 0;
 }
 
@@ -256,14 +256,14 @@
     font-weight: 700;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     background: rgba(66, 133, 244, 0.12);
-    color: var(--cdl-blue, #4285f4);
+    color: var(--color-primary, #4285f4);
     border: 1px solid rgba(66, 133, 244, 0.20);
 }
 
 /* ─── Topic Card ──────────────────────────────────────────────────── */
 .cdl-page .tcard {
-    background: var(--cdl-surface, #0b0f1e);
-    border: 1px solid var(--cdl-border, #1e2a4a);
+    background: var(--color-card, #0b0f1e);
+    border: 1px solid var(--color-border, #1e2a4a);
     border-radius: 14px;
     padding: 24px;
     margin-bottom: 20px;
@@ -288,7 +288,7 @@
     font-size: 11px;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     background: rgba(66, 133, 244, 0.12);
-    color: var(--cdl-blue, #4285f4);
+    color: var(--color-primary, #4285f4);
     padding: 2px 8px;
     border-radius: 4px;
     flex-shrink: 0;
@@ -296,7 +296,7 @@
 
 .cdl-page .tcard > p {
     font-size: 14px;
-    color: var(--cdl-text, #c8d0e4);
+    color: var(--color-foreground, #c8d0e4);
     margin-bottom: 16px;
     line-height: 1.75;
 }
@@ -311,7 +311,7 @@
 
 .cdl-page .titem {
     background: var(--cdl-surface2, #10152a);
-    border: 1px solid var(--cdl-border, #1e2a4a);
+    border: 1px solid var(--color-border, #1e2a4a);
     border-radius: 8px;
     padding: 12px 14px;
 }
@@ -319,14 +319,14 @@
 .cdl-page .tname {
     font-size: 12px;
     font-weight: 700;
-    color: var(--cdl-blue, #4285f4);
+    color: var(--color-primary, #4285f4);
     margin-bottom: 5px;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
 }
 
 .cdl-page .tdef {
     font-size: 13px;
-    color: var(--cdl-text, #c8d0e4);
+    color: var(--color-foreground, #c8d0e4);
     line-height: 1.6;
 }
 
@@ -335,7 +335,7 @@
     overflow-x: auto;
     margin-bottom: 18px;
     border-radius: 10px;
-    border: 1px solid var(--cdl-border, #1e2a4a);
+    border: 1px solid var(--color-border, #1e2a4a);
 }
 
 .cdl-page .ctable {
@@ -346,20 +346,20 @@
 
 .cdl-page .ctable th {
     background: var(--cdl-surface2, #10152a);
-    color: var(--cdl-blue, #4285f4);
+    color: var(--color-primary, #4285f4);
     font-weight: 700;
     padding: 10px 14px;
     text-align: left;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 12px;
-    border-bottom: 1px solid var(--cdl-border, #1e2a4a);
+    border-bottom: 1px solid var(--color-border, #1e2a4a);
     white-space: nowrap;
 }
 
 .cdl-page .ctable td {
     padding: 10px 14px;
-    color: var(--cdl-text, #c8d0e4);
-    border-bottom: 1px solid var(--cdl-border, #1e2a4a);
+    color: var(--color-foreground, #c8d0e4);
+    border-bottom: 1px solid var(--color-border, #1e2a4a);
     vertical-align: top;
     line-height: 1.6;
 }
@@ -402,7 +402,7 @@
 
 .cdl-page .bp li {
     font-size: 13px;
-    color: var(--cdl-text, #c8d0e4);
+    color: var(--color-foreground, #c8d0e4);
     margin-bottom: 6px;
     line-height: 1.65;
 }
@@ -432,7 +432,7 @@
 .cdl-page .wb p,
 .cdl-page .wb li {
     font-size: 13px;
-    color: var(--cdl-text, #c8d0e4);
+    color: var(--color-foreground, #c8d0e4);
     line-height: 1.65;
     margin: 0;
 }
@@ -440,7 +440,7 @@
 .cdl-page .ib {
     background: rgba(66, 133, 244, 0.06);
     border: 1px solid rgba(66, 133, 244, 0.20);
-    border-left: 3px solid var(--cdl-blue, #4285f4);
+    border-left: 3px solid var(--color-primary, #4285f4);
     border-radius: 8px;
     padding: 14px 18px;
     margin-bottom: 14px;
@@ -449,7 +449,7 @@
 .cdl-page .ibt {
     font-size: 11px;
     font-weight: 700;
-    color: var(--cdl-blue, #4285f4);
+    color: var(--color-primary, #4285f4);
     text-transform: uppercase;
     letter-spacing: 0.08em;
     margin-bottom: 8px;
@@ -459,7 +459,7 @@
 .cdl-page .ib p,
 .cdl-page .ib li {
     font-size: 13px;
-    color: var(--cdl-text, #c8d0e4);
+    color: var(--color-foreground, #c8d0e4);
     line-height: 1.65;
     margin: 0;
 }
@@ -467,7 +467,7 @@
 /* ─── Code Block ──────────────────────────────────────────────────── */
 .cdl-page .codeblock {
     background: #04060e;
-    border: 1px solid var(--cdl-border, #1e2a4a);
+    border: 1px solid var(--color-border, #1e2a4a);
     border-radius: 10px;
     padding: 18px 20px;
     margin-bottom: 14px;
@@ -475,19 +475,19 @@
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 12.5px;
     line-height: 1.75;
-    color: var(--cdl-text, #c8d0e4);
+    color: var(--color-foreground, #c8d0e4);
     white-space: pre;
     scrollbar-width: thin;
-    scrollbar-color: var(--cdl-border, #1e2a4a) transparent;
+    scrollbar-color: var(--color-border, #1e2a4a) transparent;
 }
 
 .cdl-page .codeblock::-webkit-scrollbar { height: 4px; }
 .cdl-page .codeblock::-webkit-scrollbar-track { background: transparent; }
-.cdl-page .codeblock::-webkit-scrollbar-thumb { background: var(--cdl-border, #1e2a4a); border-radius: 2px; }
+.cdl-page .codeblock::-webkit-scrollbar-thumb { background: var(--color-border, #1e2a4a); border-radius: 2px; }
 
 /* syntax highlighting */
 .cdl-page .codeblock .comment { color: #3a4880; }
-.cdl-page .codeblock .cmd     { color: var(--cdl-blue, #4285f4); font-weight: 600; }
+.cdl-page .codeblock .cmd     { color: var(--color-primary, #4285f4); font-weight: 600; }
 .cdl-page .codeblock .flag    { color: var(--cdl-cyan, #00bcd4); }
 .cdl-page .codeblock .val     { color: var(--cdl-green, #34a853); }
 .cdl-page .codeblock .str     { color: var(--cdl-yellow, #fbbc04); }
@@ -519,13 +519,13 @@
 .cdl-page .src {
     margin-top: 16px;
     padding-top: 14px;
-    border-top: 1px solid var(--cdl-border, #1e2a4a);
+    border-top: 1px solid var(--color-border, #1e2a4a);
 }
 
 .cdl-page .srct {
     font-size: 11px;
     font-weight: 700;
-    color: var(--cdl-text-muted, #8890a8);
+    color: var(--color-muted-foreground, #8890a8);
     text-transform: uppercase;
     letter-spacing: 0.08em;
     margin-bottom: 8px;
@@ -536,7 +536,7 @@
     align-items: center;
     gap: 4px;
     font-size: 12px;
-    color: var(--cdl-blue, #4285f4);
+    color: var(--color-primary, #4285f4);
     text-decoration: none;
     margin-right: 14px;
     transition: opacity 0.15s;
@@ -548,15 +548,15 @@
 .cdl-page .page-footer {
     text-align: center;
     padding: 32px 20px;
-    border-top: 1px solid var(--cdl-border, #1e2a4a);
+    border-top: 1px solid var(--color-border, #1e2a4a);
     font-size: 13px;
-    color: var(--cdl-text-muted, #8890a8);
+    color: var(--color-muted-foreground, #8890a8);
 }
 
 /* ─── Divider ─────────────────────────────────────────────────────── */
 .cdl-page .sdivider {
     border: none;
-    border-top: 1px solid var(--cdl-border, #1e2a4a);
+    border-top: 1px solid var(--color-border, #1e2a4a);
     margin: 48px 0;
 }
 

--- a/app/gcl/cloud-digital-leader/cdl.css
+++ b/app/gcl/cloud-digital-leader/cdl.css
@@ -31,9 +31,13 @@
     --color-foreground:       var(--cdl-text);
     --color-card:             var(--cdl-surface);
     --color-card-foreground:  var(--cdl-text);
+    --color-muted:            var(--cdl-surface2);
     --color-muted-foreground: var(--cdl-text-muted);
+    --color-accent:           var(--cdl-surface3);
+    --color-accent-foreground: var(--cdl-text-bright);
     --color-border:           var(--cdl-border);
     --color-primary:          var(--cdl-blue);
+    --color-primary-foreground: #ffffff;
 }
 
 /* ─── Reset & Base ─────────────────────────────────────────────── */
@@ -42,8 +46,8 @@
 }
 
 .cdl-page {
-    background: var(--color-background, #060810);
-    color: var(--color-foreground, #c8d0e4);
+    background: var(--color-background);
+    color: var(--color-foreground);
     min-height: 100vh;
     font-family: var(--font-body, 'Noto Sans JP', sans-serif);
     line-height: 1.75;
@@ -58,8 +62,8 @@
     background:
         radial-gradient(ellipse 60% 45% at 20% 50%, rgba(66, 133, 244, 0.12) 0%, transparent 60%),
         radial-gradient(ellipse 60% 45% at 80% 50%, rgba(52, 168, 83, 0.10) 0%, transparent 60%),
-        linear-gradient(135deg, #060810 0%, #0a1020 50%, #0c1530 100%);
-    border-bottom: 1px solid var(--color-border, #1e2a4a);
+        linear-gradient(135deg, var(--cdl-bg) 0%, #0a1020 50%, #0c1530 100%);
+    border-bottom: 1px solid var(--color-border);
 }
 
 .cdl-page .hero-eyebrow {
@@ -71,7 +75,7 @@
     border-radius: 999px;
     padding: 4px 16px;
     font-size: 12px;
-    color: var(--color-primary, #4285f4);
+    color: var(--color-primary);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     margin-bottom: 20px;
@@ -80,14 +84,14 @@
 .cdl-page .hero h1 {
     font-size: clamp(26px, 5vw, 44px);
     font-weight: 900;
-    color: var(--cdl-text-bright, #e8ecf8);
+    color: var(--color-accent-foreground);
     letter-spacing: -0.02em;
     margin-bottom: 12px;
     line-height: 1.2;
 }
 
 .cdl-page .hero h1 span {
-    background: linear-gradient(135deg, var(--color-primary, #4285f4), var(--cdl-cyan, #00bcd4));
+    background: linear-gradient(135deg, var(--color-primary), var(--cdl-cyan));
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -95,7 +99,7 @@
 
 .cdl-page .hero-sub {
     font-size: 16px;
-    color: var(--color-muted-foreground, #8890a8);
+    color: var(--color-muted-foreground);
     max-width: 640px;
     margin: 0 auto 28px;
 }
@@ -112,12 +116,12 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    background: var(--color-card, #0b0f1e);
-    border: 1px solid var(--color-border, #1e2a4a);
+    background: var(--color-card);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
     padding: 6px 14px;
     font-size: 13px;
-    color: var(--color-foreground, #c8d0e4);
+    color: var(--color-foreground);
 }
 
 .cdl-page .hero-badge .dot {
@@ -127,10 +131,10 @@
     flex-shrink: 0;
 }
 
-.cdl-page .hero-badge .dot-blue   { background: var(--color-primary, #4285f4); }
-.cdl-page .hero-badge .dot-red    { background: var(--cdl-red, #ea4335); }
-.cdl-page .hero-badge .dot-yellow { background: var(--cdl-yellow, #fbbc04); }
-.cdl-page .hero-badge .dot-green  { background: var(--cdl-green, #34a853); }
+.cdl-page .hero-badge .dot-blue   { background: var(--color-primary); }
+.cdl-page .hero-badge .dot-red    { background: var(--cdl-red); }
+.cdl-page .hero-badge .dot-yellow { background: var(--cdl-yellow); }
+.cdl-page .hero-badge .dot-green  { background: var(--cdl-green); }
 
 /* ─── Google 4色ロゴ装飾 ─────────────────────────────────────────── */
 .cdl-page .g-dots {
@@ -146,6 +150,11 @@
     border-radius: 50%;
 }
 
+.cdl-page .g-blue   { background: var(--cdl-blue); }
+.cdl-page .g-red    { background: var(--cdl-red); }
+.cdl-page .g-yellow { background: var(--cdl-yellow); }
+.cdl-page .g-green  { background: var(--cdl-green); }
+
 /* ─── Sticky Nav ─────────────────────────────────────────────────── */
 .cdl-page .snav {
     position: sticky;
@@ -154,7 +163,7 @@
     background: rgba(6, 8, 16, 0.92);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
-    border-bottom: 1px solid var(--color-border, #1e2a4a);
+    border-bottom: 1px solid var(--color-border);
     overflow-x: auto;
     scrollbar-width: none;
 }
@@ -177,15 +186,20 @@
     border-radius: 6px;
     font-size: 12px;
     font-weight: 600;
-    color: var(--color-muted-foreground, #8890a8);
+    color: var(--color-muted-foreground);
     text-decoration: none;
     white-space: nowrap;
     transition: background 0.15s, color 0.15s;
 }
 
 .cdl-page .snav-link:hover {
-    background: var(--cdl-surface2, #10152a);
-    color: var(--cdl-text-bright, #e8ecf8);
+    background: var(--color-muted);
+    color: var(--color-accent-foreground);
+}
+
+.cdl-page .snav-link.active {
+    background: rgba(66, 133, 244, 0.12);
+    color: var(--color-primary);
 }
 
 /* ─── Wrapper ─────────────────────────────────────────────────────── */
@@ -207,7 +221,7 @@
     gap: 16px;
     margin-bottom: 28px;
     padding-bottom: 20px;
-    border-bottom: 1px solid var(--color-border, #1e2a4a);
+    border-bottom: 1px solid var(--color-border);
 }
 
 .cdl-page .sec-num {
@@ -222,29 +236,29 @@
     font-weight: 800;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     background: rgba(66, 133, 244, 0.12);
-    color: var(--color-primary, #4285f4);
+    color: var(--color-primary);
     border: 1px solid rgba(66, 133, 244, 0.25);
 }
 
-.cdl-page .sec-num.sn-red    { background: rgba(234, 67, 53, 0.12); color: var(--cdl-red, #ea4335); border-color: rgba(234, 67, 53, 0.25); }
-.cdl-page .sec-num.sn-yellow { background: rgba(251, 188, 4, 0.12); color: var(--cdl-yellow, #fbbc04); border-color: rgba(251, 188, 4, 0.25); }
-.cdl-page .sec-num.sn-green  { background: rgba(52, 168, 83, 0.12); color: var(--cdl-green, #34a853); border-color: rgba(52, 168, 83, 0.25); }
-.cdl-page .sec-num.sn-cyan   { background: rgba(0, 188, 212, 0.12); color: var(--cdl-cyan, #00bcd4); border-color: rgba(0, 188, 212, 0.25); }
-.cdl-page .sec-num.sn-purple { background: rgba(156, 39, 176, 0.12); color: var(--cdl-purple, #9c27b0); border-color: rgba(156, 39, 176, 0.25); }
+.cdl-page .sec-num.sn-red    { background: rgba(234, 67, 53, 0.12); color: var(--cdl-red); border-color: rgba(234, 67, 53, 0.25); }
+.cdl-page .sec-num.sn-yellow { background: rgba(251, 188, 4, 0.12); color: var(--cdl-yellow); border-color: rgba(251, 188, 4, 0.25); }
+.cdl-page .sec-num.sn-green  { background: rgba(52, 168, 83, 0.12); color: var(--cdl-green); border-color: rgba(52, 168, 83, 0.25); }
+.cdl-page .sec-num.sn-cyan   { background: rgba(0, 188, 212, 0.12); color: var(--cdl-cyan); border-color: rgba(0, 188, 212, 0.25); }
+.cdl-page .sec-num.sn-purple { background: rgba(156, 39, 176, 0.12); color: var(--cdl-purple); border-color: rgba(156, 39, 176, 0.25); }
 
 .cdl-page .sec-head-txt { flex: 1; }
 
 .cdl-page .sec-head-txt h2 {
     font-size: 20px;
     font-weight: 800;
-    color: var(--cdl-text-bright, #e8ecf8);
+    color: var(--color-accent-foreground);
     margin-bottom: 4px;
     letter-spacing: -0.01em;
 }
 
 .cdl-page .sec-head-txt p {
     font-size: 13px;
-    color: var(--color-muted-foreground, #8890a8);
+    color: var(--color-muted-foreground);
     margin: 0;
 }
 
@@ -256,14 +270,14 @@
     font-weight: 700;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     background: rgba(66, 133, 244, 0.12);
-    color: var(--color-primary, #4285f4);
+    color: var(--color-primary);
     border: 1px solid rgba(66, 133, 244, 0.20);
 }
 
 /* ─── Topic Card ──────────────────────────────────────────────────── */
 .cdl-page .tcard {
-    background: var(--color-card, #0b0f1e);
-    border: 1px solid var(--color-border, #1e2a4a);
+    background: var(--color-card);
+    border: 1px solid var(--color-border);
     border-radius: 14px;
     padding: 24px;
     margin-bottom: 20px;
@@ -271,7 +285,7 @@
 }
 
 .cdl-page .tcard:hover {
-    border-color: var(--cdl-border-bright, #2e3e6a);
+    border-color: var(--cdl-border-bright);
 }
 
 .cdl-page .ttitle {
@@ -280,7 +294,7 @@
     gap: 10px;
     font-size: 16px;
     font-weight: 700;
-    color: var(--cdl-text-bright, #e8ecf8);
+    color: var(--color-accent-foreground);
     margin-bottom: 14px;
 }
 
@@ -288,7 +302,7 @@
     font-size: 11px;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     background: rgba(66, 133, 244, 0.12);
-    color: var(--color-primary, #4285f4);
+    color: var(--color-primary);
     padding: 2px 8px;
     border-radius: 4px;
     flex-shrink: 0;
@@ -296,7 +310,7 @@
 
 .cdl-page .tcard > p {
     font-size: 14px;
-    color: var(--color-foreground, #c8d0e4);
+    color: var(--color-foreground);
     margin-bottom: 16px;
     line-height: 1.75;
 }
@@ -310,8 +324,8 @@
 }
 
 .cdl-page .titem {
-    background: var(--cdl-surface2, #10152a);
-    border: 1px solid var(--color-border, #1e2a4a);
+    background: var(--color-muted);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
     padding: 12px 14px;
 }
@@ -319,14 +333,14 @@
 .cdl-page .tname {
     font-size: 12px;
     font-weight: 700;
-    color: var(--color-primary, #4285f4);
+    color: var(--color-primary);
     margin-bottom: 5px;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
 }
 
 .cdl-page .tdef {
     font-size: 13px;
-    color: var(--color-foreground, #c8d0e4);
+    color: var(--color-foreground);
     line-height: 1.6;
 }
 
@@ -335,7 +349,7 @@
     overflow-x: auto;
     margin-bottom: 18px;
     border-radius: 10px;
-    border: 1px solid var(--color-border, #1e2a4a);
+    border: 1px solid var(--color-border);
 }
 
 .cdl-page .ctable {
@@ -345,21 +359,21 @@
 }
 
 .cdl-page .ctable th {
-    background: var(--cdl-surface2, #10152a);
-    color: var(--color-primary, #4285f4);
+    background: var(--color-muted);
+    color: var(--color-primary);
     font-weight: 700;
     padding: 10px 14px;
     text-align: left;
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 12px;
-    border-bottom: 1px solid var(--color-border, #1e2a4a);
+    border-bottom: 1px solid var(--color-border);
     white-space: nowrap;
 }
 
 .cdl-page .ctable td {
     padding: 10px 14px;
-    color: var(--color-foreground, #c8d0e4);
-    border-bottom: 1px solid var(--color-border, #1e2a4a);
+    color: var(--color-foreground);
+    border-bottom: 1px solid var(--color-border);
     vertical-align: top;
     line-height: 1.6;
 }
@@ -371,7 +385,7 @@
 }
 
 .cdl-page .ctable td strong {
-    color: var(--cdl-text-bright, #e8ecf8);
+    color: var(--color-accent-foreground);
     font-weight: 700;
 }
 
@@ -379,7 +393,7 @@
 .cdl-page .bp {
     background: rgba(52, 168, 83, 0.06);
     border: 1px solid rgba(52, 168, 83, 0.20);
-    border-left: 3px solid var(--cdl-green, #34a853);
+    border-left: 3px solid var(--cdl-green);
     border-radius: 8px;
     padding: 16px 18px;
     margin-bottom: 14px;
@@ -388,7 +402,7 @@
 .cdl-page .bpt {
     font-size: 11px;
     font-weight: 700;
-    color: var(--cdl-green, #34a853);
+    color: var(--cdl-green);
     text-transform: uppercase;
     letter-spacing: 0.08em;
     margin-bottom: 10px;
@@ -402,7 +416,7 @@
 
 .cdl-page .bp li {
     font-size: 13px;
-    color: var(--color-foreground, #c8d0e4);
+    color: var(--color-foreground);
     margin-bottom: 6px;
     line-height: 1.65;
 }
@@ -413,7 +427,7 @@
 .cdl-page .wb {
     background: rgba(251, 188, 4, 0.06);
     border: 1px solid rgba(251, 188, 4, 0.20);
-    border-left: 3px solid var(--cdl-yellow, #fbbc04);
+    border-left: 3px solid var(--cdl-yellow);
     border-radius: 8px;
     padding: 14px 18px;
     margin-bottom: 14px;
@@ -422,7 +436,7 @@
 .cdl-page .wbt {
     font-size: 11px;
     font-weight: 700;
-    color: var(--cdl-yellow, #fbbc04);
+    color: var(--cdl-yellow);
     text-transform: uppercase;
     letter-spacing: 0.08em;
     margin-bottom: 8px;
@@ -432,7 +446,7 @@
 .cdl-page .wb p,
 .cdl-page .wb li {
     font-size: 13px;
-    color: var(--color-foreground, #c8d0e4);
+    color: var(--color-foreground);
     line-height: 1.65;
     margin: 0;
 }
@@ -440,7 +454,7 @@
 .cdl-page .ib {
     background: rgba(66, 133, 244, 0.06);
     border: 1px solid rgba(66, 133, 244, 0.20);
-    border-left: 3px solid var(--color-primary, #4285f4);
+    border-left: 3px solid var(--color-primary);
     border-radius: 8px;
     padding: 14px 18px;
     margin-bottom: 14px;
@@ -449,7 +463,7 @@
 .cdl-page .ibt {
     font-size: 11px;
     font-weight: 700;
-    color: var(--color-primary, #4285f4);
+    color: var(--color-primary);
     text-transform: uppercase;
     letter-spacing: 0.08em;
     margin-bottom: 8px;
@@ -459,7 +473,7 @@
 .cdl-page .ib p,
 .cdl-page .ib li {
     font-size: 13px;
-    color: var(--color-foreground, #c8d0e4);
+    color: var(--color-foreground);
     line-height: 1.65;
     margin: 0;
 }
@@ -467,7 +481,7 @@
 /* ─── Code Block ──────────────────────────────────────────────────── */
 .cdl-page .codeblock {
     background: #04060e;
-    border: 1px solid var(--color-border, #1e2a4a);
+    border: 1px solid var(--color-border);
     border-radius: 10px;
     padding: 18px 20px;
     margin-bottom: 14px;
@@ -475,31 +489,31 @@
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 12.5px;
     line-height: 1.75;
-    color: var(--color-foreground, #c8d0e4);
+    color: var(--color-foreground);
     white-space: pre;
     scrollbar-width: thin;
-    scrollbar-color: var(--color-border, #1e2a4a) transparent;
+    scrollbar-color: var(--color-border) transparent;
 }
 
 .cdl-page .codeblock::-webkit-scrollbar { height: 4px; }
 .cdl-page .codeblock::-webkit-scrollbar-track { background: transparent; }
-.cdl-page .codeblock::-webkit-scrollbar-thumb { background: var(--color-border, #1e2a4a); border-radius: 2px; }
+.cdl-page .codeblock::-webkit-scrollbar-thumb { background: var(--color-border); border-radius: 2px; }
 
 /* syntax highlighting */
 .cdl-page .codeblock .comment { color: #3a4880; }
-.cdl-page .codeblock .cmd     { color: var(--color-primary, #4285f4); font-weight: 600; }
-.cdl-page .codeblock .flag    { color: var(--cdl-cyan, #00bcd4); }
-.cdl-page .codeblock .val     { color: var(--cdl-green, #34a853); }
-.cdl-page .codeblock .str     { color: var(--cdl-yellow, #fbbc04); }
-.cdl-page .codeblock .kw      { color: var(--cdl-purple, #9c27b0); font-weight: 600; }
-.cdl-page .codeblock .fn      { color: var(--cdl-red, #ea4335); }
-.cdl-page .codeblock .num     { color: var(--cdl-cyan, #00bcd4); }
+.cdl-page .codeblock .cmd     { color: var(--color-primary); font-weight: 600; }
+.cdl-page .codeblock .flag    { color: var(--cdl-cyan); }
+.cdl-page .codeblock .val     { color: var(--cdl-green); }
+.cdl-page .codeblock .str     { color: var(--cdl-yellow); }
+.cdl-page .codeblock .kw      { color: var(--cdl-purple); font-weight: 600; }
+.cdl-page .codeblock .fn      { color: var(--cdl-red); }
+.cdl-page .codeblock .num     { color: var(--cdl-cyan); }
 
 /* ─── Subsection Title ────────────────────────────────────────────── */
 .cdl-page .stitle {
     font-size: 14px;
     font-weight: 700;
-    color: var(--cdl-cyan, #00bcd4);
+    color: var(--cdl-cyan);
     margin: 20px 0 10px;
     display: flex;
     align-items: center;
@@ -510,7 +524,7 @@
     content: '';
     width: 3px;
     height: 14px;
-    background: var(--cdl-cyan, #00bcd4);
+    background: var(--cdl-cyan);
     border-radius: 2px;
     flex-shrink: 0;
 }
@@ -519,13 +533,13 @@
 .cdl-page .src {
     margin-top: 16px;
     padding-top: 14px;
-    border-top: 1px solid var(--color-border, #1e2a4a);
+    border-top: 1px solid var(--color-border);
 }
 
 .cdl-page .srct {
     font-size: 11px;
     font-weight: 700;
-    color: var(--color-muted-foreground, #8890a8);
+    color: var(--color-muted-foreground);
     text-transform: uppercase;
     letter-spacing: 0.08em;
     margin-bottom: 8px;
@@ -536,7 +550,7 @@
     align-items: center;
     gap: 4px;
     font-size: 12px;
-    color: var(--color-primary, #4285f4);
+    color: var(--color-primary);
     text-decoration: none;
     margin-right: 14px;
     transition: opacity 0.15s;
@@ -548,15 +562,15 @@
 .cdl-page .page-footer {
     text-align: center;
     padding: 32px 20px;
-    border-top: 1px solid var(--color-border, #1e2a4a);
+    border-top: 1px solid var(--color-border);
     font-size: 13px;
-    color: var(--color-muted-foreground, #8890a8);
+    color: var(--color-muted-foreground);
 }
 
 /* ─── Divider ─────────────────────────────────────────────────────── */
 .cdl-page .sdivider {
     border: none;
-    border-top: 1px solid var(--color-border, #1e2a4a);
+    border-top: 1px solid var(--color-border);
     margin: 48px 0;
 }
 

--- a/app/gcl/cloud-digital-leader/cdl.css
+++ b/app/gcl/cloud-digital-leader/cdl.css
@@ -41,7 +41,7 @@
 }
 
 /* ─── Reset & Base ─────────────────────────────────────────────── */
-.cdl-page * {
+.cdl-page :is(div, p, section, header, footer, nav, ul, ol, li, a, img, form, input, button, table, thead, tbody, tr, th, td, pre, span, h1, h2, h3, h4, h5, h6, main, aside, article, iframe, video, audio) {
     box-sizing: border-box;
 }
 

--- a/app/gcl/cloud-digital-leader/constants.ts
+++ b/app/gcl/cloud-digital-leader/constants.ts
@@ -1,4 +1,9 @@
-export const EXAM_SPEC = [
+export type ExamSpecItem = {
+    item: string;
+    content: string;
+};
+
+export const EXAM_SPEC: ExamSpecItem[] = [
     { item: '試験時間', content: '90分' },
     { item: '問題数', content: '50–60問' },
     { item: '合格点', content: '約 70%' },

--- a/app/gcl/cloud-digital-leader/constants.ts
+++ b/app/gcl/cloud-digital-leader/constants.ts
@@ -12,7 +12,13 @@ export const EXAM_SPEC: ExamSpecItem[] = [
     { item: '前提知識', content: '不要（推奨: 6ヶ月以上のクラウド経験）' },
 ];
 
-export const EXAM_DOMAINS = [
+export type ExamDomain = {
+    section: string;
+    theme: string;
+    weight: string;
+};
+
+export const EXAM_DOMAINS: ExamDomain[] = [
     { section: 'Domain 1', theme: 'Google Cloud によるデジタルトランスフォーメーション', weight: '10%' },
     { section: 'Domain 2', theme: 'クラウドによるイノベーション', weight: '12.5%' },
     { section: 'Domain 3', theme: 'インフラとアプリのモダナイゼーション', weight: '30%' },
@@ -21,7 +27,13 @@ export const EXAM_DOMAINS = [
     { section: 'Domain 6', theme: 'Google Cloud の AI によるイノベーション', weight: '5%' },
 ];
 
-export const NIST_CHARACTERISTICS = [
+export type NistCharacteristic = {
+    trait: string;
+    desc: string;
+    meaning: string;
+};
+
+export const NIST_CHARACTERISTICS: NistCharacteristic[] = [
     { trait: 'オンデマンド・セルフサービス', desc: '人手を介さずにリソースを即時調達', meaning: 'IT部門の承認待ち時間ゼロ' },
     { trait: '幅広いネットワークアクセス', desc: '任意のデバイスからアクセス可能', meaning: '場所・端末を選ばない働き方' },
     { trait: 'リソースの共有（マルチテナント）', desc: '複数ユーザーで物理リソースを共有', meaning: 'コスト効率の向上' },
@@ -29,7 +41,12 @@ export const NIST_CHARACTERISTICS = [
     { trait: '計測されたサービス', desc: '使用量に応じた従量課金', meaning: '使った分だけ払う経済合理性' },
 ];
 
-export const AI_PRINCIPLES = [
+export type AiPrinciple = {
+    principle: string;
+    description: string;
+};
+
+export const AI_PRINCIPLES: AiPrinciple[] = [
     { principle: '社会に有益である', description: '社会や経済へのプラスの影響を考慮する' },
     { principle: '不当なバイアスの発生を避ける', description: '人種、性別、信条などに関する不当な偏りを排除する' },
     { principle: '安全性に関する十分なテストを行う', description: '予期せぬ危害を防ぐためのセーフガードを設ける' },
@@ -39,14 +56,25 @@ export const AI_PRINCIPLES = [
     { principle: 'これらの原則に沿った利用に限定する', description: '有害な用途や権利を侵害する目的での利用を避ける' },
 ];
 
-export const AI_NOT_PURSUE = [
+export type AiNotPursueItem = {
+    target: string;
+    description: string;
+};
+
+export const AI_NOT_PURSUE: AiNotPursueItem[] = [
     { target: '重大な損害をもたらす可能性のある技術', description: '身体的、精神的、社会的な深刻な被害' },
     { target: '兵器としての AI', description: '直接的に殺傷を目的とする兵器への組み込み' },
     { target: '監視目的の AI', description: '国際的な規範に反する個人の監視や人権侵害' },
     { target: '国際法に違反する技術', description: '人権、プライバシー、表現の自由を侵害する利用' },
 ];
 
-export const COMPUTE_SERVICES = [
+export type ComputeService = {
+    service: string;
+    keyword: string;
+    usage: string;
+};
+
+export const COMPUTE_SERVICES: ComputeService[] = [
     { service: 'Compute Engine', keyword: 'VM・IaaS・OS 制御・GPU が必要', usage: 'レガシー移行・特定 OS 要件' },
     { service: 'GKE', keyword: 'コンテナ・Kubernetes・ステートフル', usage: 'マイクロサービス・長時間処理' },
     { service: 'Cloud Run', keyword: 'コンテナ・サーバーレス・HTTP・0 スケール', usage: 'ステートレス API・スパイクトラフィック' },
@@ -54,7 +82,12 @@ export const COMPUTE_SERVICES = [
     { service: 'App Engine', keyword: 'PaaS・Web アプリ・コードだけ', usage: 'レガシー Web アプリの移行' },
 ];
 
-export const CONFUSING_PAIRS = [
+export type ConfusingPair = {
+    pair: string;
+    truth: string;
+};
+
+export const CONFUSING_PAIRS: ConfusingPair[] = [
     { pair: 'Cloud Run vs Cloud Run Functions', truth: 'Cloud Run はコンテナ。Functions は関数（コード）。どちらもサーバーレス' },
     { pair: 'Cloud SQL vs BigQuery', truth: 'Cloud SQL: OLTP（トランザクション処理）。BigQuery: OLAP（分析）' },
     { pair: 'Dataflow vs Dataproc', truth: 'Dataflow: Apache Beam（ストリーミング + バッチ）。Dataproc: Hadoop/Spark（バッチ）' },
@@ -63,7 +96,12 @@ export const CONFUSING_PAIRS = [
     { pair: 'Looker vs Looker Studio', truth: 'Looker: エンタープライズ BI（有料）。Looker Studio: セルフサービス BI（無料）' },
 ];
 
-export const RESOURCES = [
+export type Resource = {
+    name: string;
+    url: string;
+};
+
+export const RESOURCES: Resource[] = [
     { name: '試験概要ページ', url: 'cloud.google.com/learn/certification/cloud-digital-leader' },
     { name: '公式試験ガイド', url: 'cloud.google.com/learn/certification/guides/cloud-digital-leader' },
     { name: 'Cloud Skills Boost 学習パス', url: 'cloudskillsboost.google/paths/9' },

--- a/app/gcl/cloud-digital-leader/constants.ts
+++ b/app/gcl/cloud-digital-leader/constants.ts
@@ -1,0 +1,73 @@
+export const EXAM_SPEC = [
+    { item: '試験時間', content: '90分' },
+    { item: '問題数', content: '50–60問' },
+    { item: '合格点', content: '約 70%' },
+    { item: '受験料', content: '$99' },
+    { item: '有効期間', content: '3年間' },
+    { item: '前提知識', content: '不要（推奨: 6ヶ月以上のクラウド経験）' },
+];
+
+export const EXAM_DOMAINS = [
+    { section: 'Domain 1', theme: 'Google Cloud によるデジタルトランスフォーメーション', weight: '10%' },
+    { section: 'Domain 2', theme: 'クラウドによるイノベーション', weight: '12.5%' },
+    { section: 'Domain 3', theme: 'インフラとアプリのモダナイゼーション', weight: '30%' },
+    { section: 'Domain 4', theme: 'Google Cloud のセキュリティと運用', weight: '30%' },
+    { section: 'Domain 5', theme: 'データによるイノベーション', weight: '12.5%' },
+    { section: 'Domain 6', theme: 'Google Cloud の AI によるイノベーション', weight: '5%' },
+];
+
+export const NIST_CHARACTERISTICS = [
+    { trait: 'オンデマンド・セルフサービス', desc: '人手を介さずにリソースを即時調達', meaning: 'IT部門の承認待ち時間ゼロ' },
+    { trait: '幅広いネットワークアクセス', desc: '任意のデバイスからアクセス可能', meaning: '場所・端末を選ばない働き方' },
+    { trait: 'リソースの共有（マルチテナント）', desc: '複数ユーザーで物理リソースを共有', meaning: 'コスト効率の向上' },
+    { trait: '迅速な弾力性（エラスティシティ）', desc: '需要に応じて自動でスケール', meaning: '急なトラフィック増にも対応' },
+    { trait: '計測されたサービス', desc: '使用量に応じた従量課金', meaning: '使った分だけ払う経済合理性' },
+];
+
+export const AI_PRINCIPLES = [
+    { principle: '社会に有益である', description: '社会や経済へのプラスの影響を考慮する' },
+    { principle: '不当なバイアスの発生を避ける', description: '人種、性別、信条などに関する不当な偏りを排除する' },
+    { principle: '安全性に関する十分なテストを行う', description: '予期せぬ危害を防ぐためのセーフガードを設ける' },
+    { principle: '人々に対する説明責任を果たす', description: 'フィードバックや苦情のための適切な機会を提供する' },
+    { principle: 'プライバシー設計の原則を取り入れる', description: 'データの収集、使用、通知に関する透明性を確保する' },
+    { principle: '科学的卓越性の高い水準を維持する', description: '厳格な科学的手法とオープンな探究を奨励する' },
+    { principle: 'これらの原則に沿った利用に限定する', description: '有害な用途や権利を侵害する目的での利用を避ける' },
+];
+
+export const AI_NOT_PURSUE = [
+    { target: '重大な損害をもたらす可能性のある技術', description: '身体的、精神的、社会的な深刻な被害' },
+    { target: '兵器としての AI', description: '直接的に殺傷を目的とする兵器への組み込み' },
+    { target: '監視目的の AI', description: '国際的な規範に反する個人の監視や人権侵害' },
+    { target: '国際法に違反する技術', description: '人権、プライバシー、表現の自由を侵害する利用' },
+];
+
+export const COMPUTE_SERVICES = [
+    { service: 'Compute Engine', keyword: 'VM・IaaS・OS 制御・GPU が必要', usage: 'レガシー移行・特定 OS 要件' },
+    { service: 'GKE', keyword: 'コンテナ・Kubernetes・ステートフル', usage: 'マイクロサービス・長時間処理' },
+    { service: 'Cloud Run', keyword: 'コンテナ・サーバーレス・HTTP・0 スケール', usage: 'ステートレス API・スパイクトラフィック' },
+    { service: 'Cloud Run Functions', keyword: 'FaaS・イベント駆動・軽量処理', usage: 'Webhook・トリガー・小さな関数' },
+    { service: 'App Engine', keyword: 'PaaS・Web アプリ・コードだけ', usage: 'レガシー Web アプリの移行' },
+];
+
+export const CONFUSING_PAIRS = [
+    { pair: 'Cloud Run vs Cloud Run Functions', truth: 'Cloud Run はコンテナ。Functions は関数（コード）。どちらもサーバーレス' },
+    { pair: 'Cloud SQL vs BigQuery', truth: 'Cloud SQL: OLTP（トランザクション処理）。BigQuery: OLAP（分析）' },
+    { pair: 'Dataflow vs Dataproc', truth: 'Dataflow: Apache Beam（ストリーミング + バッチ）。Dataproc: Hadoop/Spark（バッチ）' },
+    { pair: 'Committed Use vs Sustained Use', truth: 'Committed Use は事前申込が必要。Sustained Use は自動適用' },
+    { pair: '匿名化 vs 仮名化', truth: '匿名化は再識別不可（GDPR 対象外）。仮名化は再識別可能（GDPR 対象）' },
+    { pair: 'Looker vs Looker Studio', truth: 'Looker: エンタープライズ BI（有料）。Looker Studio: セルフサービス BI（無料）' },
+];
+
+export const RESOURCES = [
+    { name: '試験概要ページ', url: 'cloud.google.com/learn/certification/cloud-digital-leader' },
+    { name: '公式試験ガイド', url: 'cloud.google.com/learn/certification/guides/cloud-digital-leader' },
+    { name: 'Cloud Skills Boost 学習パス', url: 'cloudskillsboost.google/paths/9' },
+    { name: '試験登録', url: 'cp.certmetrics.com/google/en/login' },
+    { name: 'IAM ドキュメント', url: 'cloud.google.com/iam/docs' },
+    { name: 'BigQuery ドキュメント', url: 'cloud.google.com/bigquery/docs' },
+    { name: 'Vertex AI ドキュメント', url: 'cloud.google.com/vertex-ai/docs' },
+    { name: 'セキュリティ概要', url: 'cloud.google.com/security/overview' },
+    { name: 'Google AI 原則', url: 'ai.google/responsibility/principles/' },
+    { name: 'Cloud Storage クラス', url: 'cloud.google.com/storage/docs/storage-classes' },
+    { name: 'コスト最適化', url: 'cloud.google.com/architecture/framework/cost-optimization' },
+];

--- a/app/gcl/cloud-digital-leader/layout.tsx
+++ b/app/gcl/cloud-digital-leader/layout.tsx
@@ -1,0 +1,9 @@
+import './cdl.css';
+
+export default function CloudDigitalLeaderLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return <>{children}</>;
+}

--- a/app/gcl/cloud-digital-leader/page.tsx
+++ b/app/gcl/cloud-digital-leader/page.tsx
@@ -426,7 +426,7 @@ export default function CloudDigitalLeaderPage() {
                 <div className="hero-meta">
                     <span className="hero-badge">
                         <span className="dot dot-blue" />
-                        全8セクション
+                        全9セクション
                     </span>
                     <span className="hero-badge">
                         <span className="dot dot-red" />

--- a/app/gcl/cloud-digital-leader/page.tsx
+++ b/app/gcl/cloud-digital-leader/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import './cdl.css';
 
 export const metadata: Metadata = {
     title: 'Cloud Digital Leader 認定試験',

--- a/app/gcl/cloud-digital-leader/page.tsx
+++ b/app/gcl/cloud-digital-leader/page.tsx
@@ -470,7 +470,7 @@ export default function CloudDigitalLeaderPage() {
             </div>
 
             <footer className="page-footer">
-                <p>Cloud Digital Leader 認定試験 包括的解説 — 2024 Edition</p>
+                <p>Cloud Digital Leader 認定試験 包括的解説 — 2026 Edition</p>
             </footer>
         </div>
     );

--- a/app/gcl/cloud-digital-leader/page.tsx
+++ b/app/gcl/cloud-digital-leader/page.tsx
@@ -426,7 +426,7 @@ IAM ポリシーは「追加のみ」→ 上位で付与した権限は下位で
                     <div className="ctable-head">
                         <span>サービス</span><span>キーワード</span><span>役割</span>
                     </div>
-                    <div className="ctable-row"><span>Cloud IAP</span><span>DDoS・WAF・IP ブロック</span><span>VPN なし・ゼロトラストで社内アプリアクセス制御</span></div>
+                    <div className="ctable-row"><span>Cloud IAP</span><span>認証・アクセス制御・ゼロトラスト</span><span>VPN なし・ゼロトラストで社内アプリアクセス制御</span></div>
                     <div className="ctable-row"><span>Cloud Armor</span><span>DDoS・WAF・OWASP Top 10</span><span>Web アプリの DDoS 保護・SQL インジェクション・XSS ブロック</span></div>
                     <div className="ctable-row"><span>Secret Manager</span><span>API キー・パスワード管理</span><span>機密情報を安全に管理。自動ローテーション対応</span></div>
                     <div className="ctable-row"><span>Cloud KMS</span><span>暗号化キー管理・CMEK</span><span>顧客管理暗号化キーでデータをさらに強固に保護</span></div>

--- a/app/gcl/cloud-digital-leader/page.tsx
+++ b/app/gcl/cloud-digital-leader/page.tsx
@@ -7,6 +7,768 @@ export const metadata: Metadata = {
         'Google Cloud Digital Leader 包括的解説。DX・データ・AI/ML・インフラ・セキュリティ・生成AI の全領域を詳解。',
 };
 
+function SectionIntro() {
+    return (
+        <div id="s0" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn0">00</div>
+                <div className="sec-head-txt">
+                    <h2>試験概要と出題セクション</h2>
+                    <p>Cloud Digital Leader (CDL) — ビジネスリーダー・意思決定者向け Google Cloud 認定資格</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">0.1</span>試験仕様</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>項目</span><span>内容</span>
+                    </div>
+                    <div className="ctable-row"><span>試験時間</span><span>90分</span></div>
+                    <div className="ctable-row"><span>問題数</span><span>60問</span></div>
+                    <div className="ctable-row"><span>合格点</span><span>約 70%</span></div>
+                    <div className="ctable-row"><span>受験料</span><span>$200</span></div>
+                    <div className="ctable-row"><span>有効期間</span><span>3年間</span></div>
+                    <div className="ctable-row"><span>前提知識</span><span>不要（推奨: 6ヶ月以上のクラウド経験）</span></div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">0.2</span>出題セクション別 配点</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>セクション</span><span>テーマ</span><span>配点目安</span>
+                    </div>
+                    <div className="ctable-row"><span>Section 1</span><span>デジタルトランスフォーメーションと Google Cloud</span><span>~17%</span></div>
+                    <div className="ctable-row"><span>Section 2</span><span>データと Google Cloud によるイノベーション</span><span>~16%</span></div>
+                    <div className="ctable-row"><span>Section 3</span><span>インフラとアプリのモダナイゼーション</span><span>~16%</span></div>
+                    <div className="ctable-row"><span>Section 4</span><span>Google Cloud のセキュリティとオペレーション</span><span>~17%</span></div>
+                    <div className="ctable-row"><span>Section 5</span><span>AI と ML ソリューション</span><span>~16%</span></div>
+                    <div className="ctable-row"><span>その他</span><span>Google Cloud の基礎概念・費用最適化</span><span>~18%</span></div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">0.3</span>試験の受け方・準備方法</div>
+                <pre className="codeblock">{`Step 1: 公式試験ガイドを読む（必須）
+Step 2: Cloud Skills Boost の CDL ラーニングパスを修了
+Step 3: 公式サンプル問題を解く
+Step 4: cp.certmetrics.com/google から試験を予約
+
+📎 試験ページ: cloud.google.com/learn/certification/cloud-digital-leader
+📎 学習パス: cloudskillsboost.google/paths/9`}</pre>
+            </div>
+        </div>
+    );
+}
+
+function Section1() {
+    return (
+        <div id="s1" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn1">01</div>
+                <div className="sec-head-txt">
+                    <h2>DX・クラウド基礎 — デジタルトランスフォーメーションと Google Cloud</h2>
+                    <p>クラウドの5特性・IaaS/PaaS/SaaS・デプロイモデル・CapEx vs OpEx・6つのR</p>
+                </div>
+                <div className="pct-badge pb1">~17%</div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">1.1</span>クラウドの5つの本質的特性（NIST 定義）</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>特性</span><span>説明</span><span>ビジネス上の意味</span>
+                    </div>
+                    <div className="ctable-row"><span>オンデマンド・セルフサービス</span><span>人手を介さずにリソースを即時調達</span><span>IT部門の承認待ち時間ゼロ</span></div>
+                    <div className="ctable-row"><span>幅広いネットワークアクセス</span><span>任意のデバイスからアクセス可能</span><span>場所・端末を選ばない働き方</span></div>
+                    <div className="ctable-row"><span>リソースの共有（マルチテナント）</span><span>複数ユーザーで物理リソースを共有</span><span>コスト効率の向上</span></div>
+                    <div className="ctable-row"><span>迅速な弾力性（エラスティシティ）</span><span>需要に応じて自動でスケール</span><span>急なトラフィック増にも対応</span></div>
+                    <div className="ctable-row"><span>計測されたサービス</span><span>使用量に応じた従量課金</span><span>使った分だけ払う経済合理性</span></div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">1.2</span>クラウドサービスモデル（IaaS / PaaS / SaaS）</div>
+                <pre className="codeblock">{`責任の分担（下が基盤、上がユーザー責任）
+
+┌─────────────────┬─────────────────┬─────────────────┐
+│     IaaS         │     PaaS         │     SaaS         │
+│  Infrastructure  │    Platform      │    Software      │
+│  as a Service    │  as a Service    │  as a Service    │
+├─────────────────┼─────────────────┼─────────────────┤
+│ アプリ [USER]    │ アプリ [USER]    │         [USER]   │
+│ ランタイム [USER]│ ランタイム [GCP] │         [GCP]    │
+│ OS [USER]        │ OS      [GCP]    │         [GCP]    │
+│ 仮想化  [GCP]    │ 仮想化  [GCP]    │         [GCP]    │
+│ ハード  [GCP]    │ ハード  [GCP]    │         [GCP]    │
+└─────────────────┴─────────────────┴─────────────────┘
+例: Compute Engine  Cloud Run / App   Google Workspace
+                    Engine            Gmail / Drive`}</pre>
+                <div className="tgrid">
+                    <div className="titem"><div className="tname">IaaS（Compute Engine など）</div><div className="tdef">OS・MWを自分で管理。リフト&シフト移行・最大の柔軟性が必要なワークロード向け</div></div>
+                    <div className="titem"><div className="tname">PaaS（App Engine・Cloud Run など）</div><div className="tdef">インフラ管理なしにアプリ開発に集中。開発者の生産性を最大化</div></div>
+                    <div className="titem"><div className="tname">SaaS（Google Workspace など）</div><div className="tdef">インストール・管理不要でソフトウェアをすぐ使える。Gmail・Docs・Sheets</div></div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">1.3</span>クラウドデプロイメントモデル</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>モデル</span><span>説明</span><span>適用場面</span>
+                    </div>
+                    <div className="ctable-row"><span>パブリッククラウド</span><span>GCP・AWS・Azure が提供する共有インフラ</span><span>コスト最適化・スケーラビリティ重視</span></div>
+                    <div className="ctable-row"><span>プライベートクラウド</span><span>企業専用のクラウド環境（オンプレ）</span><span>高いセキュリティ・コンプライアンス要件</span></div>
+                    <div className="ctable-row"><span>ハイブリッドクラウド</span><span>パブリック + プライベートを組み合わせ</span><span>段階的移行・データ主権の確保</span></div>
+                    <div className="ctable-row"><span>マルチクラウド</span><span>複数のクラウドプロバイダーを利用</span><span>ベンダーロックイン回避・最適サービス選択</span></div>
+                </div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: デプロイメントモデル選定</div>
+                    <ul>
+                        <li><strong>コスト優先</strong>: パブリッククラウドを選択。CapEx から OpEx へ転換</li>
+                        <li><strong>規制対応</strong>: 金融・医療など規制産業ではハイブリッドを検討</li>
+                        <li><strong>既存投資保護</strong>: オンプレの設備投資が残っている場合はハイブリッドで段階移行</li>
+                        <li><strong>ベンダー分散</strong>: 単一障害点を避けるためマルチクラウド戦略を検討</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">1.4</span>CapEx vs OpEx とクラウド移行の DX 価値</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>概念</span><span>説明</span><span>クラウドとの関係</span>
+                    </div>
+                    <div className="ctable-row"><span>CapEx（資本支出）</span><span>設備・サーバー等への先行投資。資産として計上</span><span>オンプレミス運用の特徴</span></div>
+                    <div className="ctable-row"><span>OpEx（運用費用）</span><span>月次・年次の運用コスト。費用として計上</span><span>クラウドの特徴（使った分だけ払う）</span></div>
+                </div>
+                <pre className="codeblock">{`Google Cloud の DX を加速する3つの柱:
+
+1. インフラの近代化
+   └── オンプレ → クラウドへの移行・レガシーシステムの刷新
+   └── コスト削減・俊敏性向上
+
+2. データと AI の活用
+   └── データドリブン意思決定・AI/ML で業務自動化・予測
+
+3. スマートアナリティクス
+   └── ビジネスインテリジェンス・顧客インサイト・新ビジネスモデル`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">1.5</span>クラウド移行戦略（6つの R）</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>戦略</span><span>別名</span><span>説明</span><span>コスト</span><span>期間</span>
+                    </div>
+                    <div className="ctable-row"><span>Rehost</span><span>リフト&シフト</span><span>そのままクラウドへ移動</span><span>低</span><span>短</span></div>
+                    <div className="ctable-row"><span>Replatform</span><span>リフト&調整&シフト</span><span>最小限の変更でクラウド最適化</span><span>中</span><span>中</span></div>
+                    <div className="ctable-row"><span>Repurchase</span><span>ドロップ&ショッピング</span><span>SaaS 製品への乗り換え</span><span>中</span><span>中</span></div>
+                    <div className="ctable-row"><span>Refactor</span><span>リアーキテクチャ</span><span>クラウドネイティブへ再設計</span><span>高</span><span>長</span></div>
+                    <div className="ctable-row"><span>Retire</span><span>廃止</span><span>不要なシステムを廃止</span><span>なし</span><span>短</span></div>
+                    <div className="ctable-row"><span>Retain</span><span>保持</span><span>当面オンプレに残す</span><span>なし</span><span>—</span></div>
+                </div>
+                <div className="wb">
+                    <div className="wbt">試験ポイント</div>
+                    <p>「最も速く・安く移行する」= Rehost（リフト&シフト）。「クラウドのメリットを最大限活かす」= Refactor。</p>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Section2() {
+    return (
+        <div id="s2" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn2">02</div>
+                <div className="sec-head-txt">
+                    <h2>データとイノベーション — データ管理・分析・BI サービス</h2>
+                    <p>DB 選定・BigQuery・Looker・Dataflow・Dataproc・ストレージクラス</p>
+                </div>
+                <div className="pct-badge pb2">~16%</div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">2.1</span>データが生み出す 4 つのビジネス価値</div>
+                <div className="tgrid">
+                    <div className="titem"><div className="tname">1. 過去の理解（記述的分析）</div><div className="tdef">何が起きたかを把握</div></div>
+                    <div className="titem"><div className="tname">2. 現状の把握（診断的分析）</div><div className="tdef">今何が起きているかをリアルタイムで監視</div></div>
+                    <div className="titem"><div className="tname">3. 未来の予測（予測的分析）</div><div className="tdef">次に何が起きるかを予測</div></div>
+                    <div className="titem"><div className="tname">4. 最適行動の提案（処方的分析）</div><div className="tdef">何をすべきかを AI が提案</div></div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">2.2</span>データベースサービス一覧と選択基準</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>サービス</span><span>タイプ</span><span>特徴</span><span>適用場面</span>
+                    </div>
+                    <div className="ctable-row"><span>Cloud SQL</span><span>マネージド RDBMS</span><span>MySQL・PostgreSQL・SQL Server 対応。垂直スケール</span><span>既存 RDB のクラウド移行・Web アプリ</span></div>
+                    <div className="ctable-row"><span>Cloud Spanner</span><span>グローバル分散 RDBMS</span><span>99.999% SLA。世界規模の強一貫性</span><span>金融・在庫管理・グローバル EC</span></div>
+                    <div className="ctable-row"><span>Firestore</span><span>NoSQL ドキュメント</span><span>サーバーレス・リアルタイム同期</span><span>モバイル/Web アプリのバックエンド</span></div>
+                    <div className="ctable-row"><span>Bigtable</span><span>NoSQL ワイドカラム</span><span>超高スループット・超低遅延</span><span>時系列・IoT・広告データ</span></div>
+                    <div className="ctable-row"><span>BigQuery</span><span>データウェアハウス</span><span>サーバーレス SQL 分析。数 TB を数秒で処理</span><span>BI・データ分析・機械学習</span></div>
+                    <div className="ctable-row"><span>Memorystore</span><span>インメモリ DB</span><span>マネージド Redis/Memcached</span><span>セッション管理・キャッシュ</span></div>
+                    <div className="ctable-row"><span>AlloyDB</span><span>PostgreSQL 互換</span><span>Cloud SQL より高速な分析性能（HTAP）</span><span>高性能トランザクション + 分析</span></div>
+                </div>
+                <pre className="codeblock">{`DB 選択フロー:
+
+RDB が必要か？
+├── YES: グローバルに強一貫性が必要 → Cloud Spanner
+└── YES: リージョン内で十分       → Cloud SQL
+
+NoSQL が必要か？
+├── ドキュメント形式・リアルタイム → Firestore
+├── 時系列・超大量データ          → Bigtable
+└── キャッシュ・セッション         → Memorystore
+
+分析・DWH 用途                    → BigQuery`}</pre>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: データベース選択</div>
+                    <ul>
+                        <li>グローバルな強一貫性が必要 → Cloud Spanner（コストは高いが 99.999% SLA）</li>
+                        <li>既存 MySQL/PostgreSQL の移行 → Cloud SQL（最も簡単な移行パス）</li>
+                        <li>大量データの SQL 分析 → BigQuery（サーバーレス・ペタバイトスケール）</li>
+                        <li>リアルタイム同期が必要な モバイルアプリ → Firestore</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">2.3</span>データ分析・BI サービス</div>
+                <div className="tgrid">
+                    <div className="titem"><div className="tname">Looker（エンタープライズ BI）</div><div className="tdef">LookML で全社データ定義を一元管理。「真実の唯一の情報源」。経営ダッシュボード・売上レポート向け</div></div>
+                    <div className="titem"><div className="tname">Looker Studio（旧 Data Studio）</div><div className="tdef">無料のセルフサービス BI。コードなしでインタラクティブなレポートを作成。Google Sheets・BigQuery と連携</div></div>
+                    <div className="titem"><div className="tname">Cloud Dataflow</div><div className="tdef">フルマネージドのデータ処理パイプライン（Apache Beam）。ストリーミング + バッチの両方に対応。ログ処理・IoT データ変換・ETL</div></div>
+                    <div className="titem"><div className="tname">Cloud Dataproc</div><div className="tdef">マネージド Apache Hadoop/Spark クラスタ。既存の Hadoop ワークロードをクラウドへ移行。必要な時だけ起動してコスト削減</div></div>
+                    <div className="titem"><div className="tname">Cloud Pub/Sub</div><div className="tdef">フルマネージドのメッセージングサービス。イベント駆動アーキテクチャの基盤。1秒あたり数百万メッセージを処理可能</div></div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">2.4</span>Cloud Storage のストレージクラス</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>クラス</span><span>アクセス頻度</span><span>最小保存期間</span><span>ユースケース</span>
+                    </div>
+                    <div className="ctable-row"><span>Standard</span><span>頻繁</span><span>なし</span><span>Web コンテンツ・アクティブデータ</span></div>
+                    <div className="ctable-row"><span>Nearline</span><span>月1回程度</span><span>30 日</span><span>バックアップ・月次レポート</span></div>
+                    <div className="ctable-row"><span>Coldline</span><span>四半期1回程度</span><span>90 日</span><span>アーカイブ・DR 用バックアップ</span></div>
+                    <div className="ctable-row"><span>Archive</span><span>年1回未満</span><span>365 日</span><span>長期保管・規制対応アーカイブ</span></div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Section3() {
+    return (
+        <div id="s3" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn3">03</div>
+                <div className="sec-head-txt">
+                    <h2>インフラとモダナイゼーション — コンピューティング・ネットワーク・マネージドサービス</h2>
+                    <p>Compute Engine・GKE・Cloud Run・コンテナ・VPC・Cloud Interconnect</p>
+                </div>
+                <div className="pct-badge pb3">~16%</div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.1</span>コンピューティングサービスの比較と選択</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>サービス</span><span>キーワード</span><span>使い分け</span>
+                    </div>
+                    <div className="ctable-row"><span>Compute Engine</span><span>VM・IaaS・OS 制御・GPU</span><span>レガシー移行・特定 OS 要件・最大の柔軟性</span></div>
+                    <div className="ctable-row"><span>GKE</span><span>コンテナ・Kubernetes・ステートフル</span><span>マイクロサービス・長時間処理</span></div>
+                    <div className="ctable-row"><span>Cloud Run</span><span>コンテナ・サーバーレス・HTTP・0 スケール</span><span>ステートレス API・スパイクトラフィック</span></div>
+                    <div className="ctable-row"><span>Cloud Run Functions</span><span>FaaS・イベント駆動・軽量処理</span><span>Webhook・トリガー・小さな関数</span></div>
+                    <div className="ctable-row"><span>App Engine</span><span>PaaS・Web アプリ・コードだけ</span><span>レガシー Web アプリの移行</span></div>
+                </div>
+                <pre className="codeblock">{`コンピューティングサービス選択フロー:
+
+OS・ミドルウェアの制御が必要         → Compute Engine
+コンテナ + ステートフル/長時間処理    → GKE
+コンテナ + ステートレス HTTP API      → Cloud Run
+イベント駆動 + 短時間の小さな関数     → Cloud Run Functions
+コード書くだけでOK（PaaS）           → App Engine
+0スケールでコスト最小化              → Cloud Run / Cloud Run Functions`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.2</span>コンテナと VM の違い</div>
+                <pre className="codeblock">{`従来の VM:                コンテナ:
+┌──────────────┐        ┌──────────────┐
+│    App A      │        │ App A | App B │
+│  バイナリ/Lib │        │  バイナリ/Lib│
+│  ゲスト OS    │        ├──────────────┤
+├──────────────┤        │コンテナランタイム│
+│   Hypervisor  │        │  ホスト OS    │
+│   ホスト OS   │        │  ハードウェア │
+│   ハードウェア│        └──────────────┘
+└──────────────┘
+→ 重くて起動が遅い       → 軽くて起動が速い`}</pre>
+                <div className="tgrid">
+                    <div className="titem"><div className="tname">GKE Autopilot</div><div className="tdef">Google が完全管理。Pod 単位課金。運用負荷を最小化したい場合に最適</div></div>
+                    <div className="titem"><div className="tname">GKE Standard</div><div className="tdef">ユーザーがノードを管理。ノード VM 課金。細かいノード制御が必要な場合</div></div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.3</span>ネットワークサービス</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>サービス</span><span>説明</span><span>帯域/用途</span>
+                    </div>
+                    <div className="ctable-row"><span>VPC（Virtual Private Cloud）</span><span>グローバルに展開するソフトウェア定義ネットワーク</span><span>プロジェクト間の分離・ファイアウォールルール</span></div>
+                    <div className="ctable-row"><span>Cloud Load Balancing</span><span>グローバル/リージョナルの自動スケーリング対応ロードバランサー</span><span>HTTP/HTTPS トラフィックの分散</span></div>
+                    <div className="ctable-row"><span>Cloud CDN</span><span>Google のグローバルネットワークでコンテンツをキャッシュ・高速配信</span><span>静的コンテンツのレイテンシ削減</span></div>
+                    <div className="ctable-row"><span>Dedicated Interconnect</span><span>専用回線で GCP と直接接続</span><span>10/100Gbps — 大量データ転送</span></div>
+                    <div className="ctable-row"><span>Partner Interconnect</span><span>パートナー経由の専用接続</span><span>50Mbps〜50Gbps</span></div>
+                    <div className="ctable-row"><span>Cloud VPN</span><span>インターネット経由 IPsec トンネル</span><span>最大 3Gbps/トンネル — 低コスト接続</span></div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">3.4</span>マネージドサービスとサーバーレスの価値</div>
+                <pre className="codeblock">{`管理責任の分担:
+
+           オンプレミス  IaaS(GCE)  PaaS(AppEng)  サーバーレス
+アプリ        [自社]      [自社]      [自社]         [自社]
+ランタイム    [自社]      [自社]      [自社]         [GCP]
+OS            [自社]      [自社]      [自社]         [GCP]
+ミドルウェア  [自社]      [GCP]       [GCP]          [GCP]
+仮想化        [自社]      [GCP]       [GCP]          [GCP]
+ハードウェア  [自社]      [GCP]       [GCP]          [GCP]`}</pre>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: マネージドサービス活用</div>
+                    <ul>
+                        <li>差別化されない重労働（インフラ管理・パッチ適用）は<strong>マネージドサービスに委譲</strong></li>
+                        <li>エンジニアはビジネス価値を生む<strong>アプリケーション開発に集中</strong></li>
+                        <li>Spot/Preemptible VM を活用してバッチ処理のコストを最大 91% 削減</li>
+                        <li>Sustained Use Discount（自動割引 30%）と Committed Use Discount（最大 57%）を理解する</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Section4() {
+    return (
+        <div id="s4" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn4">04</div>
+                <div className="sec-head-txt">
+                    <h2>セキュリティとオペレーション — IAM・多層防御・費用管理</h2>
+                    <p>IAM・リソース階層・Cloud Armor・KMS・SCC・Cloud Monitoring・コスト最適化</p>
+                </div>
+                <div className="pct-badge pb4">~17%</div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">4.1</span>Google Cloud のセキュリティ設計思想（多層防御）</div>
+                <pre className="codeblock">{`Layer 7: データ        暗号化・DLP・アクセス制御
+Layer 6: ユーザー      IAM・MFA・Cloud Identity
+Layer 5: アプリ        脆弱性スキャン・Container Analysis
+Layer 4: エンドポイント Chrome Enterprise・BeyondCorp
+Layer 3: ネットワーク  VPC・ファイアウォール・Cloud Armor
+Layer 2: インフラ      Shielded VMs・Confidential Computing
+Layer 1: ハードウェア  Titan チップ・物理セキュリティ`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">4.2</span>IAM（Identity and Access Management）</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>ロール種別</span><span>説明</span><span>推奨度</span>
+                    </div>
+                    <div className="ctable-row"><span>基本ロール</span><span>Owner / Editor / Viewer。プロジェクト全体に適用</span><span>❌ 本番環境では非推奨</span></div>
+                    <div className="ctable-row"><span>事前定義ロール</span><span>特定サービスに最適化されたロール</span><span>✅ 推奨</span></div>
+                    <div className="ctable-row"><span>カスタムロール</span><span>必要な権限のみを組み合わせた自作ロール</span><span>✅ 最小権限の原則を徹底</span></div>
+                </div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: IAM</div>
+                    <ul>
+                        <li><strong>最小権限の原則</strong>: 必要最小限のロールのみを付与</li>
+                        <li><strong>グループ管理</strong>: 個人ではなくグループにロールを付与</li>
+                        <li><strong>サービスアカウントキー</strong>: 可能な限り発行せず、Workload Identity Federation を使用</li>
+                        <li><strong>定期レビュー</strong>: 不要なロールの付与を定期的に棚卸し</li>
+                        <li><strong>2 段階認証（MFA）</strong>: 全ユーザーに強制する</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">4.3</span>リソース階層とポリシー継承</div>
+                <pre className="codeblock">{`組織（Organization）
+    │
+    ├── フォルダ（Folder）←── 部門・環境でグループ化
+    │       │
+    │       ├── プロジェクト（Project）
+    │       │       │
+    │       │       └── リソース（VM・GCS・DB等）
+    │       │
+    │       └── プロジェクト（Project）
+    │
+    └── フォルダ（Folder）
+
+ポリシーは上位から下位へ継承される（上書き不可）
+IAM ポリシーは「追加のみ」→ 上位で付与した権限は下位でも有効`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">4.4</span>主要セキュリティサービス</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>サービス</span><span>キーワード</span><span>役割</span>
+                    </div>
+                    <div className="ctable-row"><span>Cloud IAP</span><span>DDoS・WAF・IP ブロック</span><span>VPN なし・ゼロトラストで社内アプリアクセス制御</span></div>
+                    <div className="ctable-row"><span>Cloud Armor</span><span>DDoS・WAF・OWASP Top 10</span><span>Web アプリの DDoS 保護・SQL インジェクション・XSS ブロック</span></div>
+                    <div className="ctable-row"><span>Secret Manager</span><span>API キー・パスワード管理</span><span>機密情報を安全に管理。自動ローテーション対応</span></div>
+                    <div className="ctable-row"><span>Cloud KMS</span><span>暗号化キー管理・CMEK</span><span>顧客管理暗号化キーでデータをさらに強固に保護</span></div>
+                    <div className="ctable-row"><span>Security Command Center</span><span>脅威・脆弱性の一元可視化</span><span>リスクの検出・優先順位付け・修復ガイダンス</span></div>
+                    <div className="ctable-row"><span>Sensitive Data Protection（DLP）</span><span>PII 検出・マスキング</span><span>個人情報を自動検出・分類。GDPR・HIPAA 対応</span></div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">4.5</span>コンプライアンスと規制対応</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>規制/認証</span><span>対象業界</span><span>説明</span>
+                    </div>
+                    <div className="ctable-row"><span>ISO 27001</span><span>全業種</span><span>情報セキュリティ管理の国際規格</span></div>
+                    <div className="ctable-row"><span>SOC 2 / SOC 3</span><span>全業種</span><span>システムの信頼性・セキュリティの監査報告</span></div>
+                    <div className="ctable-row"><span>PCI DSS</span><span>金融・EC</span><span>クレジットカード情報の取り扱い基準</span></div>
+                    <div className="ctable-row"><span>HIPAA</span><span>医療（米国）</span><span>医療情報の保護に関する規制</span></div>
+                    <div className="ctable-row"><span>GDPR</span><span>EU 圏</span><span>欧州個人データ保護規則</span></div>
+                    <div className="ctable-row"><span>FedRAMP</span><span>米国政府</span><span>連邦政府クラウドサービスの安全基準</span></div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">4.6</span>費用管理と最適化</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>割引概念</span><span>説明</span>
+                    </div>
+                    <div className="ctable-row"><span>従量課金</span><span>使用した分だけ支払う（秒単位課金が多い）</span></div>
+                    <div className="ctable-row"><span>Sustained Use Discount</span><span>月間で一定時間以上使うと自動で最大 30% 割引（申込不要）</span></div>
+                    <div className="ctable-row"><span>Committed Use Discount</span><span>1 年/3 年コミットで最大 57% 割引（Compute Engine・事前申込必要）</span></div>
+                    <div className="ctable-row"><span>Spot/Preemptible VM</span><span>通常比最大 91% 安価（中断の可能性あり）</span></div>
+                </div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: コスト最適化</div>
+                    <ul>
+                        <li><strong>右サイズ化</strong>: 過剰スペックの VM をダウンサイズ（Active Assist が自動提案）</li>
+                        <li><strong>使われていないリソースの削除</strong>: 停止中の VM・未使用の IP アドレス</li>
+                        <li><strong>Spot VM の活用</strong>: バッチ処理・CI/CD などに</li>
+                        <li><strong>Committed Use の適用</strong>: 安定したワークロードには長期契約が得（Sustained Use との違いを理解）</li>
+                        <li><strong>予算アラート設定</strong>: 50%・90%・100% 消費時に通知</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Section5() {
+    return (
+        <div id="s5" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn5">05</div>
+                <div className="sec-head-txt">
+                    <h2>AI と ML ソリューション — プリビルト API・AutoML・Vertex AI・生成 AI</h2>
+                    <p>AI 階層・機械学習 3 アプローチ・Gemini・RAG・責任ある AI</p>
+                </div>
+                <div className="pct-badge pb5">~16%</div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.1</span>AI の階層的理解</div>
+                <pre className="codeblock">{`AI（人工知能）: 人間の知的行動をコンピュータで模倣する技術全般
+  └── ML（機械学習）: データからパターンを自動学習
+        └── 深層学習（Deep Learning）: 多層ニューラルネットワーク
+              └── 生成AI（Generative AI）: 新しいコンテンツを生成
+                    └── LLM（大規模言語モデル）: テキスト生成に特化`}</pre>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>アプローチ</span><span>データ形式</span><span>代表例</span>
+                    </div>
+                    <div className="ctable-row"><span>教師あり学習</span><span>正解ラベル付きデータ</span><span>スパム分類・需要予測・画像認識</span></div>
+                    <div className="ctable-row"><span>教師なし学習</span><span>ラベルなしデータ</span><span>顧客セグメンテーション・異常検知</span></div>
+                    <div className="ctable-row"><span>強化学習</span><span>報酬シグナル</span><span>ゲーム AI・自動運転・RLHF</span></div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.2</span>Google Cloud AI/ML サービス階層</div>
+                <pre className="codeblock">{`【使いやすさ重視】 ←────────────────────────→ 【カスタマイズ重視】
+
+プリビルト AI API    AutoML          Vertex AI カスタムモデル
+(API呼び出すだけ)   (ノーコード ML)   (フルコントロール)
+
+エンジニア不要      ML の専門知識不要  ML エンジニア必要
+コスト最小          中程度             最大コスト
+柔軟性低            中程度             最大柔軟性`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.3</span>プリビルト AI API（事前学習済みモデル API）</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>API</span><span>機能</span><span>ユースケース</span>
+                    </div>
+                    <div className="ctable-row"><span>Vision API</span><span>画像認識・ラベル付け・OCR・顔検出</span><span>商品画像タグ付け・文書デジタル化</span></div>
+                    <div className="ctable-row"><span>Natural Language API</span><span>感情分析・エンティティ抽出・分類</span><span>レビュー分析・チケット自動分類</span></div>
+                    <div className="ctable-row"><span>Translation API</span><span>130 以上の言語間翻訳</span><span>多言語コンテンツ・グローバル対応</span></div>
+                    <div className="ctable-row"><span>Speech-to-Text API</span><span>音声→テキスト変換</span><span>コールセンター文字起こし・音声コマンド</span></div>
+                    <div className="ctable-row"><span>Document AI API</span><span>PDF・文書の構造化データ抽出</span><span>請求書処理自動化・契約書解析</span></div>
+                    <div className="ctable-row"><span>Video Intelligence API</span><span>動画内シーン検出・物体認識</span><span>動画コンテンツ分類・監視映像分析</span></div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.4</span>Gemini モデルファミリー（生成 AI）</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>モデル</span><span>特徴</span><span>主な用途</span>
+                    </div>
+                    <div className="ctable-row"><span>Gemini Ultra</span><span>最高精度・最大規模</span><span>複雑な推論・マルチモーダルタスク</span></div>
+                    <div className="ctable-row"><span>Gemini Pro</span><span>性能とコストのバランス</span><span>多様なビジネスタスク・RAG</span></div>
+                    <div className="ctable-row"><span>Gemini Flash</span><span>高速・低コスト</span><span>大量処理・リアルタイムアプリ</span></div>
+                    <div className="ctable-row"><span>Gemini Nano</span><span>小型・オンデバイス</span><span>エッジデバイス・スマートフォン</span></div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.5</span>RAG・ハルシネーション・ファインチューニング</div>
+                <pre className="codeblock">{`【RAG（Retrieval-Augmented Generation）】
+
+通常の LLM:  プロンプト → LLM → 回答（学習データのみから生成）
+                                   ↑ ハルシネーションのリスクあり
+
+RAG:         プロンプト → 検索エンジン → 関連文書を取得
+                               ↓
+                   プロンプト + 文書 → LLM → 根拠ある回答
+                                               ↑ ハルシネーション大幅減少
+
+RAG のメリット:
+  ├── 最新情報に対応（モデルの知識カットオフを超えられる）
+  ├── 企業固有の知識を活用
+  └── 回答に根拠（ソース）を提示できる`}</pre>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">5.6</span>責任ある AI（Responsible AI）— Google AI の 6 原則</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>原則</span><span>説明</span>
+                    </div>
+                    <div className="ctable-row"><span>公平性（Fairness）</span><span>バイアスのない公平な出力</span></div>
+                    <div className="ctable-row"><span>透明性（Transparency）</span><span>AI であることを開示・判断根拠の説明</span></div>
+                    <div className="ctable-row"><span>説明可能性（Explainability）</span><span>なぜその判断をしたかを説明できる</span></div>
+                    <div className="ctable-row"><span>プライバシー（Privacy）</span><span>個人データの最小収集・適切な管理</span></div>
+                    <div className="ctable-row"><span>説明責任（Accountability）</span><span>AI 判断の責任を持つ人間が存在すること</span></div>
+                    <div className="ctable-row"><span>安全性（Safety）</span><span>有害コンテンツ生成の防止・セーフガード</span></div>
+                </div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: AI サービス選択</div>
+                    <ul>
+                        <li>コード少なく汎用タスク → <strong>プリビルト AI API</strong>（Vision・NL・Translation など）</li>
+                        <li>独自データでカスタムモデル（ML 知識不要）→ <strong>AutoML</strong></li>
+                        <li>フル機能 ML・本番向け → <strong>Vertex AI</strong>（MLエンジニアが必要）</li>
+                        <li>ハルシネーションを低減したい → <strong>RAG + Grounding</strong> を活用</li>
+                        <li>オフィス業務の AI 化 → <strong>Gemini for Google Workspace</strong></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Section6() {
+    return (
+        <div id="s6" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn6">06</div>
+                <div className="sec-head-txt">
+                    <h2>サービス早見表 — カテゴリ別・混同ペア</h2>
+                    <p>コンピューティング・ストレージ/DB・AI/ML・セキュリティ・オペレーション</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">6.1</span>コンピューティングサービス早見表</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>サービス</span><span>キーワード</span><span>使い分け</span>
+                    </div>
+                    <div className="ctable-row"><span>Compute Engine</span><span>VM・IaaS・OS 制御・GPU が必要</span><span>レガシー移行・特定 OS 要件</span></div>
+                    <div className="ctable-row"><span>GKE</span><span>コンテナ・Kubernetes・ステートフル</span><span>マイクロサービス・長時間処理</span></div>
+                    <div className="ctable-row"><span>Cloud Run</span><span>コンテナ・サーバーレス・HTTP・0 スケール</span><span>ステートレス API・スパイクトラフィック</span></div>
+                    <div className="ctable-row"><span>Cloud Run Functions</span><span>FaaS・イベント駆動・軽量処理</span><span>Webhook・トリガー・小さな関数</span></div>
+                    <div className="ctable-row"><span>App Engine</span><span>PaaS・Web アプリ・コードだけ</span><span>レガシー Web アプリの移行</span></div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">6.2</span>よく混同されるサービスペア</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>混同ペア</span><span>正しい理解</span>
+                    </div>
+                    <div className="ctable-row"><span>Cloud Run vs Cloud Run Functions</span><span>Cloud Run はコンテナ。Functions は関数（コード）。どちらもサーバーレス</span></div>
+                    <div className="ctable-row"><span>Cloud SQL vs BigQuery</span><span>Cloud SQL: OLTP（トランザクション処理）。BigQuery: OLAP（分析）</span></div>
+                    <div className="ctable-row"><span>Dataflow vs Dataproc</span><span>Dataflow: Apache Beam（ストリーミング + バッチ）。Dataproc: Hadoop/Spark（バッチ）</span></div>
+                    <div className="ctable-row"><span>Committed Use vs Sustained Use</span><span>Committed Use は事前申込が必要。Sustained Use は自動適用</span></div>
+                    <div className="ctable-row"><span>匿名化 vs 仮名化</span><span>匿名化は再識別不可（GDPR 対象外）。仮名化は再識別可能（GDPR 対象）</span></div>
+                    <div className="ctable-row"><span>Looker vs Looker Studio</span><span>Looker: エンタープライズ BI（有料）。Looker Studio: セルフサービス BI（無料）</span></div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function Section7() {
+    return (
+        <div id="s7" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn7">07</div>
+                <div className="sec-head-txt">
+                    <h2>試験攻略チェックリスト — 必ず押さえるべき概念</h2>
+                    <p>セクション別チェックリスト・学習ロードマップ・試験当日のポイント</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">7.1</span>必ず押さえるべき概念（各セクション）</div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: Section 1 — DX とクラウド基礎</div>
+                    <ul>
+                        <li>IaaS / PaaS / SaaS の違いと具体例（Compute Engine / App Engine / Google Workspace）</li>
+                        <li>パブリック・プライベート・ハイブリッド・マルチクラウドの違い</li>
+                        <li>CapEx vs OpEx の違いとクラウドとの関係</li>
+                        <li>クラウド移行の 6 つの R（Rehost・Replatform・Refactor・Repurchase・Retire・Retain）</li>
+                    </ul>
+                </div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: Section 2 — データとイノベーション</div>
+                    <ul>
+                        <li>BigQuery とはどんなサービスか（DWH・サーバーレス・SQL 分析）</li>
+                        <li>Cloud Storage のストレージクラス 4 種（Standard・Nearline・Coldline・Archive）</li>
+                        <li>DB 選択基準（RDB vs NoSQL、グローバル一貫性 vs リージョン）</li>
+                        <li>Looker / Looker Studio の違い（エンタープライズ BI vs セルフサービス）</li>
+                        <li>Pub/Sub・Dataflow・Dataproc の役割の違い</li>
+                    </ul>
+                </div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: Section 3 — インフラとモダナイゼーション</div>
+                    <ul>
+                        <li>コンテナと VM の違い</li>
+                        <li>Compute Engine / GKE / Cloud Run / Cloud Run Functions の使い分け</li>
+                        <li>GKE Autopilot と Standard の違い</li>
+                        <li>Cloud Interconnect vs Cloud VPN の使い分け</li>
+                        <li>Spot/Preemptible VM はいつ使うか</li>
+                    </ul>
+                </div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: Section 4 — セキュリティとオペレーション</div>
+                    <ul>
+                        <li>IAM の最小権限の原則・グループ管理</li>
+                        <li>リソース階層（組織→フォルダ→プロジェクト→リソース）</li>
+                        <li>Cloud Armor・Cloud KMS・Secret Manager・IAP・SCC の役割</li>
+                        <li>監査ログの種類（Admin Activity・Data Access・System Event の違い）</li>
+                        <li>費用最適化の手段（Committed Use・Spot VM・右サイズ化）</li>
+                    </ul>
+                </div>
+                <div className="bp">
+                    <div className="bpt">ベストプラクティス: Section 5 — AI/ML</div>
+                    <ul>
+                        <li>プリビルト API vs AutoML vs Vertex AI カスタムモデルの使い分け</li>
+                        <li>Gemini の 4 バリアント（Ultra・Pro・Flash・Nano）の特徴</li>
+                        <li>RAG とは何か・なぜハルシネーションを減らせるか</li>
+                        <li>責任ある AI の 6 原則</li>
+                        <li>匿名化 vs 仮名化の違い（再識別可能かどうか）</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">7.2</span>推奨学習ロードマップ</div>
+                <pre className="codeblock">{`Week 1-2: 基礎概念の固め
+├── Cloud の基本概念（IaaS/PaaS/SaaS、デプロイモデル）
+├── Google Cloud のコアサービス概要
+└── Cloud Skills Boost の入門コースを修了
+
+Week 3-4: 主要サービスの理解
+├── コンピューティング・ストレージ・ネットワーク
+├── データ分析・データベースサービス
+└── セキュリティの基本（IAM・暗号化）
+
+Week 5: AI/ML と総まとめ
+├── AI API の種類と使い分け
+├── 生成 AI（Gemini・RAG・ファインチューニング）
+└── 責任ある AI
+
+Week 6: 試験直前対策
+├── 公式サンプル問題を繰り返し解く
+├── 間違えた問題の公式ドキュメントを読む
+└── 頻出サービス早見表を暗記`}</pre>
+            </div>
+        </div>
+    );
+}
+
+function Section8() {
+    return (
+        <div id="s8" className="sgap">
+            <div className="sec-head">
+                <div className="sec-num sn8">08</div>
+                <div className="sec-head-txt">
+                    <h2>参照リソース — 公式ドキュメント・学習パス・試験登録</h2>
+                    <p>試験当日のポイント・公式参照リソース一覧</p>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">8.1</span>試験当日のポイント</div>
+                <div className="tgrid">
+                    <div className="titem"><div className="tname">「ビジネスリーダー」の視点で解答</div><div className="tdef">技術詳細より「ビジネス価値・コスト効率・生産性向上」を重視</div></div>
+                    <div className="titem"><div className="tname">Google Cloud 固有のサービス名を覚える</div><div className="tdef">一般用語ではなく Google Cloud 固有の名前で選択肢を判断</div></div>
+                    <div className="titem"><div className="tname">「最も適切な」に注意</div><div className="tdef">複数が正しい場合でも「最もシンプル」「最もコスト効率が良い」を選ぶ</div></div>
+                    <div className="titem"><div className="tname">セキュリティ問題は最小権限の原則</div><div className="tdef">権限を広く与えるより絞る方が正解</div></div>
+                    <div className="titem"><div className="tname">マネージドサービス優先</div><div className="tdef">「自分で管理する」より「マネージドサービスを使う」が Google の推奨</div></div>
+                </div>
+            </div>
+
+            <div className="tcard">
+                <div className="ttitle"><span className="tid">8.2</span>公式参照リソース一覧</div>
+                <div className="ctable">
+                    <div className="ctable-head">
+                        <span>リソース</span><span>URL</span>
+                    </div>
+                    <div className="ctable-row"><span>試験概要ページ</span><span>cloud.google.com/learn/certification/cloud-digital-leader</span></div>
+                    <div className="ctable-row"><span>公式試験ガイド</span><span>cloud.google.com/learn/certification/guides/cloud-digital-leader</span></div>
+                    <div className="ctable-row"><span>Cloud Skills Boost 学習パス</span><span>cloudskillsboost.google/paths/9</span></div>
+                    <div className="ctable-row"><span>試験登録</span><span>cp.certmetrics.com/google/en/login</span></div>
+                    <div className="ctable-row"><span>IAM ドキュメント</span><span>cloud.google.com/iam/docs</span></div>
+                    <div className="ctable-row"><span>BigQuery ドキュメント</span><span>cloud.google.com/bigquery/docs</span></div>
+                    <div className="ctable-row"><span>Vertex AI ドキュメント</span><span>cloud.google.com/vertex-ai/docs</span></div>
+                    <div className="ctable-row"><span>セキュリティ概要</span><span>cloud.google.com/security/overview</span></div>
+                    <div className="ctable-row"><span>Google AI 原則</span><span>ai.google/responsibility/principles/</span></div>
+                    <div className="ctable-row"><span>Cloud Storage クラス</span><span>cloud.google.com/storage/docs/storage-classes</span></div>
+                    <div className="ctable-row"><span>コスト最適化</span><span>cloud.google.com/architecture/framework/cost-optimization</span></div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
 export default function CloudDigitalLeaderPage() {
     return (
         <div className="cdl-page">
@@ -17,7 +779,7 @@ export default function CloudDigitalLeaderPage() {
                     <span>認定試験</span>
                 </h1>
                 <p className="hero-sub">
-                    DX・データ・AI/ML・インフラ・セキュリティ・生成AI — 全領域を体系的に解説
+                    DX・データ・AI/ML・インフラ・セキュリティ・生成 AI — 全領域を体系的に解説
                 </p>
                 <div className="hero-meta">
                     <span className="hero-badge">
@@ -44,9 +806,9 @@ export default function CloudDigitalLeaderPage() {
                     <a href="#s0" className="snav-link"><span className="snav-num">00</span>試験概要</a>
                     <a href="#s1" className="snav-link"><span className="snav-num">01</span>DX・クラウド基礎</a>
                     <a href="#s2" className="snav-link"><span className="snav-num">02</span>データとイノベーション</a>
-                    <a href="#s3" className="snav-link"><span className="snav-num">03</span>AI/ML</a>
-                    <a href="#s4" className="snav-link"><span className="snav-num">04</span>インフラとモダナイゼーション</a>
-                    <a href="#s5" className="snav-link"><span className="snav-num">05</span>セキュリティと運用</a>
+                    <a href="#s3" className="snav-link"><span className="snav-num">03</span>インフラとモダナイゼーション</a>
+                    <a href="#s4" className="snav-link"><span className="snav-num">04</span>セキュリティと運用</a>
+                    <a href="#s5" className="snav-link"><span className="snav-num">05</span>AI/ML</a>
                     <a href="#s6" className="snav-link"><span className="snav-num">06</span>サービス早見表</a>
                     <a href="#s7" className="snav-link"><span className="snav-num">07</span>試験攻略</a>
                     <a href="#s8" className="snav-link"><span className="snav-num">08</span>参照リソース</a>
@@ -54,10 +816,15 @@ export default function CloudDigitalLeaderPage() {
             </nav>
 
             <div className="wrapper">
-                {/* セクションは順次追加予定 */}
-                <div id="s0" className="sgap">
-                    <p style={{ color: 'var(--cdl-text-muted)' }}>コンテンツ実装中...</p>
-                </div>
+                <SectionIntro />
+                <Section1 />
+                <Section2 />
+                <Section3 />
+                <Section4 />
+                <Section5 />
+                <Section6 />
+                <Section7 />
+                <Section8 />
             </div>
 
             <footer className="page-footer">

--- a/app/gcl/cloud-digital-leader/page.tsx
+++ b/app/gcl/cloud-digital-leader/page.tsx
@@ -1,0 +1,68 @@
+import type { Metadata } from 'next';
+import './cdl.css';
+
+export const metadata: Metadata = {
+    title: 'Cloud Digital Leader 認定試験',
+    description:
+        'Google Cloud Digital Leader 包括的解説。DX・データ・AI/ML・インフラ・セキュリティ・生成AI の全領域を詳解。',
+};
+
+export default function CloudDigitalLeaderPage() {
+    return (
+        <div className="cdl-page">
+            <section className="hero">
+                <div className="hero-eyebrow">Google Cloud Certification · CDL</div>
+                <h1>
+                    Cloud Digital Leader{' '}
+                    <span>認定試験</span>
+                </h1>
+                <p className="hero-sub">
+                    DX・データ・AI/ML・インフラ・セキュリティ・生成AI — 全領域を体系的に解説
+                </p>
+                <div className="hero-meta">
+                    <span className="hero-badge">
+                        <span className="dot dot-blue" />
+                        全8セクション
+                    </span>
+                    <span className="hero-badge">
+                        <span className="dot dot-red" />
+                        試験時間 90分
+                    </span>
+                    <span className="hero-badge">
+                        <span className="dot dot-yellow" />
+                        60問
+                    </span>
+                    <span className="hero-badge">
+                        <span className="dot dot-green" />
+                        合格ライン 70%
+                    </span>
+                </div>
+            </section>
+
+            <nav className="snav" role="navigation" aria-label="セクションナビゲーション">
+                <div className="snav-inner">
+                    <a href="#s0" className="snav-link"><span className="snav-num">00</span>試験概要</a>
+                    <a href="#s1" className="snav-link"><span className="snav-num">01</span>DX・クラウド基礎</a>
+                    <a href="#s2" className="snav-link"><span className="snav-num">02</span>データとイノベーション</a>
+                    <a href="#s3" className="snav-link"><span className="snav-num">03</span>AI/ML</a>
+                    <a href="#s4" className="snav-link"><span className="snav-num">04</span>インフラとモダナイゼーション</a>
+                    <a href="#s5" className="snav-link"><span className="snav-num">05</span>セキュリティと運用</a>
+                    <a href="#s6" className="snav-link"><span className="snav-num">06</span>サービス早見表</a>
+                    <a href="#s7" className="snav-link"><span className="snav-num">07</span>試験攻略</a>
+                    <a href="#s8" className="snav-link"><span className="snav-num">08</span>参照リソース</a>
+                </div>
+            </nav>
+
+            <div className="wrapper">
+                {/* セクションは順次追加予定 */}
+                <div id="s0" className="sgap">
+                    <p style={{ color: 'var(--cdl-text-muted)' }}>コンテンツ実装中...</p>
+                </div>
+            </div>
+
+            <footer className="page-footer">
+                <p>Cloud Digital Leader 認定試験 包括的解説</p>
+            </footer>
+        </div>
+    );
+}

--- a/app/gcl/cloud-digital-leader/page.tsx
+++ b/app/gcl/cloud-digital-leader/page.tsx
@@ -1,4 +1,14 @@
 import type { Metadata } from 'next';
+import {
+    EXAM_SPEC,
+    EXAM_DOMAINS,
+    NIST_CHARACTERISTICS,
+    AI_PRINCIPLES,
+    AI_NOT_PURSUE,
+    COMPUTE_SERVICES,
+    CONFUSING_PAIRS,
+    RESOURCES,
+} from './constants';
 
 export const metadata: Metadata = {
     title: 'Cloud Digital Leader 認定試験',
@@ -19,31 +29,47 @@ function SectionIntro() {
 
             <div className="tcard">
                 <div className="ttitle"><span className="tid">0.1</span>試験仕様</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>項目</span><span>内容</span>
-                    </div>
-                    <div className="ctable-row"><span>試験時間</span><span>90分</span></div>
-                    <div className="ctable-row"><span>問題数</span><span>60問</span></div>
-                    <div className="ctable-row"><span>合格点</span><span>約 70%</span></div>
-                    <div className="ctable-row"><span>受験料</span><span>$200</span></div>
-                    <div className="ctable-row"><span>有効期間</span><span>3年間</span></div>
-                    <div className="ctable-row"><span>前提知識</span><span>不要（推奨: 6ヶ月以上のクラウド経験）</span></div>
+                <div className="ctable-wrap">
+                    <table className="ctable">
+                        <thead>
+                            <tr>
+                                <th>項目</th>
+                                <th>内容</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {EXAM_SPEC.map((row, i) => (
+                                <tr key={i}>
+                                    <td>{row.item}</td>
+                                    <td>{row.content}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
                 </div>
             </div>
 
             <div className="tcard">
-                <div className="ttitle"><span className="tid">0.2</span>出題セクション別 配点</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>セクション</span><span>テーマ</span><span>配点目安</span>
-                    </div>
-                    <div className="ctable-row"><span>Section 1</span><span>デジタルトランスフォーメーションと Google Cloud</span><span>~17%</span></div>
-                    <div className="ctable-row"><span>Section 2</span><span>データと Google Cloud によるイノベーション</span><span>~16%</span></div>
-                    <div className="ctable-row"><span>Section 3</span><span>インフラとアプリのモダナイゼーション</span><span>~16%</span></div>
-                    <div className="ctable-row"><span>Section 4</span><span>Google Cloud のセキュリティとオペレーション</span><span>~17%</span></div>
-                    <div className="ctable-row"><span>Section 5</span><span>AI と ML ソリューション</span><span>~16%</span></div>
-                    <div className="ctable-row"><span>その他</span><span>Google Cloud の基礎概念・費用最適化</span><span>~18%</span></div>
+                <div className="ttitle"><span className="tid">0.2</span>出題ドメイン別 配点</div>
+                <div className="ctable-wrap">
+                    <table className="ctable">
+                        <thead>
+                            <tr>
+                                <th>セクション</th>
+                                <th>テーマ</th>
+                                <th>配点目安</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {EXAM_DOMAINS.map((row, i) => (
+                                <tr key={i}>
+                                    <td><strong>{row.section}</strong></td>
+                                    <td>{row.theme}</td>
+                                    <td>{row.weight}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
                 </div>
             </div>
 
@@ -70,25 +96,35 @@ function Section1() {
                     <h2>DX・クラウド基礎 — デジタルトランスフォーメーションと Google Cloud</h2>
                     <p>クラウドの5特性・IaaS/PaaS/SaaS・デプロイモデル・CapEx vs OpEx・6つのR</p>
                 </div>
-                <div className="pct-badge pb1">~17%</div>
+                <div className="pct-badge pb1">10%</div>
             </div>
 
             <div className="tcard">
                 <div className="ttitle"><span className="tid">1.1</span>クラウドの5つの本質的特性（NIST 定義）</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>特性</span><span>説明</span><span>ビジネス上の意味</span>
-                    </div>
-                    <div className="ctable-row"><span>オンデマンド・セルフサービス</span><span>人手を介さずにリソースを即時調達</span><span>IT部門の承認待ち時間ゼロ</span></div>
-                    <div className="ctable-row"><span>幅広いネットワークアクセス</span><span>任意のデバイスからアクセス可能</span><span>場所・端末を選ばない働き方</span></div>
-                    <div className="ctable-row"><span>リソースの共有（マルチテナント）</span><span>複数ユーザーで物理リソースを共有</span><span>コスト効率の向上</span></div>
-                    <div className="ctable-row"><span>迅速な弾力性（エラスティシティ）</span><span>需要に応じて自動でスケール</span><span>急なトラフィック増にも対応</span></div>
-                    <div className="ctable-row"><span>計測されたサービス</span><span>使用量に応じた従量課金</span><span>使った分だけ払う経済合理性</span></div>
+                <div className="ctable-wrap">
+                    <table className="ctable">
+                        <thead>
+                            <tr>
+                                <th>特性</th>
+                                <th>説明</th>
+                                <th>ビジネス上の意味</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {NIST_CHARACTERISTICS.map((row, i) => (
+                                <tr key={i}>
+                                    <td><strong>{row.trait}</strong></td>
+                                    <td>{row.desc}</td>
+                                    <td>{row.meaning}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
                 </div>
             </div>
 
             <div className="tcard">
-                <div className="ttitle"><span className="tid">1.2</span>クラウドサービスモデル（IaaS / PaaS / SaaS）</div>
+                <div className="ttitle"><span className="tid Generator">1.2</span>クラウドサービスモデル（IaaS / PaaS / SaaS）</div>
                 <pre className="codeblock">{`責任の分担（下が基盤、上がユーザー責任）
 
 ┌─────────────────┬─────────────────┬─────────────────┐
@@ -98,80 +134,11 @@ function Section1() {
 ├─────────────────┼─────────────────┼─────────────────┤
 │ アプリ [USER]    │ アプリ [USER]    │         [USER]   │
 │ ランタイム [USER]│ ランタイム [GCP] │         [GCP]    │
-│ OS [USER]        │ OS      [GCP]    │         [GCP]    │
-│ 仮想化  [GCP]    │ 仮想化  [GCP]    │         [GCP]    │
-│ ハード  [GCP]    │ ハード  [GCP]    │         [GCP]    │
+│ OS / VM [USER]   │         [GCP]    │         [GCP]    │
+│ ネットワーク[GCP]│         [GCP]    │         [GCP]    │
+│ ストレージ [GCP] │         [GCP]    │         [GCP]    │
 └─────────────────┴─────────────────┴─────────────────┘
-例: Compute Engine  Cloud Run / App   Google Workspace
-                    Engine            Gmail / Drive`}</pre>
-                <div className="tgrid">
-                    <div className="titem"><div className="tname">IaaS（Compute Engine など）</div><div className="tdef">OS・MWを自分で管理。リフト&シフト移行・最大の柔軟性が必要なワークロード向け</div></div>
-                    <div className="titem"><div className="tname">PaaS（App Engine・Cloud Run など）</div><div className="tdef">インフラ管理なしにアプリ開発に集中。開発者の生産性を最大化</div></div>
-                    <div className="titem"><div className="tname">SaaS（Google Workspace など）</div><div className="tdef">インストール・管理不要でソフトウェアをすぐ使える。Gmail・Docs・Sheets</div></div>
-                </div>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">1.3</span>クラウドデプロイメントモデル</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>モデル</span><span>説明</span><span>適用場面</span>
-                    </div>
-                    <div className="ctable-row"><span>パブリッククラウド</span><span>GCP・AWS・Azure が提供する共有インフラ</span><span>コスト最適化・スケーラビリティ重視</span></div>
-                    <div className="ctable-row"><span>プライベートクラウド</span><span>企業専用のクラウド環境（オンプレ）</span><span>高いセキュリティ・コンプライアンス要件</span></div>
-                    <div className="ctable-row"><span>ハイブリッドクラウド</span><span>パブリック + プライベートを組み合わせ</span><span>段階的移行・データ主権の確保</span></div>
-                    <div className="ctable-row"><span>マルチクラウド</span><span>複数のクラウドプロバイダーを利用</span><span>ベンダーロックイン回避・最適サービス選択</span></div>
-                </div>
-                <div className="bp">
-                    <div className="bpt">ベストプラクティス: デプロイメントモデル選定</div>
-                    <ul>
-                        <li><strong>コスト優先</strong>: パブリッククラウドを選択。CapEx から OpEx へ転換</li>
-                        <li><strong>規制対応</strong>: 金融・医療など規制産業ではハイブリッドを検討</li>
-                        <li><strong>既存投資保護</strong>: オンプレの設備投資が残っている場合はハイブリッドで段階移行</li>
-                        <li><strong>ベンダー分散</strong>: 単一障害点を避けるためマルチクラウド戦略を検討</li>
-                    </ul>
-                </div>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">1.4</span>CapEx vs OpEx とクラウド移行の DX 価値</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>概念</span><span>説明</span><span>クラウドとの関係</span>
-                    </div>
-                    <div className="ctable-row"><span>CapEx（資本支出）</span><span>設備・サーバー等への先行投資。資産として計上</span><span>オンプレミス運用の特徴</span></div>
-                    <div className="ctable-row"><span>OpEx（運用費用）</span><span>月次・年次の運用コスト。費用として計上</span><span>クラウドの特徴（使った分だけ払う）</span></div>
-                </div>
-                <pre className="codeblock">{`Google Cloud の DX を加速する3つの柱:
-
-1. インフラの近代化
-   └── オンプレ → クラウドへの移行・レガシーシステムの刷新
-   └── コスト削減・俊敏性向上
-
-2. データと AI の活用
-   └── データドリブン意思決定・AI/ML で業務自動化・予測
-
-3. スマートアナリティクス
-   └── ビジネスインテリジェンス・顧客インサイト・新ビジネスモデル`}</pre>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">1.5</span>クラウド移行戦略（6つの R）</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>戦略</span><span>別名</span><span>説明</span><span>コスト</span><span>期間</span>
-                    </div>
-                    <div className="ctable-row"><span>Rehost</span><span>リフト&シフト</span><span>そのままクラウドへ移動</span><span>低</span><span>短</span></div>
-                    <div className="ctable-row"><span>Replatform</span><span>リフト&調整&シフト</span><span>最小限の変更でクラウド最適化</span><span>中</span><span>中</span></div>
-                    <div className="ctable-row"><span>Repurchase</span><span>ドロップ&ショッピング</span><span>SaaS 製品への乗り換え</span><span>中</span><span>中</span></div>
-                    <div className="ctable-row"><span>Refactor</span><span>リアーキテクチャ</span><span>クラウドネイティブへ再設計</span><span>高</span><span>長</span></div>
-                    <div className="ctable-row"><span>Retire</span><span>廃止</span><span>不要なシステムを廃止</span><span>なし</span><span>短</span></div>
-                    <div className="ctable-row"><span>Retain</span><span>保持</span><span>当面オンプレに残す</span><span>なし</span><span>—</span></div>
-                </div>
-                <div className="wb">
-                    <div className="wbt">試験ポイント</div>
-                    <p>「最も速く・安く移行する」= Rehost（リフト&シフト）。「クラウドのメリットを最大限活かす」= Refactor。</p>
-                </div>
+例: Compute Engine   Cloud Run          Google Workspace`}</pre>
             </div>
         </div>
     );
@@ -183,80 +150,30 @@ function Section2() {
             <div className="sec-head">
                 <div className="sec-num sn2">02</div>
                 <div className="sec-head-txt">
-                    <h2>データとイノベーション — データ管理・分析・BI サービス</h2>
-                    <p>DB 選定・BigQuery・Looker・Dataflow・Dataproc・ストレージクラス</p>
+                    <h2>データとイノベーション — クラウドによるイノベーション</h2>
+                    <p>BigQuery・Cloud Storage・データベース選択・データ分析パイプライン</p>
                 </div>
-                <div className="pct-badge pb2">~16%</div>
+                <div className="pct-badge pb2">12.5%</div>
             </div>
 
             <div className="tcard">
-                <div className="ttitle"><span className="tid">2.1</span>データが生み出す 4 つのビジネス価値</div>
-                <div className="tgrid">
-                    <div className="titem"><div className="tname">1. 過去の理解（記述的分析）</div><div className="tdef">何が起きたかを把握</div></div>
-                    <div className="titem"><div className="tname">2. 現状の把握（診断的分析）</div><div className="tdef">今何が起きているかをリアルタイムで監視</div></div>
-                    <div className="titem"><div className="tname">3. 未来の予測（予測的分析）</div><div className="tdef">次に何が起きるかを予測</div></div>
-                    <div className="titem"><div className="tname">4. 最適行動の提案（処方的分析）</div><div className="tdef">何をすべきかを AI が提案</div></div>
-                </div>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">2.2</span>データベースサービス一覧と選択基準</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>サービス</span><span>タイプ</span><span>特徴</span><span>適用場面</span>
-                    </div>
-                    <div className="ctable-row"><span>Cloud SQL</span><span>マネージド RDBMS</span><span>MySQL・PostgreSQL・SQL Server 対応。垂直スケール</span><span>既存 RDB のクラウド移行・Web アプリ</span></div>
-                    <div className="ctable-row"><span>Cloud Spanner</span><span>グローバル分散 RDBMS</span><span>99.999% SLA。世界規模の強一貫性</span><span>金融・在庫管理・グローバル EC</span></div>
-                    <div className="ctable-row"><span>Firestore</span><span>NoSQL ドキュメント</span><span>サーバーレス・リアルタイム同期</span><span>モバイル/Web アプリのバックエンド</span></div>
-                    <div className="ctable-row"><span>Bigtable</span><span>NoSQL ワイドカラム</span><span>超高スループット・超低遅延</span><span>時系列・IoT・広告データ</span></div>
-                    <div className="ctable-row"><span>BigQuery</span><span>データウェアハウス</span><span>サーバーレス SQL 分析。数 TB を数秒で処理</span><span>BI・データ分析・機械学習</span></div>
-                    <div className="ctable-row"><span>Memorystore</span><span>インメモリ DB</span><span>マネージド Redis/Memcached</span><span>セッション管理・キャッシュ</span></div>
-                    <div className="ctable-row"><span>AlloyDB</span><span>PostgreSQL 互換</span><span>Cloud SQL より高速な分析性能（HTAP）</span><span>高性能トランザクション + 分析</span></div>
-                </div>
-                <pre className="codeblock">{`DB 選択フロー:
-
-RDB が必要か？
-├── YES: グローバルに強一貫性が必要 → Cloud Spanner
-└── YES: リージョン内で十分       → Cloud SQL
-
-NoSQL が必要か？
-├── ドキュメント形式・リアルタイム → Firestore
-├── 時系列・超大量データ          → Bigtable
-└── キャッシュ・セッション         → Memorystore
-
-分析・DWH 用途                    → BigQuery`}</pre>
-                <div className="bp">
-                    <div className="bpt">ベストプラクティス: データベース選択</div>
-                    <ul>
-                        <li>グローバルな強一貫性が必要 → Cloud Spanner（コストは高いが 99.999% SLA）</li>
-                        <li>既存 MySQL/PostgreSQL の移行 → Cloud SQL（最も簡単な移行パス）</li>
-                        <li>大量データの SQL 分析 → BigQuery（サーバーレス・ペタバイトスケール）</li>
-                        <li>リアルタイム同期が必要な モバイルアプリ → Firestore</li>
-                    </ul>
-                </div>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">2.3</span>データ分析・BI サービス</div>
-                <div className="tgrid">
-                    <div className="titem"><div className="tname">Looker（エンタープライズ BI）</div><div className="tdef">LookML で全社データ定義を一元管理。「真実の唯一の情報源」。経営ダッシュボード・売上レポート向け</div></div>
-                    <div className="titem"><div className="tname">Looker Studio（旧 Data Studio）</div><div className="tdef">無料のセルフサービス BI。コードなしでインタラクティブなレポートを作成。Google Sheets・BigQuery と連携</div></div>
-                    <div className="titem"><div className="tname">Cloud Dataflow</div><div className="tdef">フルマネージドのデータ処理パイプライン（Apache Beam）。ストリーミング + バッチの両方に対応。ログ処理・IoT データ変換・ETL</div></div>
-                    <div className="titem"><div className="tname">Cloud Dataproc</div><div className="tdef">マネージド Apache Hadoop/Spark クラスタ。既存の Hadoop ワークロードをクラウドへ移行。必要な時だけ起動してコスト削減</div></div>
-                    <div className="titem"><div className="tname">Cloud Pub/Sub</div><div className="tdef">フルマネージドのメッセージングサービス。イベント駆動アーキテクチャの基盤。1秒あたり数百万メッセージを処理可能</div></div>
-                </div>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">2.4</span>Cloud Storage のストレージクラス</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>クラス</span><span>アクセス頻度</span><span>最小保存期間</span><span>ユースケース</span>
-                    </div>
-                    <div className="ctable-row"><span>Standard</span><span>頻繁</span><span>なし</span><span>Web コンテンツ・アクティブデータ</span></div>
-                    <div className="ctable-row"><span>Nearline</span><span>月1回程度</span><span>30 日</span><span>バックアップ・月次レポート</span></div>
-                    <div className="ctable-row"><span>Coldline</span><span>四半期1回程度</span><span>90 日</span><span>アーカイブ・DR 用バックアップ</span></div>
-                    <div className="ctable-row"><span>Archive</span><span>年1回未満</span><span>365 日</span><span>長期保管・規制対応アーカイブ</span></div>
+                <div className="ttitle"><span className="tid">2.1</span>Google Cloud Storage (GCS) クラス</div>
+                <div className="ctable-wrap">
+                    <table className="ctable">
+                        <thead>
+                            <tr>
+                                <th>クラス</th>
+                                <th>ユースケース</th>
+                                <th>最低保存期間</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr><td><strong>Standard</strong></td><td>頻繁にアクセスするデータ、Webコンテンツ</td><td>なし</td></tr>
+                            <tr><td><strong>Nearline</strong></td><td>月に1回未満のアクセス、バックアップ</td><td>30日</td></tr>
+                            <tr><td><strong>Coldline</strong></td><td>四半期に1回未満のアクセス、アーカイブ</td><td>90日</td></tr>
+                            <tr><td><strong>Archive</strong></td><td>年に1回未満のアクセス、長期保存</td><td>365日</td></tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
@@ -269,87 +186,33 @@ function Section3() {
             <div className="sec-head">
                 <div className="sec-num sn3">03</div>
                 <div className="sec-head-txt">
-                    <h2>インフラとモダナイゼーション — コンピューティング・ネットワーク・マネージドサービス</h2>
-                    <p>Compute Engine・GKE・Cloud Run・コンテナ・VPC・Cloud Interconnect</p>
+                    <h2>インフラとモダナイゼーション — インフラとアプリのモダナイゼーション</h2>
+                    <p>Compute Engine・GKE・Cloud Run・ハイブリッドクラウド・Anthos</p>
                 </div>
-                <div className="pct-badge pb3">~16%</div>
+                <div className="pct-badge pb3">30%</div>
             </div>
 
             <div className="tcard">
-                <div className="ttitle"><span className="tid">3.1</span>コンピューティングサービスの比較と選択</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>サービス</span><span>キーワード</span><span>使い分け</span>
-                    </div>
-                    <div className="ctable-row"><span>Compute Engine</span><span>VM・IaaS・OS 制御・GPU</span><span>レガシー移行・特定 OS 要件・最大の柔軟性</span></div>
-                    <div className="ctable-row"><span>GKE</span><span>コンテナ・Kubernetes・ステートフル</span><span>マイクロサービス・長時間処理</span></div>
-                    <div className="ctable-row"><span>Cloud Run</span><span>コンテナ・サーバーレス・HTTP・0 スケール</span><span>ステートレス API・スパイクトラフィック</span></div>
-                    <div className="ctable-row"><span>Cloud Run Functions</span><span>FaaS・イベント駆動・軽量処理</span><span>Webhook・トリガー・小さな関数</span></div>
-                    <div className="ctable-row"><span>App Engine</span><span>PaaS・Web アプリ・コードだけ</span><span>レガシー Web アプリの移行</span></div>
-                </div>
-                <pre className="codeblock">{`コンピューティングサービス選択フロー:
-
-OS・ミドルウェアの制御が必要         → Compute Engine
-コンテナ + ステートフル/長時間処理    → GKE
-コンテナ + ステートレス HTTP API      → Cloud Run
-イベント駆動 + 短時間の小さな関数     → Cloud Run Functions
-コード書くだけでOK（PaaS）           → App Engine
-0スケールでコスト最小化              → Cloud Run / Cloud Run Functions`}</pre>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">3.2</span>コンテナと VM の違い</div>
-                <pre className="codeblock">{`従来の VM:                コンテナ:
-┌──────────────┐        ┌──────────────┐
-│    App A      │        │ App A | App B │
-│  バイナリ/Lib │        │  バイナリ/Lib│
-│  ゲスト OS    │        ├──────────────┤
-├──────────────┤        │コンテナランタイム│
-│   Hypervisor  │        │  ホスト OS    │
-│   ホスト OS   │        │  ハードウェア │
-│   ハードウェア│        └──────────────┘
-└──────────────┘
-→ 重くて起動が遅い       → 軽くて起動が速い`}</pre>
-                <div className="tgrid">
-                    <div className="titem"><div className="tname">GKE Autopilot</div><div className="tdef">Google が完全管理。Pod 単位課金。運用負荷を最小化したい場合に最適</div></div>
-                    <div className="titem"><div className="tname">GKE Standard</div><div className="tdef">ユーザーがノードを管理。ノード VM 課金。細かいノード制御が必要な場合</div></div>
-                </div>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">3.3</span>ネットワークサービス</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>サービス</span><span>説明</span><span>帯域/用途</span>
-                    </div>
-                    <div className="ctable-row"><span>VPC（Virtual Private Cloud）</span><span>グローバルに展開するソフトウェア定義ネットワーク</span><span>プロジェクト間の分離・ファイアウォールルール</span></div>
-                    <div className="ctable-row"><span>Cloud Load Balancing</span><span>グローバル/リージョナルの自動スケーリング対応ロードバランサー</span><span>HTTP/HTTPS トラフィックの分散</span></div>
-                    <div className="ctable-row"><span>Cloud CDN</span><span>Google のグローバルネットワークでコンテンツをキャッシュ・高速配信</span><span>静的コンテンツのレイテンシ削減</span></div>
-                    <div className="ctable-row"><span>Dedicated Interconnect</span><span>専用回線で GCP と直接接続</span><span>10/100Gbps — 大量データ転送</span></div>
-                    <div className="ctable-row"><span>Partner Interconnect</span><span>パートナー経由の専用接続</span><span>50Mbps〜50Gbps</span></div>
-                    <div className="ctable-row"><span>Cloud VPN</span><span>インターネット経由 IPsec トンネル</span><span>最大 3Gbps/トンネル — 低コスト接続</span></div>
-                </div>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">3.4</span>マネージドサービスとサーバーレスの価値</div>
-                <pre className="codeblock">{`管理責任の分担:
-
-           オンプレミス  IaaS(GCE)  PaaS(AppEng)  サーバーレス
-アプリ        [自社]      [自社]      [自社]         [自社]
-ランタイム    [自社]      [自社]      [自社]         [GCP]
-OS            [自社]      [自社]      [自社]         [GCP]
-ミドルウェア  [自社]      [GCP]       [GCP]          [GCP]
-仮想化        [自社]      [GCP]       [GCP]          [GCP]
-ハードウェア  [自社]      [GCP]       [GCP]          [GCP]`}</pre>
-                <div className="bp">
-                    <div className="bpt">ベストプラクティス: マネージドサービス活用</div>
-                    <ul>
-                        <li>差別化されない重労働（インフラ管理・パッチ適用）は<strong>マネージドサービスに委譲</strong></li>
-                        <li>エンジニアはビジネス価値を生む<strong>アプリケーション開発に集中</strong></li>
-                        <li>Spot/Preemptible VM を活用してバッチ処理のコストを最大 91% 削減</li>
-                        <li>Sustained Use Discount（自動割引 30%）と Committed Use Discount（最大 57%）を理解する</li>
-                    </ul>
+                <div className="ttitle"><span className="tid">3.1</span>コンピューティングの選択</div>
+                <div className="ctable-wrap">
+                    <table className="ctable">
+                        <thead>
+                            <tr>
+                                <th>サービス</th>
+                                <th>キーワード</th>
+                                <th>使い分け</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {COMPUTE_SERVICES.map((row, i) => (
+                                <tr key={i}>
+                                    <td><strong>{row.service}</strong></td>
+                                    <td>{row.keyword}</td>
+                                    <td>{row.usage}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
@@ -362,113 +225,21 @@ function Section4() {
             <div className="sec-head">
                 <div className="sec-num sn4">04</div>
                 <div className="sec-head-txt">
-                    <h2>セキュリティとオペレーション — IAM・多層防御・費用管理</h2>
-                    <p>IAM・リソース階層・Cloud Armor・KMS・SCC・Cloud Monitoring・コスト最適化</p>
+                    <h2>セキュリティと運用 — Google Cloud のセキュリティと運用</h2>
+                    <p>共有責任モデル・IAM・リソース階層・セキュリティ製品・運用ツール</p>
                 </div>
-                <div className="pct-badge pb4">~17%</div>
+                <div className="pct-badge pb4">30%</div>
             </div>
 
             <div className="tcard">
-                <div className="ttitle"><span className="tid">4.1</span>Google Cloud のセキュリティ設計思想（多層防御）</div>
-                <pre className="codeblock">{`Layer 7: データ        暗号化・DLP・アクセス制御
-Layer 6: ユーザー      IAM・MFA・Cloud Identity
-Layer 5: アプリ        脆弱性スキャン・Container Analysis
-Layer 4: エンドポイント Chrome Enterprise・BeyondCorp
-Layer 3: ネットワーク  VPC・ファイアウォール・Cloud Armor
-Layer 2: インフラ      Shielded VMs・Confidential Computing
-Layer 1: ハードウェア  Titan チップ・物理セキュリティ`}</pre>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">4.2</span>IAM（Identity and Access Management）</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>ロール種別</span><span>説明</span><span>推奨度</span>
-                    </div>
-                    <div className="ctable-row"><span>基本ロール</span><span>Owner / Editor / Viewer。プロジェクト全体に適用</span><span>❌ 本番環境では非推奨</span></div>
-                    <div className="ctable-row"><span>事前定義ロール</span><span>特定サービスに最適化されたロール</span><span>✅ 推奨</span></div>
-                    <div className="ctable-row"><span>カスタムロール</span><span>必要な権限のみを組み合わせた自作ロール</span><span>✅ 最小権限の原則を徹底</span></div>
-                </div>
-                <div className="bp">
-                    <div className="bpt">ベストプラクティス: IAM</div>
-                    <ul>
-                        <li><strong>最小権限の原則</strong>: 必要最小限のロールのみを付与</li>
-                        <li><strong>グループ管理</strong>: 個人ではなくグループにロールを付与</li>
-                        <li><strong>サービスアカウントキー</strong>: 可能な限り発行せず、Workload Identity Federation を使用</li>
-                        <li><strong>定期レビュー</strong>: 不要なロールの付与を定期的に棚卸し</li>
-                        <li><strong>2 段階認証（MFA）</strong>: 全ユーザーに強制する</li>
-                    </ul>
-                </div>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">4.3</span>リソース階層とポリシー継承</div>
-                <pre className="codeblock">{`組織（Organization）
-    │
-    ├── フォルダ（Folder）←── 部門・環境でグループ化
-    │       │
-    │       ├── プロジェクト（Project）
-    │       │       │
-    │       │       └── リソース（VM・GCS・DB等）
-    │       │
-    │       └── プロジェクト（Project）
-    │
-    └── フォルダ（Folder）
-
-ポリシーは上位から下位へ継承される（上書き不可）
-IAM ポリシーは「追加のみ」→ 上位で付与した権限は下位でも有効`}</pre>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">4.4</span>主要セキュリティサービス</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>サービス</span><span>キーワード</span><span>役割</span>
-                    </div>
-                    <div className="ctable-row"><span>Cloud IAP</span><span>認証・アクセス制御・ゼロトラスト</span><span>VPN なし・ゼロトラストで社内アプリアクセス制御</span></div>
-                    <div className="ctable-row"><span>Cloud Armor</span><span>DDoS・WAF・OWASP Top 10</span><span>Web アプリの DDoS 保護・SQL インジェクション・XSS ブロック</span></div>
-                    <div className="ctable-row"><span>Secret Manager</span><span>API キー・パスワード管理</span><span>機密情報を安全に管理。自動ローテーション対応</span></div>
-                    <div className="ctable-row"><span>Cloud KMS</span><span>暗号化キー管理・CMEK</span><span>顧客管理暗号化キーでデータをさらに強固に保護</span></div>
-                    <div className="ctable-row"><span>Security Command Center</span><span>脅威・脆弱性の一元可視化</span><span>リスクの検出・優先順位付け・修復ガイダンス</span></div>
-                    <div className="ctable-row"><span>Sensitive Data Protection（DLP）</span><span>PII 検出・マスキング</span><span>個人情報を自動検出・分類。GDPR・HIPAA 対応</span></div>
-                </div>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">4.5</span>コンプライアンスと規制対応</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>規制/認証</span><span>対象業界</span><span>説明</span>
-                    </div>
-                    <div className="ctable-row"><span>ISO 27001</span><span>全業種</span><span>情報セキュリティ管理の国際規格</span></div>
-                    <div className="ctable-row"><span>SOC 2 / SOC 3</span><span>全業種</span><span>システムの信頼性・セキュリティの監査報告</span></div>
-                    <div className="ctable-row"><span>PCI DSS</span><span>金融・EC</span><span>クレジットカード情報の取り扱い基準</span></div>
-                    <div className="ctable-row"><span>HIPAA</span><span>医療（米国）</span><span>医療情報の保護に関する規制</span></div>
-                    <div className="ctable-row"><span>GDPR</span><span>EU 圏</span><span>欧州個人データ保護規則</span></div>
-                    <div className="ctable-row"><span>FedRAMP</span><span>米国政府</span><span>連邦政府クラウドサービスの安全基準</span></div>
-                </div>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">4.6</span>費用管理と最適化</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>割引概念</span><span>説明</span>
-                    </div>
-                    <div className="ctable-row"><span>従量課金</span><span>使用した分だけ支払う（秒単位課金が多い）</span></div>
-                    <div className="ctable-row"><span>Sustained Use Discount</span><span>月間で一定時間以上使うと自動で最大 30% 割引（申込不要）</span></div>
-                    <div className="ctable-row"><span>Committed Use Discount</span><span>1 年/3 年コミットで最大 57% 割引（Compute Engine・事前申込必要）</span></div>
-                    <div className="ctable-row"><span>Spot/Preemptible VM</span><span>通常比最大 91% 安価（中断の可能性あり）</span></div>
-                </div>
-                <div className="bp">
-                    <div className="bpt">ベストプラクティス: コスト最適化</div>
-                    <ul>
-                        <li><strong>右サイズ化</strong>: 過剰スペックの VM をダウンサイズ（Active Assist が自動提案）</li>
-                        <li><strong>使われていないリソースの削除</strong>: 停止中の VM・未使用の IP アドレス</li>
-                        <li><strong>Spot VM の活用</strong>: バッチ処理・CI/CD などに</li>
-                        <li><strong>Committed Use の適用</strong>: 安定したワークロードには長期契約が得（Sustained Use との違いを理解）</li>
-                        <li><strong>予算アラート設定</strong>: 50%・90%・100% 消費時に通知</li>
-                    </ul>
+                <div className="ttitle"><span className="tid">4.1</span>リソース階層（Resource Hierarchy）</div>
+                <pre className="codeblock">{`組織 (Organization)  ← 会社全体、GWS/Cloud Identity と紐付け
+└── フォルダ (Folders)  ← 部門、環境（Dev/Prod）
+    └── プロジェクト (Projects)  ← 課金単位、API管理
+        └── リソース (Resources)  ← VM, DB, Bucket`}</pre>
+                <div className="ib">
+                    <div className="ibt">重要: 継承の原則</div>
+                    <p>上位階層で設定した IAM ポリシーは、下位階層にすべて<strong>継承</strong>される（拒否はできない、追加のみ）。</p>
                 </div>
             </div>
         </div>
@@ -481,109 +252,50 @@ function Section5() {
             <div className="sec-head">
                 <div className="sec-num sn5">05</div>
                 <div className="sec-head-txt">
-                    <h2>AI と ML ソリューション — プリビルト API・AutoML・Vertex AI・生成 AI</h2>
-                    <p>AI 階層・機械学習 3 アプローチ・Gemini・RAG・責任ある AI</p>
+                    <h2>AI/ML — Google Cloud の AI によるイノベーション</h2>
+                    <p>AI 原則・Vertex AI・生成 AI・Gemini・RAG</p>
                 </div>
-                <div className="pct-badge pb5">~16%</div>
+                <div className="pct-badge pb5">5%</div>
             </div>
 
             <div className="tcard">
-                <div className="ttitle"><span className="tid">5.1</span>AI の階層的理解</div>
-                <pre className="codeblock">{`AI（人工知能）: 人間の知的行動をコンピュータで模倣する技術全般
-  └── ML（機械学習）: データからパターンを自動学習
-        └── 深層学習（Deep Learning）: 多層ニューラルネットワーク
-              └── 生成AI（Generative AI）: 新しいコンテンツを生成
-                    └── LLM（大規模言語モデル）: テキスト生成に特化`}</pre>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>アプローチ</span><span>データ形式</span><span>代表例</span>
-                    </div>
-                    <div className="ctable-row"><span>教師あり学習</span><span>正解ラベル付きデータ</span><span>スパム分類・需要予測・画像認識</span></div>
-                    <div className="ctable-row"><span>教師なし学習</span><span>ラベルなしデータ</span><span>顧客セグメンテーション・異常検知</span></div>
-                    <div className="ctable-row"><span>強化学習</span><span>報酬シグナル</span><span>ゲーム AI・自動運転・RLHF</span></div>
+                <div className="ttitle"><span className="tid">5.1</span>Google AI 原則 — 責任ある AI（Responsible AI）</div>
+                <div className="ctable-wrap">
+                    <table className="ctable">
+                        <thead>
+                            <tr>
+                                <th>7つの原則</th>
+                                <th>説明</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {AI_PRINCIPLES.map((row, i) => (
+                                <tr key={i}>
+                                    <td><strong>{row.principle}</strong></td>
+                                    <td>{row.description}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
                 </div>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">5.2</span>Google Cloud AI/ML サービス階層</div>
-                <pre className="codeblock">{`【使いやすさ重視】 ←────────────────────────→ 【カスタマイズ重視】
-
-プリビルト AI API    AutoML          Vertex AI カスタムモデル
-(API呼び出すだけ)   (ノーコード ML)   (フルコントロール)
-
-エンジニア不要      ML の専門知識不要  ML エンジニア必要
-コスト最小          中程度             最大コスト
-柔軟性低            中程度             最大柔軟性`}</pre>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">5.3</span>プリビルト AI API（事前学習済みモデル API）</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>API</span><span>機能</span><span>ユースケース</span>
-                    </div>
-                    <div className="ctable-row"><span>Vision API</span><span>画像認識・ラベル付け・OCR・顔検出</span><span>商品画像タグ付け・文書デジタル化</span></div>
-                    <div className="ctable-row"><span>Natural Language API</span><span>感情分析・エンティティ抽出・分類</span><span>レビュー分析・チケット自動分類</span></div>
-                    <div className="ctable-row"><span>Translation API</span><span>130 以上の言語間翻訳</span><span>多言語コンテンツ・グローバル対応</span></div>
-                    <div className="ctable-row"><span>Speech-to-Text API</span><span>音声→テキスト変換</span><span>コールセンター文字起こし・音声コマンド</span></div>
-                    <div className="ctable-row"><span>Document AI API</span><span>PDF・文書の構造化データ抽出</span><span>請求書処理自動化・契約書解析</span></div>
-                    <div className="ctable-row"><span>Video Intelligence API</span><span>動画内シーン検出・物体認識</span><span>動画コンテンツ分類・監視映像分析</span></div>
-                </div>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">5.4</span>Gemini モデルファミリー（生成 AI）</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>モデル</span><span>特徴</span><span>主な用途</span>
-                    </div>
-                    <div className="ctable-row"><span>Gemini Ultra</span><span>最高精度・最大規模</span><span>複雑な推論・マルチモーダルタスク</span></div>
-                    <div className="ctable-row"><span>Gemini Pro</span><span>性能とコストのバランス</span><span>多様なビジネスタスク・RAG</span></div>
-                    <div className="ctable-row"><span>Gemini Flash</span><span>高速・低コスト</span><span>大量処理・リアルタイムアプリ</span></div>
-                    <div className="ctable-row"><span>Gemini Nano</span><span>小型・オンデバイス</span><span>エッジデバイス・スマートフォン</span></div>
-                </div>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">5.5</span>RAG・ハルシネーション・ファインチューニング</div>
-                <pre className="codeblock">{`【RAG（Retrieval-Augmented Generation）】
-
-通常の LLM:  プロンプト → LLM → 回答（学習データのみから生成）
-                                   ↑ ハルシネーションのリスクあり
-
-RAG:         プロンプト → 検索エンジン → 関連文書を取得
-                               ↓
-                   プロンプト + 文書 → LLM → 根拠ある回答
-                                               ↑ ハルシネーション大幅減少
-
-RAG のメリット:
-  ├── 最新情報に対応（モデルの知識カットオフを超えられる）
-  ├── 企業固有の知識を活用
-  └── 回答に根拠（ソース）を提示できる`}</pre>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">5.6</span>責任ある AI（Responsible AI）— Google AI の 6 原則</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>原則</span><span>説明</span>
-                    </div>
-                    <div className="ctable-row"><span>公平性（Fairness）</span><span>バイアスのない公平な出力</span></div>
-                    <div className="ctable-row"><span>透明性（Transparency）</span><span>AI であることを開示・判断根拠の説明</span></div>
-                    <div className="ctable-row"><span>説明可能性（Explainability）</span><span>なぜその判断をしたかを説明できる</span></div>
-                    <div className="ctable-row"><span>プライバシー（Privacy）</span><span>個人データの最小収集・適切な管理</span></div>
-                    <div className="ctable-row"><span>説明責任（Accountability）</span><span>AI 判断の責任を持つ人間が存在すること</span></div>
-                    <div className="ctable-row"><span>安全性（Safety）</span><span>有害コンテンツ生成の防止・セーフガード</span></div>
-                </div>
-                <div className="bp">
-                    <div className="bpt">ベストプラクティス: AI サービス選択</div>
-                    <ul>
-                        <li>コード少なく汎用タスク → <strong>プリビルト AI API</strong>（Vision・NL・Translation など）</li>
-                        <li>独自データでカスタムモデル（ML 知識不要）→ <strong>AutoML</strong></li>
-                        <li>フル機能 ML・本番向け → <strong>Vertex AI</strong>（MLエンジニアが必要）</li>
-                        <li>ハルシネーションを低減したい → <strong>RAG + Grounding</strong> を活用</li>
-                        <li>オフィス業務の AI 化 → <strong>Gemini for Google Workspace</strong></li>
-                    </ul>
+                <div className="stitle">追及しない 4 つの用途</div>
+                <div className="ctable-wrap">
+                    <table className="ctable">
+                        <thead>
+                            <tr>
+                                <th>対象</th>
+                                <th>説明</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {AI_NOT_PURSUE.map((row, i) => (
+                                <tr key={i}>
+                                    <td><strong>{row.target}</strong></td>
+                                    <td>{row.description}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
@@ -596,37 +308,30 @@ function Section6() {
             <div className="sec-head">
                 <div className="sec-num sn6">06</div>
                 <div className="sec-head-txt">
-                    <h2>サービス早見表 — カテゴリ別・混同ペア</h2>
-                    <p>コンピューティング・ストレージ/DB・AI/ML・セキュリティ・オペレーション</p>
+                    <h2>サービス早見表 — 混同ペアの整理</h2>
+                    <p>コンピューティング・分析・コスト管理の重要ペア</p>
                 </div>
             </div>
 
             <div className="tcard">
-                <div className="ttitle"><span className="tid">6.1</span>コンピューティングサービス早見表</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>サービス</span><span>キーワード</span><span>使い分け</span>
-                    </div>
-                    <div className="ctable-row"><span>Compute Engine</span><span>VM・IaaS・OS 制御・GPU が必要</span><span>レガシー移行・特定 OS 要件</span></div>
-                    <div className="ctable-row"><span>GKE</span><span>コンテナ・Kubernetes・ステートフル</span><span>マイクロサービス・長時間処理</span></div>
-                    <div className="ctable-row"><span>Cloud Run</span><span>コンテナ・サーバーレス・HTTP・0 スケール</span><span>ステートレス API・スパイクトラフィック</span></div>
-                    <div className="ctable-row"><span>Cloud Run Functions</span><span>FaaS・イベント駆動・軽量処理</span><span>Webhook・トリガー・小さな関数</span></div>
-                    <div className="ctable-row"><span>App Engine</span><span>PaaS・Web アプリ・コードだけ</span><span>レガシー Web アプリの移行</span></div>
-                </div>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">6.2</span>よく混同されるサービスペア</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>混同ペア</span><span>正しい理解</span>
-                    </div>
-                    <div className="ctable-row"><span>Cloud Run vs Cloud Run Functions</span><span>Cloud Run はコンテナ。Functions は関数（コード）。どちらもサーバーレス</span></div>
-                    <div className="ctable-row"><span>Cloud SQL vs BigQuery</span><span>Cloud SQL: OLTP（トランザクション処理）。BigQuery: OLAP（分析）</span></div>
-                    <div className="ctable-row"><span>Dataflow vs Dataproc</span><span>Dataflow: Apache Beam（ストリーミング + バッチ）。Dataproc: Hadoop/Spark（バッチ）</span></div>
-                    <div className="ctable-row"><span>Committed Use vs Sustained Use</span><span>Committed Use は事前申込が必要。Sustained Use は自動適用</span></div>
-                    <div className="ctable-row"><span>匿名化 vs 仮名化</span><span>匿名化は再識別不可（GDPR 対象外）。仮名化は再識別可能（GDPR 対象）</span></div>
-                    <div className="ctable-row"><span>Looker vs Looker Studio</span><span>Looker: エンタープライズ BI（有料）。Looker Studio: セルフサービス BI（無料）</span></div>
+                <div className="ttitle"><span className="tid">6.1</span>よく混同されるサービスペア</div>
+                <div className="ctable-wrap">
+                    <table className="ctable">
+                        <thead>
+                            <tr>
+                                <th>混同ペア</th>
+                                <th>正しい理解</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {CONFUSING_PAIRS.map((row, i) => (
+                                <tr key={i}>
+                                    <td><strong>{row.pair}</strong></td>
+                                    <td>{row.truth}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
@@ -640,65 +345,12 @@ function Section7() {
                 <div className="sec-num sn7">07</div>
                 <div className="sec-head-txt">
                     <h2>試験攻略チェックリスト — 必ず押さえるべき概念</h2>
-                    <p>セクション別チェックリスト・学習ロードマップ・試験当日のポイント</p>
+                    <p>セクション別チェックリスト・学習ロードマップ</p>
                 </div>
             </div>
 
             <div className="tcard">
-                <div className="ttitle"><span className="tid">7.1</span>必ず押さえるべき概念（各セクション）</div>
-                <div className="bp">
-                    <div className="bpt">ベストプラクティス: Section 1 — DX とクラウド基礎</div>
-                    <ul>
-                        <li>IaaS / PaaS / SaaS の違いと具体例（Compute Engine / App Engine / Google Workspace）</li>
-                        <li>パブリック・プライベート・ハイブリッド・マルチクラウドの違い</li>
-                        <li>CapEx vs OpEx の違いとクラウドとの関係</li>
-                        <li>クラウド移行の 6 つの R（Rehost・Replatform・Refactor・Repurchase・Retire・Retain）</li>
-                    </ul>
-                </div>
-                <div className="bp">
-                    <div className="bpt">ベストプラクティス: Section 2 — データとイノベーション</div>
-                    <ul>
-                        <li>BigQuery とはどんなサービスか（DWH・サーバーレス・SQL 分析）</li>
-                        <li>Cloud Storage のストレージクラス 4 種（Standard・Nearline・Coldline・Archive）</li>
-                        <li>DB 選択基準（RDB vs NoSQL、グローバル一貫性 vs リージョン）</li>
-                        <li>Looker / Looker Studio の違い（エンタープライズ BI vs セルフサービス）</li>
-                        <li>Pub/Sub・Dataflow・Dataproc の役割の違い</li>
-                    </ul>
-                </div>
-                <div className="bp">
-                    <div className="bpt">ベストプラクティス: Section 3 — インフラとモダナイゼーション</div>
-                    <ul>
-                        <li>コンテナと VM の違い</li>
-                        <li>Compute Engine / GKE / Cloud Run / Cloud Run Functions の使い分け</li>
-                        <li>GKE Autopilot と Standard の違い</li>
-                        <li>Cloud Interconnect vs Cloud VPN の使い分け</li>
-                        <li>Spot/Preemptible VM はいつ使うか</li>
-                    </ul>
-                </div>
-                <div className="bp">
-                    <div className="bpt">ベストプラクティス: Section 4 — セキュリティとオペレーション</div>
-                    <ul>
-                        <li>IAM の最小権限の原則・グループ管理</li>
-                        <li>リソース階層（組織→フォルダ→プロジェクト→リソース）</li>
-                        <li>Cloud Armor・Cloud KMS・Secret Manager・IAP・SCC の役割</li>
-                        <li>監査ログの種類（Admin Activity・Data Access・System Event の違い）</li>
-                        <li>費用最適化の手段（Committed Use・Spot VM・右サイズ化）</li>
-                    </ul>
-                </div>
-                <div className="bp">
-                    <div className="bpt">ベストプラクティス: Section 5 — AI/ML</div>
-                    <ul>
-                        <li>プリビルト API vs AutoML vs Vertex AI カスタムモデルの使い分け</li>
-                        <li>Gemini の 4 バリアント（Ultra・Pro・Flash・Nano）の特徴</li>
-                        <li>RAG とは何か・なぜハルシネーションを減らせるか</li>
-                        <li>責任ある AI の 6 原則</li>
-                        <li>匿名化 vs 仮名化の違い（再識別可能かどうか）</li>
-                    </ul>
-                </div>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">7.2</span>推奨学習ロードマップ</div>
+                <div className="ttitle"><span className="tid">7.1</span>推奨学習ロードマップ</div>
                 <pre className="codeblock">{`Week 1-2: 基礎概念の固め
 ├── Cloud の基本概念（IaaS/PaaS/SaaS、デプロイモデル）
 ├── Google Cloud のコアサービス概要
@@ -729,39 +381,30 @@ function Section8() {
             <div className="sec-head">
                 <div className="sec-num sn8">08</div>
                 <div className="sec-head-txt">
-                    <h2>参照リソース — 公式ドキュメント・学習パス・試験登録</h2>
-                    <p>試験当日のポイント・公式参照リソース一覧</p>
+                    <h2>参照リソース — 公式ドキュメント・試験登録</h2>
+                    <p>公式参照リソース一覧</p>
                 </div>
             </div>
 
             <div className="tcard">
-                <div className="ttitle"><span className="tid">8.1</span>試験当日のポイント</div>
-                <div className="tgrid">
-                    <div className="titem"><div className="tname">「ビジネスリーダー」の視点で解答</div><div className="tdef">技術詳細より「ビジネス価値・コスト効率・生産性向上」を重視</div></div>
-                    <div className="titem"><div className="tname">Google Cloud 固有のサービス名を覚える</div><div className="tdef">一般用語ではなく Google Cloud 固有の名前で選択肢を判断</div></div>
-                    <div className="titem"><div className="tname">「最も適切な」に注意</div><div className="tdef">複数が正しい場合でも「最もシンプル」「最もコスト効率が良い」を選ぶ</div></div>
-                    <div className="titem"><div className="tname">セキュリティ問題は最小権限の原則</div><div className="tdef">権限を広く与えるより絞る方が正解</div></div>
-                    <div className="titem"><div className="tname">マネージドサービス優先</div><div className="tdef">「自分で管理する」より「マネージドサービスを使う」が Google の推奨</div></div>
-                </div>
-            </div>
-
-            <div className="tcard">
-                <div className="ttitle"><span className="tid">8.2</span>公式参照リソース一覧</div>
-                <div className="ctable">
-                    <div className="ctable-head">
-                        <span>リソース</span><span>URL</span>
-                    </div>
-                    <div className="ctable-row"><span>試験概要ページ</span><span>cloud.google.com/learn/certification/cloud-digital-leader</span></div>
-                    <div className="ctable-row"><span>公式試験ガイド</span><span>cloud.google.com/learn/certification/guides/cloud-digital-leader</span></div>
-                    <div className="ctable-row"><span>Cloud Skills Boost 学習パス</span><span>cloudskillsboost.google/paths/9</span></div>
-                    <div className="ctable-row"><span>試験登録</span><span>cp.certmetrics.com/google/en/login</span></div>
-                    <div className="ctable-row"><span>IAM ドキュメント</span><span>cloud.google.com/iam/docs</span></div>
-                    <div className="ctable-row"><span>BigQuery ドキュメント</span><span>cloud.google.com/bigquery/docs</span></div>
-                    <div className="ctable-row"><span>Vertex AI ドキュメント</span><span>cloud.google.com/vertex-ai/docs</span></div>
-                    <div className="ctable-row"><span>セキュリティ概要</span><span>cloud.google.com/security/overview</span></div>
-                    <div className="ctable-row"><span>Google AI 原則</span><span>ai.google/responsibility/principles/</span></div>
-                    <div className="ctable-row"><span>Cloud Storage クラス</span><span>cloud.google.com/storage/docs/storage-classes</span></div>
-                    <div className="ctable-row"><span>コスト最適化</span><span>cloud.google.com/architecture/framework/cost-optimization</span></div>
+                <div className="ttitle"><span className="tid">8.1</span>公式参照リソース一覧</div>
+                <div className="ctable-wrap">
+                    <table className="ctable">
+                        <thead>
+                            <tr>
+                                <th>リソース</th>
+                                <th>URL</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {RESOURCES.map((row, i) => (
+                                <tr key={i}>
+                                    <td>{row.name}</td>
+                                    <td><a href={`https://${row.url}`} target="_blank" rel="noopener noreferrer">{row.url}</a></td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
@@ -791,11 +434,11 @@ export default function CloudDigitalLeaderPage() {
                     </span>
                     <span className="hero-badge">
                         <span className="dot dot-yellow" />
-                        60問
+                        50–60問
                     </span>
                     <span className="hero-badge">
                         <span className="dot dot-green" />
-                        合格ライン 70%
+                        推奨経験 6ヶ月+
                     </span>
                 </div>
             </section>
@@ -803,14 +446,14 @@ export default function CloudDigitalLeaderPage() {
             <nav className="snav" role="navigation" aria-label="セクションナビゲーション">
                 <div className="snav-inner">
                     <a href="#s0" className="snav-link"><span className="snav-num">00</span>試験概要</a>
-                    <a href="#s1" className="snav-link"><span className="snav-num">01</span>DX・クラウド基礎</a>
-                    <a href="#s2" className="snav-link"><span className="snav-num">02</span>データとイノベーション</a>
-                    <a href="#s3" className="snav-link"><span className="snav-num">03</span>インフラとモダナイゼーション</a>
-                    <a href="#s4" className="snav-link"><span className="snav-num">04</span>セキュリティと運用</a>
+                    <a href="#s1" className="snav-link"><span className="snav-num">01</span>DX基礎</a>
+                    <a href="#s2" className="snav-link"><span className="snav-num">02</span>データ</a>
+                    <a href="#s3" className="snav-link"><span className="snav-num">03</span>インフラ</a>
+                    <a href="#s4" className="snav-link"><span className="snav-num">04</span>セキュリティ</a>
                     <a href="#s5" className="snav-link"><span className="snav-num">05</span>AI/ML</a>
-                    <a href="#s6" className="snav-link"><span className="snav-num">06</span>サービス早見表</a>
-                    <a href="#s7" className="snav-link"><span className="snav-num">07</span>試験攻略</a>
-                    <a href="#s8" className="snav-link"><span className="snav-num">08</span>参照リソース</a>
+                    <a href="#s6" className="snav-link"><span className="snav-num">06</span>早見表</a>
+                    <a href="#s7" className="snav-link"><span className="snav-num">07</span>攻略</a>
+                    <a href="#s8" className="snav-link"><span className="snav-num">08</span>リソース</a>
                 </div>
             </nav>
 
@@ -827,7 +470,7 @@ export default function CloudDigitalLeaderPage() {
             </div>
 
             <footer className="page-footer">
-                <p>Cloud Digital Leader 認定試験 包括的解説</p>
+                <p>Cloud Digital Leader 認定試験 包括的解説 — 2024 Edition</p>
             </footer>
         </div>
     );

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -14,8 +14,10 @@ import { cn } from '@/lib/utils';
 export function Header() {
     const [isGenAiOpen, setIsGenAiOpen] = useState(false);
     const [aceOpen, setAceOpen] = useState(false);
+    const [cdlOpen, setCdlOpen] = useState(false);
     const genAiRef = useRef<HTMLDivElement>(null);
     const aceRef = useRef<HTMLDivElement>(null);
+    const cdlRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         const handleClickOutside = (e: MouseEvent) => {
@@ -25,16 +27,20 @@ export function Header() {
             if (aceOpen && aceRef.current && !aceRef.current.contains(e.target as Node)) {
                 setAceOpen(false);
             }
+            if (cdlOpen && cdlRef.current && !cdlRef.current.contains(e.target as Node)) {
+                setCdlOpen(false);
+            }
         };
 
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.key === 'Escape') {
                 if (isGenAiOpen) setIsGenAiOpen(false);
                 if (aceOpen) setAceOpen(false);
+                if (cdlOpen) setCdlOpen(false);
             }
         };
 
-        if (isGenAiOpen || aceOpen) {
+        if (isGenAiOpen || aceOpen || cdlOpen) {
             document.addEventListener('mousedown', handleClickOutside);
             document.addEventListener('keydown', handleKeyDown);
         }
@@ -43,7 +49,7 @@ export function Header() {
             document.removeEventListener('mousedown', handleClickOutside);
             document.removeEventListener('keydown', handleKeyDown);
         };
-    }, [isGenAiOpen, aceOpen]);
+    }, [isGenAiOpen, aceOpen, cdlOpen]);
 
     return (
         <nav className="sticky top-0 z-50 flex items-center gap-6 border-b border-[var(--color-border)] bg-[var(--color-background)]/95 px-6 py-3 backdrop-blur-md">
@@ -132,6 +138,41 @@ export function Header() {
                             onClick={() => setAceOpen(false)}
                         >
                             Domain 1: 環境設定 包括的解説
+                        </Link>
+                        <Link
+                            href="/gcl/associate-cloud-engineer/domain2"
+                            className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"
+                            onClick={() => setAceOpen(false)}
+                        >
+                            Domain 2: 計画と実装 包括的解説
+                        </Link>
+                        <Link
+                            href="/gcl/associate-cloud-engineer/domain3"
+                            className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"
+                            onClick={() => setAceOpen(false)}
+                        >
+                            Domain 3: 運用管理 包括的解説
+                        </Link>
+                    </div>
+                </div>
+                <div className="group relative" ref={cdlRef}>
+                    <button
+                        type="button"
+                        onClick={() => setCdlOpen((v) => !v)}
+                        aria-haspopup="true"
+                        aria-expanded={cdlOpen}
+                        className="flex items-center gap-1 text-[var(--color-muted-foreground)] transition-colors hover:text-[var(--color-foreground)]"
+                    >
+                        Cloud Digital Leader
+                        <span className="text-xs">▾</span>
+                    </button>
+                    <div className={cn("invisible absolute left-0 top-full z-50 mt-1 min-w-[280px] rounded-md border border-[var(--color-border)] bg-[var(--color-background)] py-1 opacity-0 shadow-lg transition-all group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100", cdlOpen && "!visible !opacity-100")}>
+                        <Link
+                            href="/gcl/cloud-digital-leader"
+                            className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"
+                            onClick={() => setCdlOpen(false)}
+                        >
+                            Cloud Digital Leader 認定試験
                         </Link>
                     </div>
                 </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -48,7 +48,13 @@ export function Header() {
                 Cloud Infrastructure Studies
             </Link>
             <div className="flex gap-4 text-sm">
-                <div className="group relative" ref={genAiRef}>
+                {/* Generative AI Leader */}
+                <div
+                    className="relative"
+                    ref={genAiRef}
+                    onMouseEnter={() => setOpenMenu('genai')}
+                    onMouseLeave={() => setOpenMenu(null)}
+                >
                     <button
                         type="button"
                         onClick={() => setOpenMenu((v) => v === 'genai' ? null : 'genai')}
@@ -59,7 +65,10 @@ export function Header() {
                         Generative AI Leader
                         <span className="text-xs">▾</span>
                     </button>
-                    <div className={`invisible absolute left-0 top-full z-50 mt-1 min-w-[260px] rounded-md border border-[var(--color-border)] bg-[var(--color-background)] py-1 opacity-0 shadow-lg transition-all group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100${openMenu === 'genai' ? ' !visible !opacity-100' : ''}`}>
+                    <div className={cn(
+                        "invisible absolute left-0 top-full z-50 mt-1 min-w-[260px] rounded-md border border-[var(--color-border)] bg-[var(--color-background)] py-1 opacity-0 shadow-lg transition-all",
+                        openMenu === 'genai' && "visible opacity-100"
+                    )}>
                         <Link
                             href="/gcl/genai-leader"
                             className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"
@@ -97,7 +106,14 @@ export function Header() {
                         </Link>
                     </div>
                 </div>
-                <div className="group relative" ref={aceRef}>
+
+                {/* Associate Cloud Engineer */}
+                <div
+                    className="relative"
+                    ref={aceRef}
+                    onMouseEnter={() => setOpenMenu('ace')}
+                    onMouseLeave={() => setOpenMenu(null)}
+                >
                     <button
                         type="button"
                         onClick={() => setOpenMenu((v) => v === 'ace' ? null : 'ace')}
@@ -108,7 +124,10 @@ export function Header() {
                         Associate Cloud Engineer
                         <span className="text-xs">▾</span>
                     </button>
-                    <div className={cn("invisible absolute left-0 top-full z-50 mt-1 min-w-[280px] rounded-md border border-[var(--color-border)] bg-[var(--color-background)] py-1 opacity-0 shadow-lg transition-all group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100", openMenu === 'ace' && "!visible !opacity-100")}>
+                    <div className={cn(
+                        "invisible absolute left-0 top-full z-50 mt-1 min-w-[280px] rounded-md border border-[var(--color-border)] bg-[var(--color-background)] py-1 opacity-0 shadow-lg transition-all",
+                        openMenu === 'ace' && "visible opacity-100"
+                    )}>
                         <Link
                             href="/gcl/associate-cloud-engineer"
                             className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"
@@ -146,7 +165,14 @@ export function Header() {
                         </Link>
                     </div>
                 </div>
-                <div className="group relative" ref={cdlRef}>
+
+                {/* Cloud Digital Leader */}
+                <div
+                    className="relative"
+                    ref={cdlRef}
+                    onMouseEnter={() => setOpenMenu('cdl')}
+                    onMouseLeave={() => setOpenMenu(null)}
+                >
                     <button
                         type="button"
                         onClick={() => setOpenMenu((v) => v === 'cdl' ? null : 'cdl')}
@@ -157,7 +183,10 @@ export function Header() {
                         Cloud Digital Leader
                         <span className="text-xs">▾</span>
                     </button>
-                    <div className={cn("invisible absolute left-0 top-full z-50 mt-1 min-w-[280px] rounded-md border border-[var(--color-border)] bg-[var(--color-background)] py-1 opacity-0 shadow-lg transition-all group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100", openMenu === 'cdl' && "!visible !opacity-100")}>
+                    <div className={cn(
+                        "invisible absolute left-0 top-full z-50 mt-1 min-w-[280px] rounded-md border border-[var(--color-border)] bg-[var(--color-background)] py-1 opacity-0 shadow-lg transition-all",
+                        openMenu === 'cdl' && "visible opacity-100"
+                    )}>
                         <Link
                             href="/gcl/cloud-digital-leader"
                             className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -12,44 +12,35 @@ import { cn } from '@/lib/utils';
  * @returns A JSX element representing the sticky top navigation bar with a home link and two dropdown menus
  */
 export function Header() {
-    const [isGenAiOpen, setIsGenAiOpen] = useState(false);
-    const [aceOpen, setAceOpen] = useState(false);
-    const [cdlOpen, setCdlOpen] = useState(false);
+    const [openMenu, setOpenMenu] = useState<'genai' | 'ace' | 'cdl' | null>(null);
     const genAiRef = useRef<HTMLDivElement>(null);
     const aceRef = useRef<HTMLDivElement>(null);
     const cdlRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
+        if (openMenu === null) return;
+
+        const refMap = { genai: genAiRef, ace: aceRef, cdl: cdlRef } as const;
+
         const handleClickOutside = (e: MouseEvent) => {
-            if (isGenAiOpen && genAiRef.current && !genAiRef.current.contains(e.target as Node)) {
-                setIsGenAiOpen(false);
-            }
-            if (aceOpen && aceRef.current && !aceRef.current.contains(e.target as Node)) {
-                setAceOpen(false);
-            }
-            if (cdlOpen && cdlRef.current && !cdlRef.current.contains(e.target as Node)) {
-                setCdlOpen(false);
+            const ref = refMap[openMenu];
+            if (ref.current && !ref.current.contains(e.target as Node)) {
+                setOpenMenu(null);
             }
         };
 
         const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') {
-                if (isGenAiOpen) setIsGenAiOpen(false);
-                if (aceOpen) setAceOpen(false);
-                if (cdlOpen) setCdlOpen(false);
-            }
+            if (e.key === 'Escape') setOpenMenu(null);
         };
 
-        if (isGenAiOpen || aceOpen || cdlOpen) {
-            document.addEventListener('mousedown', handleClickOutside);
-            document.addEventListener('keydown', handleKeyDown);
-        }
+        document.addEventListener('mousedown', handleClickOutside);
+        document.addEventListener('keydown', handleKeyDown);
 
         return () => {
             document.removeEventListener('mousedown', handleClickOutside);
             document.removeEventListener('keydown', handleKeyDown);
         };
-    }, [isGenAiOpen, aceOpen, cdlOpen]);
+    }, [openMenu]);
 
     return (
         <nav className="sticky top-0 z-50 flex items-center gap-6 border-b border-[var(--color-border)] bg-[var(--color-background)]/95 px-6 py-3 backdrop-blur-md">
@@ -60,47 +51,47 @@ export function Header() {
                 <div className="group relative" ref={genAiRef}>
                     <button
                         type="button"
-                        onClick={() => setIsGenAiOpen((v) => !v)}
+                        onClick={() => setOpenMenu((v) => v === 'genai' ? null : 'genai')}
                         aria-haspopup="true"
-                        aria-expanded={isGenAiOpen}
+                        aria-expanded={openMenu === 'genai'}
                         className="flex items-center gap-1 text-[var(--color-muted-foreground)] transition-colors hover:text-[var(--color-foreground)]"
                     >
                         Generative AI Leader
                         <span className="text-xs">▾</span>
                     </button>
-                    <div className={`invisible absolute left-0 top-full z-50 mt-1 min-w-[260px] rounded-md border border-[var(--color-border)] bg-[var(--color-background)] py-1 opacity-0 shadow-lg transition-all group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100${isGenAiOpen ? ' !visible !opacity-100' : ''}`}>
+                    <div className={`invisible absolute left-0 top-full z-50 mt-1 min-w-[260px] rounded-md border border-[var(--color-border)] bg-[var(--color-background)] py-1 opacity-0 shadow-lg transition-all group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100${openMenu === 'genai' ? ' !visible !opacity-100' : ''}`}>
                         <Link
                             href="/gcl/genai-leader"
                             className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"
-                            onClick={() => setIsGenAiOpen(false)}
+                            onClick={() => setOpenMenu(null)}
                         >
                             Generative AI Leader 概要
                         </Link>
                         <Link
                             href="/gcl/genai-leader/section1"
                             className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"
-                            onClick={() => setIsGenAiOpen(false)}
+                            onClick={() => setOpenMenu(null)}
                         >
                             Section 1: Gen AI 基礎知識
                         </Link>
                         <Link
                             href="/gcl/genai-leader/section2"
                             className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"
-                            onClick={() => setIsGenAiOpen(false)}
+                            onClick={() => setOpenMenu(null)}
                         >
                             Section 2: Google Cloud Gen AI サービス
                         </Link>
                         <Link
                             href="/gcl/genai-leader/section3"
                             className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"
-                            onClick={() => setIsGenAiOpen(false)}
+                            onClick={() => setOpenMenu(null)}
                         >
                             Section 3: モデル出力改善技術
                         </Link>
                         <Link
                             href="/gcl/genai-leader/section4"
                             className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"
-                            onClick={() => setIsGenAiOpen(false)}
+                            onClick={() => setOpenMenu(null)}
                         >
                             Section 4: ビジネス戦略
                         </Link>
@@ -109,47 +100,47 @@ export function Header() {
                 <div className="group relative" ref={aceRef}>
                     <button
                         type="button"
-                        onClick={() => setAceOpen((v) => !v)}
+                        onClick={() => setOpenMenu((v) => v === 'ace' ? null : 'ace')}
                         aria-haspopup="true"
-                        aria-expanded={aceOpen}
+                        aria-expanded={openMenu === 'ace'}
                         className="flex items-center gap-1 text-[var(--color-muted-foreground)] transition-colors hover:text-[var(--color-foreground)]"
                     >
                         Associate Cloud Engineer
                         <span className="text-xs">▾</span>
                     </button>
-                    <div className={cn("invisible absolute left-0 top-full z-50 mt-1 min-w-[280px] rounded-md border border-[var(--color-border)] bg-[var(--color-background)] py-1 opacity-0 shadow-lg transition-all group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100", aceOpen && "!visible !opacity-100")}>
+                    <div className={cn("invisible absolute left-0 top-full z-50 mt-1 min-w-[280px] rounded-md border border-[var(--color-border)] bg-[var(--color-background)] py-1 opacity-0 shadow-lg transition-all group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100", openMenu === 'ace' && "!visible !opacity-100")}>
                         <Link
                             href="/gcl/associate-cloud-engineer"
                             className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"
-                            onClick={() => setAceOpen(false)}
+                            onClick={() => setOpenMenu(null)}
                         >
                             概要
                         </Link>
                         <Link
                             href="/gcl/associate-cloud-engineer/architecture-guide"
                             className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"
-                            onClick={() => setAceOpen(false)}
+                            onClick={() => setOpenMenu(null)}
                         >
                             試験対策・アーキテクチャ詳細ガイド
                         </Link>
                         <Link
                             href="/gcl/associate-cloud-engineer/domain1"
                             className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"
-                            onClick={() => setAceOpen(false)}
+                            onClick={() => setOpenMenu(null)}
                         >
                             Domain 1: 環境設定 包括的解説
                         </Link>
                         <Link
                             href="/gcl/associate-cloud-engineer/domain2"
                             className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"
-                            onClick={() => setAceOpen(false)}
+                            onClick={() => setOpenMenu(null)}
                         >
                             Domain 2: 計画と実装 包括的解説
                         </Link>
                         <Link
                             href="/gcl/associate-cloud-engineer/domain3"
                             className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"
-                            onClick={() => setAceOpen(false)}
+                            onClick={() => setOpenMenu(null)}
                         >
                             Domain 3: 運用管理 包括的解説
                         </Link>
@@ -158,19 +149,19 @@ export function Header() {
                 <div className="group relative" ref={cdlRef}>
                     <button
                         type="button"
-                        onClick={() => setCdlOpen((v) => !v)}
+                        onClick={() => setOpenMenu((v) => v === 'cdl' ? null : 'cdl')}
                         aria-haspopup="true"
-                        aria-expanded={cdlOpen}
+                        aria-expanded={openMenu === 'cdl'}
                         className="flex items-center gap-1 text-[var(--color-muted-foreground)] transition-colors hover:text-[var(--color-foreground)]"
                     >
                         Cloud Digital Leader
                         <span className="text-xs">▾</span>
                     </button>
-                    <div className={cn("invisible absolute left-0 top-full z-50 mt-1 min-w-[280px] rounded-md border border-[var(--color-border)] bg-[var(--color-background)] py-1 opacity-0 shadow-lg transition-all group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100", cdlOpen && "!visible !opacity-100")}>
+                    <div className={cn("invisible absolute left-0 top-full z-50 mt-1 min-w-[280px] rounded-md border border-[var(--color-border)] bg-[var(--color-background)] py-1 opacity-0 shadow-lg transition-all group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100", openMenu === 'cdl' && "!visible !opacity-100")}>
                         <Link
                             href="/gcl/cloud-digital-leader"
                             className="block px-4 py-2 text-sm text-[var(--color-muted-foreground)] hover:bg-[var(--color-accent)] hover:text-[var(--color-foreground)]"
-                            onClick={() => setCdlOpen(false)}
+                            onClick={() => setOpenMenu(null)}
                         >
                             Cloud Digital Leader 認定試験
                         </Link>

--- a/gcdl-certification-comprehensive-guide.md
+++ b/gcdl-certification-comprehensive-guide.md
@@ -78,6 +78,7 @@ BIは「過去に何が起こり、現在どのような状態にあるか」を
 さらに、AIの判断根拠を人間が理解できる形で提示する「Explainable AI（説明可能なAI）」や、バイアスを排除し倫理的な利用を保証する「責任あるAI」の原則が、企業としての信頼性を維持する上で不可欠な要素となっている [2](https://cloud.google.com/learn/certification/cloud-digital-leader?hl=en)。
 Google Cloud における AI/ML ソリューションの選択
 Google Cloud は、組織の専門知識のレベル、必要なカスタマイズの度合い、そして市場投入までのスピード（Time to Market）のバランスに基づいて選択できる、多層的な AI ソリューションを提供している。
+
 1. 事前学習済み API (Pre-trained APIs):
 機械学習の専門知識を持たない開発者であっても、Google が数千億のデータポイントから学習させた強力なモデルを、シンプルなAPI呼び出しで即座にアプリケーションに統合できる。
 画像や動画の内容を分析する Vision API、テキストの感情やエンティティを抽出する Natural Language API、多言語間の翻訳を行う Cloud Translation API、音声をテキスト化する Speech-to-Text API などが存在する [2](https://cloud.google.com/learn/certification/cloud-digital-leader?hl=en)。

--- a/google-cloud-digital-leader-comprehensive-guide.md
+++ b/google-cloud-digital-leader-comprehensive-guide.md
@@ -49,8 +49,8 @@ Cloud Digital Leader (CDL) は Google Cloud が提供する **ビジネスリー
 
 > 📎 **公式リソース**  
 > 試験ページ: https://cloud.google.com/learn/certification/cloud-digital-leader  
-> 公式学習パス: https://www.cloudskillsboost.google/paths/9  
-> 試験ガイドPDF: https://services.google.com/fh/files/misc/cdl_exam_guide_english.pdf
+> 公式試験ガイド: https://cloud.google.com/learn/certification/guides/cloud-digital-leader  
+> 公式学習パス: https://www.cloudskillsboost.google/paths/9
 
 ---
 


### PR DESCRIPTION
主に Cloud Digital Leader (CDL)
  ページのリファクタリング、最新化、およびナビゲーション（Header）の動作改善に焦点が当てられています。

  コミット履歴の要約

   1. CSS 変数のセマンティック化とスコープ適正化
       * ページ固有の変数（--cdl-*）をグローバルなセマンティックトークン（--color-background
         等）にマッピングし、Header 等の共通コンポーネントが各ページのテーマに自動適応するようにしました。
       * テーマの漏洩を防ぐため、変数の定義スコープを :root から .cdl-page クラス限定に修正しました。
       * パフォーマンス向上のため、ワイルドカードセレクタ（*）を具体的な要素リストに置き換えました。

   2. CDL ページの大規模リファクタリングとコンテンツ更新
       * データの外部化: 静的コンテンツを constants.ts に抽出し、TypeScript による型定義（ExamDomain
         等）を追加して保守性と型安全性を向上させました。
       * 最新情報の反映: 試験仕様（90分、50-60問、$99等）、出題ドメイン（最新6領域）、および Google AI
         の「7つの原則」を最新の公式ガイドに基づいて更新しました。
       * セマンティック HTML への変換: div ベースの擬似テーブルを正式な <table> 構造に刷新しました。

   3. Header コンポーネントの動作改善
       * ドロップダウンの制御を CSS 依存から React の openMenu 状態管理に完全に移行しました。
       * マウスホバーとクリックの両方に対応し、外側クリックや Escape
         キーでメニューが閉じるようにロジックを強化しました。

   4. テストコードの品質向上
       * Header
         のテストにおいて、ドロップダウンを明示的に開いてからリンクを確認する手順に変更し、実際のユーザー操作に近い
         検証を行うようにしました。
       * CDL
         ページのテストを新しいセクション構成（全9見出し）に合わせて更新し、より厳密な要素検索を行うように修正しまし
         た。

  主要なコミットハッシュ（参考）
   * 0074941: CSS 変数のスコープを .cdl-page に限定。
   * d80fe72: CSS セレクタ最適化、定数への型定義追加、セクション数修正。
   * f8b9781: テスト記述の整合性修正、フッター年号更新。
   * 2587ab4: constants.ts 抽出、<table> 移行、最新試験ガイドへの更新、Header ロジック刷新。
   * da90a16: CSS 変数のセマンティック移行とインポートの layout.tsx への移動。