### PR TITLE
Add PCNE module with Section 1-2, tests, and header integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,5 +99,7 @@ Aws/                                # AWS資料アーカイブ
 - **コードブロック内の改行 (`.code-block`)**: JSX変換時、コード内の改行に `{"\n"}` を使用せず、各行を `<div className="code-line">...</div>` でラップすること。`.code-line` は `white-space: pre` を適用してインデントを保持し、`map` 展開時は安定した `key` を付与すること。
 - **表形式データの構造化**: テキストのスペース揃えで列を表現したデータは、フォント変更による列ズレを防ぐため、必ず `<table>` 要素に変換すること。その際、必ず `<thead>` と `<th scope="col">` を用いたセマンティックな構造にすること。
 - **CSS変数・テーマトークンの適用**: `globals.css` の3層アーキテクチャ CSS 変数（`--color-background`, `--color-foreground`, `--color-border` など）を厳格に使用すること。独自のローカル変数定義や `--color-bg-primary` のような実在しないトークンの使用は避ける。コンポーネントレベルの CSS 内で新たなカスタムプロパティ（`--*`）を定義することは禁止する。
+- **レイアウトと最大幅の制約**: 各セクションのメインコンテンツは画面幅いっぱいに広がらないよう、CSS Modulesで `max-width` (例: 1000px または `.container` ラッパー) を設定し、中央寄せにすること。`SharedSection.module.css` のような共通スタイルでは `.section > *` セレクタ等を活用して内部の幅を制限し、背景や下線は画面全体に広がるようにする。
+- **グローバルメニューの運用**: `components/Header.tsx` のようなグローバルナビゲーションには、未作成・未完成のセクションへのリンクは配置せず、ページが作成されてから随時追加すること。
 - 新ページを `app/gcl/` に追加した場合、`components/Header.tsx` のナビゲーションも更新すること
 - ページ固有の共通定数は `constants.ts` に集約する（`app/gcl/genai-leader/constants.ts` 参照）

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -45,7 +45,9 @@
 - **Client/Server コンポーネント境界**: ページ固有のアンカーナビなど状態やブラウザAPIに依存するUIは `'use client'` ディレクティブを含む専用コンポーネントとして切り出し、メインの `page.tsx` を Server Component として維持してください。また、Client コンポーネント内でサーバー専用API (`fs`, `cookies`, `headers`) を参照することは禁止し、PropsはJSONシリアライズ可能なものに限定してください。
 - **コードブロック内の改行 (`.code-block`)**: JSX変換時、コード内の改行に `{"\n"}` を使用せず、各行を `<div className="code-line">...</div>` でラップしてください。`.code-line` は `white-space: pre` 等でインデントを保持し、`map` での展開時には安定した `key` を付与してください。
 - **表形式データの構造化**: テキストのスペース揃えで列を表現したデータは、フォント変更による列ズレを防ぐため、必ず `<table>` 要素に変換してください。その際、必ず `<thead>` を含め、見出しセルには `<th scope="col">` を使用してください。
-- **CSS変数・テーマトークンの適用**: `globals.css` の3層アーキテクチャ CSS 変数（`--color-background`, `--color-foreground`, `--color-card` など）を厳格に使用してください。コンポーネントの CSS 内で新しいカスタムプロパティ (`--*`) を定義することは禁止します（グローバルな `@theme` トークンのみを参照）。
+- **CSS変数・テーマトークンの適用**: `globals.css` の3層アーキテクチャ CSS 変数（`--color-background`, `--color-foreground`, `--color-card` など）を厳格に使用すること。コンポーネントの CSS 内で新しいカスタムプロパティ (`--*`) を定義することは禁止します（グローバルな `@theme` トークンのみを参照）。
+- **レイアウトと最大幅の制約**: 各セクションのメインコンテンツは画面幅いっぱいに広がらないよう、CSS Modulesで `max-width` (例: 1000px または `.container` ラッパー) を設定し、中央寄せにしてください。`SharedSection.module.css` のような共通スタイルでは `.section > *` セレクタ等を活用して内部の幅を制限し、背景や下線は画面全体に広がるようにします。
+- **グローバルメニューの運用**: `components/Header.tsx` のようなグローバルナビゲーションには、未作成・未完成のセクションへのリンクは配置せず、該当ページやセクションが実装されてから追加するようにしてください。
 - ページコンポーネント（`page.tsx`）が巨大化するのを防ぐため、各セクションは必ず `components/sections/` に分割し、スタイリングには CSS Modules (`*.module.css`) を使用してください。セクション間で共通のスタイル（例: `SectionBase.module.css`）を利用する場合は、CSS 内での `@import` を避け、各 TSX ファイルから直接 `import baseStyles from './SectionBase.module.css'` のようにインポートして適用してください。
 - ASCIIダイアグラムの使用を避け、専用の SVG コンポーネント (`DiagramSVG.tsx` 等) に置き換えてください。型の制約（Discriminated Union）により、アクセシビリティを担保するための `ariaLabel="説明文"` または `decorative={true}` の指定が必須となります。
 - アクセシビリティ（`aria-label` 等の付与）を徹底し、コンポーネントやユーティリティ関数には Docstrings (JSDoc) を追加してください。

--- a/MIGRATION_PROGRESS.md
+++ b/MIGRATION_PROGRESS.md
@@ -4,16 +4,37 @@ HTMLファイルから Next.js / React コンポーネントへの移行作業�
 
 ## 現在地
 
-- **最新 HEAD:** (Commit Pending) feat(cdl/s6): implement Section 7 Exam Preparation with TDD
-- **次の作業:** Cloud Digital Leader の全セクション移行完了。必要に応じた他のセクションへの移行、または全体の見直し。
-- **テスト数:** 250件パス (Section 6: layout, page, Section1〜7 を含む全テスト)
+- **最新 HEAD:** (Commit Pending) feat(pcne): base setup and constants
+- **次の作業:** PCNE Step 1: Base Setup & Constants
+- **テスト数:** 250件パス 
 - **ビルド:** 成功 (Next.js 16.2.3 Turbopack)
-- **最終更新日時(UTC):** 2026-05-10T02:30:00Z
+- **最終更新日時(UTC):** 2026-05-10T02:40:00Z
 
 ## 次回セッションでの再開プロンプト
 
-Cloud Digital Leader Section 6 の移行がすべて完了しました（E2Eテストはスキップ）。
-次は他のセクション（Generative AI Leaderの残りなど）の移行、もしくは全体の品質改善から再開してください。
+Professional Cloud Network Engineer (PCNE) の移行の Step 1 (Base Setup & Constants) を開始してください。
+
+---
+
+## 2026-05-10: Professional Cloud Network Engineer Migration (In Progress)
+
+### 完了済み
+
+- **Step 1: Base Setup & Constants**: 
+  - `constants.ts`, `layout.tsx`, `page.tsx`, `pcne.module.css` を作成。
+  - Heroセクション、スティッキーナビゲーションの実装。
+
+### 次のステップ
+
+- [x] **Step 1: Base Setup & Constants**: `constants.ts`, `layout.tsx`, `page.tsx`, `pcne.module.css`
+- [ ] **Step 2: INTRO (試験の全体像と準備方法)**
+- [ ] **Step 3: Section 1 (VPC ネットワークの設計・実装)**
+- [ ] **Step 4: Section 2 (ハイブリッド・マルチクラウド接続)**
+- [ ] **Step 5: Section 3 (ロードバランシングと最適化)**
+- [ ] **Step 6: Section 4 (ネットワークサービスとDNS)**
+- [ ] **Step 7: Section 5 (ネットワークセキュリティ)**
+- [ ] **Step 8: Section 6 (監視・トラブルシュート)**
+- [ ] **Step 9: まとめ (試験攻略チートシート & 混同しやすいポイント)**
 
 ---
 

--- a/MIGRATION_PROGRESS.md
+++ b/MIGRATION_PROGRESS.md
@@ -4,15 +4,15 @@ HTMLファイルから Next.js / React コンポーネントへの移行作業�
 
 ## 現在地
 
-- **最新 HEAD:** (Commit Pending) feat(pcne): base setup and constants
-- **次の作業:** PCNE Step 1: Base Setup & Constants
-- **テスト数:** 250件パス 
+- **最新 HEAD:** (Commit Pending) feat(pcne): implement Section Intro with TDD
+- **次の作業:** PCNE Step 3: Section 1 (VPC ネットワークの設計・実装)
+- **テスト数:** 256件パス 
 - **ビルド:** 成功 (Next.js 16.2.3 Turbopack)
 - **最終更新日時(UTC):** 2026-05-10T02:40:00Z
 
 ## 次回セッションでの再開プロンプト
 
-Professional Cloud Network Engineer (PCNE) の移行の Step 1 (Base Setup & Constants) を開始してください。
+Professional Cloud Network Engineer (PCNE) の移行の Step 3 (Section 1: VPC ネットワークの設計・実装) を開始してください。
 
 ---
 
@@ -23,11 +23,14 @@ Professional Cloud Network Engineer (PCNE) の移行の Step 1 (Base Setup & Con
 - **Step 1: Base Setup & Constants**: 
   - `constants.ts`, `layout.tsx`, `page.tsx`, `pcne.module.css` を作成。
   - Heroセクション、スティッキーナビゲーションの実装。
+- **Step 2: INTRO (試験の全体像と準備方法)**:
+  - `SectionIntro.tsx` を TDD で実装。
+  - 出題配点バー、推奨学習ステップ、公式リソースを移行。
 
 ### 次のステップ
 
 - [x] **Step 1: Base Setup & Constants**: `constants.ts`, `layout.tsx`, `page.tsx`, `pcne.module.css`
-- [ ] **Step 2: INTRO (試験の全体像と準備方法)**
+- [x] **Step 2: INTRO (試験の全体像と準備方法)**
 - [ ] **Step 3: Section 1 (VPC ネットワークの設計・実装)**
 - [ ] **Step 4: Section 2 (ハイブリッド・マルチクラウド接続)**
 - [ ] **Step 5: Section 3 (ロードバランシングと最適化)**

--- a/MIGRATION_PROGRESS.md
+++ b/MIGRATION_PROGRESS.md
@@ -4,21 +4,20 @@ HTMLファイルから Next.js / React コンポーネントへの移行作業�
 
 ## 現在地
 
-- **最新 HEAD:** `97faa28` feat(cdl/s6): implement Section 6 Sustainability with TDD
-- **次の作業:** CDL Section 6 Part 7 Exam Preparation (Section7.tsx) の移行
-- **テスト数:** 246件パス (Section 6: layout, page, Section1〜6 を含む全テスト)
-- **ビルド:** 成功
-- **最終更新日時(UTC):** 2026-05-09T10:15:00Z
+- **最新 HEAD:** (Commit Pending) feat(cdl/s6): implement Section 7 Exam Preparation with TDD
+- **次の作業:** Cloud Digital Leader の全セクション移行完了。必要に応じた他のセクションへの移行、または全体の見直し。
+- **テスト数:** 250件パス (Section 6: layout, page, Section1〜7 を含む全テスト)
+- **ビルド:** 成功 (Next.js 16.2.3 Turbopack)
+- **最終更新日時(UTC):** 2026-05-10T02:30:00Z
 
 ## 次回セッションでの再開プロンプト
 
-CDL Section 6 の移行を Step 7 まで完了しました。
-Step 7 (Part 6 Sustainability) が TDD で実装済みです。
-次は Step 8: Part 7 Exam Preparation (Section7.tsx) の移行から再開してください。
+Cloud Digital Leader Section 6 の移行がすべて完了しました（E2Eテストはスキップ）。
+次は他のセクション（Generative AI Leaderの残りなど）の移行、もしくは全体の品質改善から再開してください。
 
 ---
 
-## 2026-05-08: Cloud Digital Leader Section 6 Migration (In Progress)
+## 2026-05-08: Cloud Digital Leader Section 6 Migration (完了)
 
 ### 完了済み
 
@@ -38,11 +37,15 @@ Step 7 (Part 6 Sustainability) が TDD で実装済みです。
 - **Step 7: Part 6 - Sustainability**:
   - `Section6.tsx` を TDD で実装。Google の環境目標（24/7 カーボンフリー）、Carbon Footprint レポート、Scope 1/2/3 の定義、クラウド移行の環境メリットを移行。
   - `page.tsx` に `Section6` を統合。
+- **Step 8: Part 7 - Exam Preparation**:
+  - `Section7.tsx` を TDD で実装。頻出問題パターン、キーワードマップ、推奨学習リソースを移行。
+  - `page.tsx` に `Section7` を統合。
+- **最終調整**:
+  - E2E検証はスキップし、本番ビルドの成功を確認。
 
 ### 次のステップ
 
-- [ ] Step 8: Part 7 - Exam Preparation (`Section7.tsx`) の移行。
-- [ ] 最終的な調整と統合。
+- [ ] (なし) Section 6 は完了。
 
 ---
 

--- a/MIGRATION_PROGRESS.md
+++ b/MIGRATION_PROGRESS.md
@@ -4,15 +4,15 @@ HTMLファイルから Next.js / React コンポーネントへの移行作業�
 
 ## 現在地
 
-- **最新 HEAD:** (Commit Pending) feat(pcne): implement Section 1 with TDD
-- **次の作業:** PCNE Step 4: Section 2 (ハイブリッド・マルチクラウド接続)
-- **テスト数:** 261件パス 
+- **最新 HEAD:** (Commit Pending) feat(pcne): implement Section 2 with TDD
+- **次の作業:** PCNE Step 5: Section 3 (ロードバランシングと最適化)
+- **テスト数:** 266件パス 
 - **ビルド:** 成功 (Next.js 16.2.3 Turbopack)
-- **最終更新日時(UTC):** 2026-05-10T02:47:00Z
+- **最終更新日時(UTC):** 2026-05-10T02:55:00Z
 
 ## 次回セッションでの再開プロンプト
 
-Professional Cloud Network Engineer (PCNE) の移行の Step 4 (Section 2: ハイブリッド・マルチクラウド接続) を開始してください。
+Professional Cloud Network Engineer (PCNE) の移行の Step 5 (Section 3: ロードバランシングと最適化) を開始してください。
 
 ---
 
@@ -29,13 +29,16 @@ Professional Cloud Network Engineer (PCNE) の移行の Step 4 (Section 2: ハ�
 - **Step 3: Section 1 (VPC ネットワークの設計・実装)**:
   - `Section1.tsx` を TDD で実装。
   - VPCモード比較、ファイアウォールルール、VPCピアリングとShared VPCの違い、Cloud NAT・PGA・PSCの比較を移行。
+- **Step 4: Section 2 (ハイブリッド・マルチクラウド接続)**:
+  - `Section2.tsx` を TDD で実装。
+  - VPN/Interconnectの比較、HA VPN、Dedicated Interconnect の SLA要件、Cloud Router と BGP を移行。
 
 ### 次のステップ
 
 - [x] **Step 1: Base Setup & Constants**: `constants.ts`, `layout.tsx`, `page.tsx`, `pcne.module.css`
 - [x] **Step 2: INTRO (試験の全体像と準備方法)**
 - [x] **Step 3: Section 1 (VPC ネットワークの設計・実装)**
-- [ ] **Step 4: Section 2 (ハイブリッド・マルチクラウド接続)**
+- [x] **Step 4: Section 2 (ハイブリッド・マルチクラウド接続)**
 - [ ] **Step 5: Section 3 (ロードバランシングと最適化)**
 - [ ] **Step 6: Section 4 (ネットワークサービスとDNS)**
 - [ ] **Step 7: Section 5 (ネットワークセキュリティ)**

--- a/MIGRATION_PROGRESS.md
+++ b/MIGRATION_PROGRESS.md
@@ -6,7 +6,7 @@ HTMLファイルから Next.js / React コンポーネントへの移行作業�
 
 - **最新 HEAD:** (Commit Pending) feat(pcne): implement Section 2 with TDD
 - **次の作業:** PCNE Step 5: Section 3 (ロードバランシングと最適化)
-- **テスト数:** 266件パス 
+- **テスト数:** 266件パス
 - **ビルド:** 成功 (Next.js 16.2.3 Turbopack)
 - **最終更新日時(UTC):** 2026-05-10T02:55:00Z
 
@@ -20,7 +20,7 @@ Professional Cloud Network Engineer (PCNE) の移行の Step 5 (Section 3: ロ�
 
 ### 完了済み
 
-- **Step 1: Base Setup & Constants**: 
+- **Step 1: Base Setup & Constants**:
   - `constants.ts`, `layout.tsx`, `page.tsx`, `pcne.module.css` を作成。
   - Heroセクション、スティッキーナビゲーションの実装。
 - **Step 2: INTRO (試験の全体像と準備方法)**:
@@ -51,7 +51,7 @@ Professional Cloud Network Engineer (PCNE) の移行の Step 5 (Section 3: ロ�
 
 ### 完了済み
 
-- **Step 1: Base Setup & Constants**: 
+- **Step 1: Base Setup & Constants**:
   - `constants.ts`, `layout.tsx`, `page.tsx`, `section6.module.css` を作成。
   - Heroセクション、スティッキーナビゲーションの実装。
 - **Step 2: Part 1 - Financial Governance**:

--- a/MIGRATION_PROGRESS.md
+++ b/MIGRATION_PROGRESS.md
@@ -4,15 +4,15 @@ HTMLファイルから Next.js / React コンポーネントへの移行作業�
 
 ## 現在地
 
-- **最新 HEAD:** (Commit Pending) feat(pcne): implement Section Intro with TDD
-- **次の作業:** PCNE Step 3: Section 1 (VPC ネットワークの設計・実装)
-- **テスト数:** 256件パス 
+- **最新 HEAD:** (Commit Pending) feat(pcne): implement Section 1 with TDD
+- **次の作業:** PCNE Step 4: Section 2 (ハイブリッド・マルチクラウド接続)
+- **テスト数:** 261件パス 
 - **ビルド:** 成功 (Next.js 16.2.3 Turbopack)
-- **最終更新日時(UTC):** 2026-05-10T02:40:00Z
+- **最終更新日時(UTC):** 2026-05-10T02:47:00Z
 
 ## 次回セッションでの再開プロンプト
 
-Professional Cloud Network Engineer (PCNE) の移行の Step 3 (Section 1: VPC ネットワークの設計・実装) を開始してください。
+Professional Cloud Network Engineer (PCNE) の移行の Step 4 (Section 2: ハイブリッド・マルチクラウド接続) を開始してください。
 
 ---
 
@@ -26,12 +26,15 @@ Professional Cloud Network Engineer (PCNE) の移行の Step 3 (Section 1: VPC �
 - **Step 2: INTRO (試験の全体像と準備方法)**:
   - `SectionIntro.tsx` を TDD で実装。
   - 出題配点バー、推奨学習ステップ、公式リソースを移行。
+- **Step 3: Section 1 (VPC ネットワークの設計・実装)**:
+  - `Section1.tsx` を TDD で実装。
+  - VPCモード比較、ファイアウォールルール、VPCピアリングとShared VPCの違い、Cloud NAT・PGA・PSCの比較を移行。
 
 ### 次のステップ
 
 - [x] **Step 1: Base Setup & Constants**: `constants.ts`, `layout.tsx`, `page.tsx`, `pcne.module.css`
 - [x] **Step 2: INTRO (試験の全体像と準備方法)**
-- [ ] **Step 3: Section 1 (VPC ネットワークの設計・実装)**
+- [x] **Step 3: Section 1 (VPC ネットワークの設計・実装)**
 - [ ] **Step 4: Section 2 (ハイブリッド・マルチクラウド接続)**
 - [ ] **Step 5: Section 3 (ロードバランシングと最適化)**
 - [ ] **Step 6: Section 4 (ネットワークサービスとDNS)**

--- a/__tests__/gcl/cloud-digital-leader/section6/Section7.test.tsx
+++ b/__tests__/gcl/cloud-digital-leader/section6/Section7.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Section7 } from '../../../../app/gcl/cloud-digital-leader/section6/components/Section7';
+
+describe('CDL Section 6 - Section 7 (Exam Preparation)', () => {
+    it('renders the section title correctly', () => {
+        render(<Section7 />);
+        expect(screen.getByRole('heading', { name: /試験対策/, level: 2 })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: /チェックリスト/, level: 2 })).toBeInTheDocument();
+    });
+
+    it('renders the frequency patterns section correctly', () => {
+        render(<Section7 />);
+        expect(screen.getByText(/頻出問題パターン TOP 10/)).toBeInTheDocument();
+        expect(screen.getByText(/PATTERN 01 — 財務ガバナンス/)).toBeInTheDocument();
+        expect(screen.getByText(/「予算の上限に達したらどうなるか？」/)).toBeInTheDocument();
+        expect(screen.getByText(/PATTERN 02 — Cloud Monitoring/)).toBeInTheDocument();
+        expect(screen.getByText(/PATTERN 10 — Error Budget/)).toBeInTheDocument();
+    });
+
+    it('renders the keyword map correctly', () => {
+        render(<Section7 />);
+        expect(screen.getByText(/Section 6 キーワードマップ/)).toBeInTheDocument();
+        expect(screen.getByRole('table')).toBeInTheDocument();
+        expect(screen.getByText('カテゴリ')).toBeInTheDocument();
+        expect(screen.getByText('重要キーワード')).toBeInTheDocument();
+        expect(screen.getByText('重要度')).toBeInTheDocument();
+        expect(screen.getByText('財務ガバナンス')).toBeInTheDocument();
+        expect(screen.getByText(/予算アラート、Committed Use Discounts/)).toBeInTheDocument();
+    });
+
+    it('renders the official sources correctly', () => {
+        render(<Section7 />);
+        expect(screen.getByText(/推奨学習リソース/)).toBeInTheDocument();
+        expect(screen.getByText(/Cloud Digital Leader 公式試験ガイド（PDF）/)).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /https:\/\/services\.google\.com\/fh\/files\/misc\/cloud_digital_leader_exam_guide_english\.pdf/ })).toBeInTheDocument();
+        expect(screen.getByText(/Cloud Digital Leader 認定資格 公式ページ/)).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /https:\/\/cloud\.google\.com\/learn\/certification\/cloud-digital-leader/ })).toBeInTheDocument();
+        expect(screen.getByText(/Cloud Billing — 予算とアラート/)).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /https:\/\/cloud\.google\.com\/billing\/docs\/how-to\/budgets/ })).toBeInTheDocument();
+    });
+});

--- a/__tests__/gcl/professional-cloud-network-engineer/Section1.test.tsx
+++ b/__tests__/gcl/professional-cloud-network-engineer/Section1.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Section1 } from '../../../app/gcl/professional-cloud-network-engineer/components/Section1';
+
+describe('Professional Cloud Network Engineer - Section1', () => {
+    it('renders the section title correctly', () => {
+        render(<Section1 />);
+        expect(screen.getByRole('heading', { name: /VPC ネットワークの設計・実装/, level: 2 })).toBeInTheDocument();
+        expect(screen.getByText('Section 1 (21%)')).toBeInTheDocument();
+    });
+
+    it('renders the VPC mode comparison correctly', () => {
+        render(<Section1 />);
+        expect(screen.getByText(/1.1 VPCの根本概念 ─ グローバルスコープとモード選択/)).toBeInTheDocument();
+        expect(screen.getByText(/手動でIPレンジを指定して作成/)).toBeInTheDocument();
+        expect(screen.getByText(/Auto → Custom への変換は/)).toBeInTheDocument();
+    });
+
+    it('renders the Firewall rules section correctly', () => {
+        render(<Section1 />);
+        expect(screen.getByText(/1.2 VPCファイアウォールルール ─ ステートフル・優先度・階層型ポリシー/)).toBeInTheDocument();
+        expect(screen.getByText(/階層型ファイアウォールポリシー/)).toBeInTheDocument();
+        expect(screen.getByText(/組織（Organization）またはフォルダ（Folder）レベル/)).toBeInTheDocument();
+    });
+
+    it('renders the VPC Peering vs Shared VPC section correctly', () => {
+        render(<Section1 />);
+        expect(screen.getByText(/1.3 VPCピアリング vs Shared VPC ─ 設計パターンの選択/)).toBeInTheDocument();
+        expect(screen.getByText(/推移的ルーティング/)).toBeInTheDocument();
+        expect(screen.getAllByText('ホストプロジェクト')[0]).toBeInTheDocument();
+        expect(screen.getByText(/ネットワークチームがサブネットやファイアウォールを一元管理/)).toBeInTheDocument();
+    });
+
+    it('renders the private communication section correctly', () => {
+        render(<Section1 />);
+        expect(screen.getByText(/1.4 プライベート通信制御 ─ Cloud NAT・PGA・PSC/)).toBeInTheDocument();
+        expect(screen.getByText('Cloud NAT')).toBeInTheDocument();
+        expect(screen.getByText('Private Google Access')).toBeInTheDocument();
+        expect(screen.getByText('Private Service Connect')).toBeInTheDocument();
+    });
+});

--- a/__tests__/gcl/professional-cloud-network-engineer/Section2.test.tsx
+++ b/__tests__/gcl/professional-cloud-network-engineer/Section2.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Section2 } from '../../../app/gcl/professional-cloud-network-engineer/components/Section2';
+
+describe('Professional Cloud Network Engineer - Section2', () => {
+    it('renders the section title correctly', () => {
+        render(<Section2 />);
+        expect(screen.getByRole('heading', { name: /ハイブリッド接続とネットワーク相互接続/, level: 2 })).toBeInTheDocument();
+        expect(screen.getByText('Section 2 (23%)')).toBeInTheDocument();
+    });
+
+    it('renders the connectivity comparison correctly', () => {
+        render(<Section2 />);
+        expect(screen.getByText(/2.1 接続方式の全体比較 ─ 帯域・コスト・SLAで選択する/)).toBeInTheDocument();
+        expect(screen.getAllByText('HA VPN')[0]).toBeInTheDocument();
+        expect(screen.getAllByText('Dedicated Interconnect')[0]).toBeInTheDocument();
+        expect(screen.getByText(/大帯域・低レイテンシ必須/)).toBeInTheDocument();
+    });
+
+    it('renders the HA VPN section correctly', () => {
+        render(<Section2 />);
+        expect(screen.getByText(/2.2 HA VPN ─ 99.99% SLAを実現する高可用性VPN設計/)).toBeInTheDocument();
+        expect(screen.getByText(/IKEv2/)).toBeInTheDocument();
+        expect(screen.getByText(/BGP（動的ルーティング）を必ず設定する/)).toBeInTheDocument();
+    });
+
+    it('renders the Cloud Interconnect section correctly', () => {
+        render(<Section2 />);
+        expect(screen.getByText(/2.3 Cloud Interconnect ─ 専用線による99.99%冗長設計/)).toBeInTheDocument();
+        expect(screen.getByText(/異なる2 Metro × 2回線 = 合計4回線/)).toBeInTheDocument();
+        expect(screen.getByText(/1本の物理専用線を論理的に複数に分割する仕組み/)).toBeInTheDocument();
+    });
+
+    it('renders the Cloud Router & BGP section correctly', () => {
+        render(<Section2 />);
+        expect(screen.getByText(/2.4 Cloud Router と BGP ─ 動的ルーティングの仕組みと設定/)).toBeInTheDocument();
+        expect(screen.getByText(/データプレーンのトラフィック自体は通過しません/)).toBeInTheDocument();
+        expect(screen.getByText(/BGP MED/)).toBeInTheDocument();
+    });
+});

--- a/__tests__/gcl/professional-cloud-network-engineer/SectionIntro.test.tsx
+++ b/__tests__/gcl/professional-cloud-network-engineer/SectionIntro.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { SectionIntro } from '../../../app/gcl/professional-cloud-network-engineer/components/SectionIntro';
+
+describe('Professional Cloud Network Engineer - SectionIntro', () => {
+    it('renders the section title correctly', () => {
+        render(<SectionIntro />);
+        expect(screen.getByRole('heading', { name: /試験の全体像と準備方法/, level: 2 })).toBeInTheDocument();
+        expect(screen.getByText('INTRO')).toBeInTheDocument();
+    });
+
+    it('renders the exam weights correctly', () => {
+        render(<SectionIntro />);
+        expect(screen.getByText(/S1: VPCネットワーク設計/)).toBeInTheDocument();
+        expect(screen.getByText(/~21%/)).toBeInTheDocument();
+        expect(screen.getByText(/S2: ハイブリッド接続・ネットワーク相互接続/)).toBeInTheDocument();
+        expect(screen.getByText(/~23%/)).toBeInTheDocument();
+        expect(screen.getByText(/S3: ロードバランシングとトラフィック管理/)).toBeInTheDocument();
+        expect(screen.getByText(/~19%/)).toBeInTheDocument();
+        expect(screen.getByText(/S4: CDN・DNS・IPアドレス管理/)).toBeInTheDocument();
+        expect(screen.getByText(/~15%/)).toBeInTheDocument();
+        expect(screen.getByText(/S5: ネットワークセキュリティの設計と実装/)).toBeInTheDocument();
+        expect(screen.getByText(/~12%/)).toBeInTheDocument();
+        expect(screen.getByText(/S6: ネットワーク操作と監視/)).toBeInTheDocument();
+        expect(screen.getByText(/~10%/)).toBeInTheDocument();
+    });
+
+    it('renders the recommended learning steps correctly', () => {
+        render(<SectionIntro />);
+        expect(screen.getByText(/推奨学習ステップ/)).toBeInTheDocument();
+        expect(screen.getByText(/公式試験ガイドを熟読する（必須）/)).toBeInTheDocument();
+        expect(screen.getByText(/Cloud Skills Boost のPCNEラーニングパスを修了/)).toBeInTheDocument();
+        expect(screen.getByText(/ハンズオンラボで実際に操作する/)).toBeInTheDocument();
+        expect(screen.getByText(/公式サンプル問題・模擬試験で実力測定/)).toBeInTheDocument();
+        expect(screen.getByText(/弱点分野を公式ドキュメントで補強して試験登録/)).toBeInTheDocument();
+    });
+
+    it('renders official resources correctly', () => {
+        render(<SectionIntro />);
+        expect(screen.getByText(/公式リソース/)).toBeInTheDocument();
+        expect(screen.getByText(/公式試験ページ — Professional Cloud Network Engineer/)).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /cloud\.google\.com\/learn\/certification\/cloud-network-engineer/ })).toBeInTheDocument();
+        expect(screen.getByText(/最新試験ガイド PDF（英語・2024年4月版）/)).toBeInTheDocument();
+    });
+});

--- a/__tests__/gcl/professional-cloud-network-engineer/SectionIntro.test.tsx
+++ b/__tests__/gcl/professional-cloud-network-engineer/SectionIntro.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
-import { SectionIntro } from '../../../app/gcl/professional-cloud-network-engineer/components/SectionIntro';
+import { SectionIntro } from '@/app/gcl/professional-cloud-network-engineer/components/SectionIntro';
 
 describe('Professional Cloud Network Engineer - SectionIntro', () => {
     it('renders the section title correctly', () => {

--- a/__tests__/gcl/professional-cloud-network-engineer/layout.test.tsx
+++ b/__tests__/gcl/professional-cloud-network-engineer/layout.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Layout, { metadata } from '../../../app/gcl/professional-cloud-network-engineer/layout';
+
+describe('Professional Cloud Network Engineer - Layout', () => {
+    it('should have the correct metadata', () => {
+        expect(metadata.title).toBe('Professional Cloud Network Engineer | Google Cloud Certification');
+        expect(metadata.description).toContain('完全試験対策ガイド');
+    });
+
+    it('should render children correctly', () => {
+        const { getByText } = render(
+            <Layout>
+                <div>Test Child Content</div>
+            </Layout>
+        );
+        expect(getByText('Test Child Content')).toBeInTheDocument();
+    });
+});

--- a/__tests__/gcl/professional-cloud-network-engineer/page.test.tsx
+++ b/__tests__/gcl/professional-cloud-network-engineer/page.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
-import PcnePage from '../../../app/gcl/professional-cloud-network-engineer/page';
+import PcnePage from '@/app/gcl/professional-cloud-network-engineer/page';
 
 describe('Professional Cloud Network Engineer - Page', () => {
     it('renders the hero section correctly', () => {
         render(<PcnePage />);
-        expect(screen.getByRole('heading', { name: /Professional Cloud.*Network Engineer.*完全試験対策ガイド/s, level: 1 })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: /Professional Cloud[\s\S]*Network Engineer[\s\S]*完全試験対策ガイド/, level: 1 })).toBeInTheDocument();
         expect(screen.getByText('Professional Cloud Network Engineer')).toBeInTheDocument();
         expect(screen.getByText(/ネットワーク初学者から中級者まで対応。VPC設計から/)).toBeInTheDocument();
     });

--- a/__tests__/gcl/professional-cloud-network-engineer/page.test.tsx
+++ b/__tests__/gcl/professional-cloud-network-engineer/page.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import PcnePage from '../../../app/gcl/professional-cloud-network-engineer/page';
+
+describe('Professional Cloud Network Engineer - Page', () => {
+    it('renders the hero section correctly', () => {
+        render(<PcnePage />);
+        expect(screen.getByRole('heading', { name: /Professional Cloud.*Network Engineer.*完全試験対策ガイド/s, level: 1 })).toBeInTheDocument();
+        expect(screen.getByText('Professional Cloud Network Engineer')).toBeInTheDocument();
+        expect(screen.getByText(/ネットワーク初学者から中級者まで対応。VPC設計から/)).toBeInTheDocument();
+    });
+
+    it('renders the hero stats correctly', () => {
+        render(<PcnePage />);
+        expect(screen.getByText(/試験時間: 120分/)).toBeInTheDocument();
+        expect(screen.getByText(/問題数: 50〜60問/)).toBeInTheDocument();
+        expect(screen.getByText(/受験料: \$200/)).toBeInTheDocument();
+        expect(screen.getByText(/推奨経験: 3年以上/)).toBeInTheDocument();
+        expect(screen.getByText(/更新: 2年ごと/)).toBeInTheDocument();
+    });
+
+    it('renders the hero badges correctly', () => {
+        render(<PcnePage />);
+        expect(screen.getByText('🌐 VPC 設計')).toBeInTheDocument();
+        expect(screen.getByText('🔗 ハイブリッド接続')).toBeInTheDocument();
+        expect(screen.getByText('⚖️ ロードバランシング')).toBeInTheDocument();
+    });
+
+    it('renders the sticky navigation correctly', () => {
+        render(<PcnePage />);
+        const nav = screen.getByRole('navigation', { name: /Quick navigation/ });
+        expect(nav).toBeInTheDocument();
+        
+        expect(screen.getByText('PCNE')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /01 VPCネットワーク/ })).toHaveAttribute('href', '#s1');
+        expect(screen.getByRole('link', { name: /02 ハイブリッド接続/ })).toHaveAttribute('href', '#s2');
+        expect(screen.getByRole('link', { name: /まとめ チートシート/ })).toHaveAttribute('href', '#cheatsheet');
+    });
+});

--- a/app/gcl/cloud-digital-leader/section6/components/Section7.tsx
+++ b/app/gcl/cloud-digital-leader/section6/components/Section7.tsx
@@ -25,125 +25,80 @@ export function Section7() {
                 </h3>
 
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', marginTop: '8px' }}>
-                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
-                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
-                            PATTERN 01 — 財務ガバナンス
+                    {[
+                        {
+                            id: '01',
+                            title: '財務ガバナンス',
+                            question: '「予算の上限に達したらどうなるか？」',
+                            answer: <>✅ 正解：<strong>通知が届くだけでリソースは停止しない</strong>。自動停止には Pub/Sub + Cloud Functions が必要。</>
+                        },
+                        {
+                            id: '02',
+                            title: 'Cloud Monitoring',
+                            question: '「VM のメモリ使用量を監視するために必要なものは？」',
+                            answer: <>✅ 正解：<strong>Ops Agent のインストール</strong>。CPU/ネットワークは自動収集だが、メモリはエージェントが必要。</>
+                        },
+                        {
+                            id: '03',
+                            title: '監査ログ',
+                            question: '「Cloud Storage のオブジェクト読み取りを記録したい」',
+                            answer: <>✅ 正解：<strong>データアクセス監査ログを手動で有効化</strong>する。デフォルトでは無効（有料のため）。</>
+                        },
+                        {
+                            id: '04',
+                            title: 'SRE 概念',
+                            question: '「SLO と SLA の違いは？」',
+                            answer: <>✅ 正解：<strong>SLO は内部目標値（より高い）、SLA は顧客との契約値（より低い）</strong>。SLO 未達でも SLA 内なら違約金は発生しない。</>
+                        },
+                        {
+                            id: '05',
+                            title: 'ログエクスポート',
+                            question: '「コストを最小化しながらログを7年間保管したい」',
+                            answer: <>✅ 正解：<strong>Cloud Storage の Coldline へのシンク設定</strong>。BigQuery は分析向きで割高。</>
+                        },
+                        {
+                            id: '06',
+                            title: 'Toil',
+                            question: '「SRE において Toil とは何か？」',
+                            answer: <>✅ 正解：<strong>手作業・繰り返し・自動化できる運用作業</strong>。SRE は Toil を 50% 以下に保ち、残りを自動化・開発に充てる。</>
+                        },
+                        {
+                            id: '07',
+                            title: 'サステナビリティ',
+                            question: '「Google Cloud 利用のCO₂排出量を確認するツールは？」',
+                            answer: <>✅ 正解：<strong>Carbon Footprint ツール</strong>（Cloud Console 内）。プロジェクト・リージョン・サービス別に可視化できる。</>
+                        },
+                        {
+                            id: '08',
+                            title: 'コスト最適化',
+                            question: '「バッチ処理のコストを最大限に削減したい」',
+                            answer: <>✅ 正解：<strong>Spot VM の使用</strong>（最大91%割引）。停止されてもよいバッチ・ML トレーニングが適用対象。</>
+                        },
+                        {
+                            id: '09',
+                            title: 'DevOps vs SRE',
+                            question: '「DevOps と SRE の関係を最もよく表しているのは？」',
+                            answer: <>✅ 正解：<strong>「SRE は DevOps の具体的な実装（クラス）である」</strong>。DevOps が目標・文化、SRE がその実現手法。</>
+                        },
+                        {
+                            id: '10',
+                            title: 'Error Budget',
+                            question: '「エラーバジェットを使い果たしそうな時、SRE チームはどうすべきか？」',
+                            answer: <>✅ 正解：<strong>新機能のリリースを停止して信頼性改善に集中する</strong>。バジェットが残っている間は機能開発を優先できる。</>
+                        }
+                    ].map(pattern => (
+                        <div key={pattern.id} style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
+                            <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
+                                PATTERN {pattern.id} — {pattern.title}
+                            </div>
+                            <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
+                                {pattern.question}
+                            </p>
+                            <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
+                                {pattern.answer}
+                            </p>
                         </div>
-                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
-                            「予算の上限に達したらどうなるか？」
-                        </p>
-                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
-                            ✅ 正解：<strong>通知が届くだけでリソースは停止しない</strong>。自動停止には Pub/Sub + Cloud Functions が必要。
-                        </p>
-                    </div>
-
-                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
-                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
-                            PATTERN 02 — Cloud Monitoring
-                        </div>
-                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
-                            「VM のメモリ使用量を監視するために必要なものは？」
-                        </p>
-                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
-                            ✅ 正解：<strong>Ops Agent のインストール</strong>。CPU/ネットワークは自動収集だが、メモリはエージェントが必要。
-                        </p>
-                    </div>
-
-                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
-                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
-                            PATTERN 03 — 監査ログ
-                        </div>
-                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
-                            「Cloud Storage のオブジェクト読み取りを記録したい」
-                        </p>
-                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
-                            ✅ 正解：<strong>データアクセス監査ログを手動で有効化</strong>する。デフォルトでは無効（有料のため）。
-                        </p>
-                    </div>
-
-                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
-                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
-                            PATTERN 04 — SRE 概念
-                        </div>
-                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
-                            「SLO と SLA の違いは？」
-                        </p>
-                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
-                            ✅ 正解：<strong>SLO は内部目標値（より高い）、SLA は顧客との契約値（より低い）</strong>。SLO 未達でも SLA 内なら違約金は発生しない。
-                        </p>
-                    </div>
-
-                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
-                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
-                            PATTERN 05 — ログエクスポート
-                        </div>
-                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
-                            「コストを最小化しながらログを7年間保管したい」
-                        </p>
-                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
-                            ✅ 正解：<strong>Cloud Storage の Coldline へのシンク設定</strong>。BigQuery は分析向きで割高。
-                        </p>
-                    </div>
-
-                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
-                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
-                            PATTERN 06 — Toil
-                        </div>
-                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
-                            「SRE において Toil とは何か？」
-                        </p>
-                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
-                            ✅ 正解：<strong>手作業・繰り返し・自動化できる運用作業</strong>。SRE は Toil を 50% 以下に保ち、残りを自動化・開発に充てる。
-                        </p>
-                    </div>
-
-                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
-                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
-                            PATTERN 07 — サステナビリティ
-                        </div>
-                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
-                            「Google Cloud 利用のCO₂排出量を確認するツールは？」
-                        </p>
-                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
-                            ✅ 正解：<strong>Carbon Footprint ツール</strong>（Cloud Console 内）。プロジェクト・リージョン・サービス別に可視化できる。
-                        </p>
-                    </div>
-
-                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
-                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
-                            PATTERN 08 — コスト最適化
-                        </div>
-                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
-                            「バッチ処理のコストを最大化して削減したい」
-                        </p>
-                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
-                            ✅ 正解：<strong>Spot VM の使用</strong>（最大91%割引）。停止されてもよいバッチ・ML トレーニングが適用対象。
-                        </p>
-                    </div>
-
-                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
-                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
-                            PATTERN 09 — DevOps vs SRE
-                        </div>
-                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
-                            「DevOps と SRE の関係を最もよく表しているのは？」
-                        </p>
-                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
-                            ✅ 正解：<strong>「SRE は DevOps の具体的な実装（クラス）である」</strong>。DevOps が目標・文化、SRE がその実現手法。
-                        </p>
-                    </div>
-
-                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
-                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
-                            PATTERN 10 — Error Budget
-                        </div>
-                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
-                            「エラーバジェットを使い果たしそうな時、SRE チームはどうすべきか？」
-                        </p>
-                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
-                            ✅ 正解：<strong>新機能のリリースを停止して信頼性改善に集中する</strong>。バジェットが残っている間は機能開発を優先できる。
-                        </p>
-                    </div>
+                    ))}
                 </div>
             </div>
 

--- a/app/gcl/cloud-digital-leader/section6/components/Section7.tsx
+++ b/app/gcl/cloud-digital-leader/section6/components/Section7.tsx
@@ -2,14 +2,11 @@ import React from 'react';
 import sharedStyles from './SharedSection.module.css';
 
 /**
- * Renders the Section 6 - Part 7 (Exam Preparation) component for the Cloud Digital Leader guide.
- * It provides a checklist, top 10 frequent patterns, keyword map, and official resources for exam preparation.
- * 
- * Accessibility: The root section element has an `aria-labelledby` linking it to the section title for screen readers.
- * Interactive links use standard `href` and `target="_blank"` with `rel="noopener noreferrer"`.
- * 
- * @returns {React.ReactElement} The section component containing exam preparation content.
- * @remarks This component has no props and no side effects.
+ * Renders the exam-preparation section for Section 6 of the Cloud Digital Leader guide.
+ *
+ * The section includes a checklist, a "頻出問題パターン TOP 10" block, a keyword map table, and links to official study resources. This component accepts no props and has no side effects.
+ *
+ * @returns A React element containing the Section 6 — Part 7 exam-preparation content.
  */
 export function Section7() {
     return (

--- a/app/gcl/cloud-digital-leader/section6/components/Section7.tsx
+++ b/app/gcl/cloud-digital-leader/section6/components/Section7.tsx
@@ -1,0 +1,267 @@
+import React from 'react';
+import sharedStyles from './SharedSection.module.css';
+
+/**
+ * Renders the Section 6 - Part 7 (Exam Preparation) component for the Cloud Digital Leader guide.
+ * It provides a checklist, top 10 frequent patterns, keyword map, and official resources for exam preparation.
+ * 
+ * Accessibility: The root section element has an `aria-labelledby` linking it to the section title for screen readers.
+ * Interactive links use standard `href` and `target="_blank"` with `rel="noopener noreferrer"`.
+ * 
+ * @returns {React.ReactElement} The section component containing exam preparation content.
+ * @remarks This component has no props and no side effects.
+ */
+export function Section7() {
+    return (
+        <section className={sharedStyles.section} id="s7" aria-labelledby="s7-title">
+            <div className={sharedStyles.sectionLabel}>Section 6 — Part 7</div>
+            <h2 className={sharedStyles.sectionTitle} id="s7-title">試験対策<br />チェックリスト</h2>
+            <p className={sharedStyles.sectionDesc}>
+                Section 6 の出題頻度が高いポイントと、間違えやすい引っかけ問題をまとめました。試験直前の確認にご活用ください。
+            </p>
+            <div className={sharedStyles.divider}></div>
+
+            {/* 頻出問題パターン */}
+            <div className={sharedStyles.detailBlock}>
+                <h3>
+                    <span aria-hidden="true">🎯</span> 頻出問題パターン TOP 10 <span className={`${sharedStyles.tag} ${sharedStyles.tagOrange}`}>試験対策</span>
+                </h3>
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', marginTop: '8px' }}>
+                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
+                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
+                            PATTERN 01 — 財務ガバナンス
+                        </div>
+                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
+                            「予算の上限に達したらどうなるか？」
+                        </p>
+                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
+                            ✅ 正解：<strong>通知が届くだけでリソースは停止しない</strong>。自動停止には Pub/Sub + Cloud Functions が必要。
+                        </p>
+                    </div>
+
+                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
+                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
+                            PATTERN 02 — Cloud Monitoring
+                        </div>
+                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
+                            「VM のメモリ使用量を監視するために必要なものは？」
+                        </p>
+                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
+                            ✅ 正解：<strong>Ops Agent のインストール</strong>。CPU/ネットワークは自動収集だが、メモリはエージェントが必要。
+                        </p>
+                    </div>
+
+                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
+                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
+                            PATTERN 03 — 監査ログ
+                        </div>
+                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
+                            「Cloud Storage のオブジェクト読み取りを記録したい」
+                        </p>
+                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
+                            ✅ 正解：<strong>データアクセス監査ログを手動で有効化</strong>する。デフォルトでは無効（有料のため）。
+                        </p>
+                    </div>
+
+                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
+                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
+                            PATTERN 04 — SRE 概念
+                        </div>
+                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
+                            「SLO と SLA の違いは？」
+                        </p>
+                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
+                            ✅ 正解：<strong>SLO は内部目標値（より高い）、SLA は顧客との契約値（より低い）</strong>。SLO 未達でも SLA 内なら違約金は発生しない。
+                        </p>
+                    </div>
+
+                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
+                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
+                            PATTERN 05 — ログエクスポート
+                        </div>
+                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
+                            「コストを最小化しながらログを7年間保管したい」
+                        </p>
+                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
+                            ✅ 正解：<strong>Cloud Storage の Coldline へのシンク設定</strong>。BigQuery は分析向きで割高。
+                        </p>
+                    </div>
+
+                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
+                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
+                            PATTERN 06 — Toil
+                        </div>
+                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
+                            「SRE において Toil とは何か？」
+                        </p>
+                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
+                            ✅ 正解：<strong>手作業・繰り返し・自動化できる運用作業</strong>。SRE は Toil を 50% 以下に保ち、残りを自動化・開発に充てる。
+                        </p>
+                    </div>
+
+                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
+                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
+                            PATTERN 07 — サステナビリティ
+                        </div>
+                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
+                            「Google Cloud 利用のCO₂排出量を確認するツールは？」
+                        </p>
+                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
+                            ✅ 正解：<strong>Carbon Footprint ツール</strong>（Cloud Console 内）。プロジェクト・リージョン・サービス別に可視化できる。
+                        </p>
+                    </div>
+
+                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
+                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
+                            PATTERN 08 — コスト最適化
+                        </div>
+                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
+                            「バッチ処理のコストを最大化して削減したい」
+                        </p>
+                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
+                            ✅ 正解：<strong>Spot VM の使用</strong>（最大91%割引）。停止されてもよいバッチ・ML トレーニングが適用対象。
+                        </p>
+                    </div>
+
+                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
+                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
+                            PATTERN 09 — DevOps vs SRE
+                        </div>
+                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
+                            「DevOps と SRE の関係を最もよく表しているのは？」
+                        </p>
+                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
+                            ✅ 正解：<strong>「SRE は DevOps の具体的な実装（クラス）である」</strong>。DevOps が目標・文化、SRE がその実現手法。
+                        </p>
+                    </div>
+
+                    <div style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: '10px', padding: '20px 24px' }}>
+                        <div style={{ fontFamily: '"DM Mono", monospace', fontSize: '1rem', color: 'var(--accent)', letterSpacing: '0.1em', marginBottom: '8px' }}>
+                            PATTERN 10 — Error Budget
+                        </div>
+                        <p style={{ fontSize: '1rem', color: '#c8deff', marginBottom: '6px', fontWeight: 500 }}>
+                            「エラーバジェットを使い果たしそうな時、SRE チームはどうすべきか？」
+                        </p>
+                        <p style={{ fontSize: '1rem', color: 'var(--text-muted)' }}>
+                            ✅ 正解：<strong>新機能のリリースを停止して信頼性改善に集中する</strong>。バジェットが残っている間は機能開発を優先できる。
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            {/* キーワードマップ */}
+            <div className={sharedStyles.detailBlock}>
+                <h3>
+                    <span aria-hidden="true">🗺️</span> Section 6 キーワードマップ <span className={`${sharedStyles.tag} ${sharedStyles.tagBlue}`}>まとめ</span>
+                </h3>
+                <div className={`table-wrapper ${sharedStyles.tableWrapperMt}`}>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th scope="col">カテゴリ</th>
+                                <th scope="col">重要キーワード</th>
+                                <th scope="col">重要度</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td className={sharedStyles.tdName}>財務ガバナンス</td>
+                                <td>
+                                    予算アラート、Committed Use Discounts、Spot
+                                    VM、ラベル、BigQuery エクスポート、Recommender
+                                </td>
+                                <td><span className={`${sharedStyles.pill} ${sharedStyles.pillOrange}`}>★★★</span></td>
+                            </tr>
+                            <tr>
+                                <td className={sharedStyles.tdName}>SRE</td>
+                                <td>
+                                    SLI / SLO / SLA / Error Budget、Toil、Blameless
+                                    Postmortem、DevOps との関係
+                                </td>
+                                <td><span className={`${sharedStyles.pill} ${sharedStyles.pillOrange}`}>★★★</span></td>
+                            </tr>
+                            <tr>
+                                <td className={sharedStyles.tdName}>Cloud Monitoring</td>
+                                <td>
+                                    Ops Agent、メトリクス・ログ・トレース・プロファイル、Cloud
+                                    Trace、Error Reporting
+                                </td>
+                                <td><span className={`${sharedStyles.pill} ${sharedStyles.pillOrange}`}>★★★</span></td>
+                            </tr>
+                            <tr>
+                                <td className={sharedStyles.tdName}>Cloud Logging</td>
+                                <td>
+                                    管理アクティビティ / データアクセス /
+                                    システムイベント監査ログ、Log Router、シンク先
+                                </td>
+                                <td><span className={`${sharedStyles.pill} ${sharedStyles.pillOrange}`}>★★★</span></td>
+                            </tr>
+                            <tr>
+                                <td className={sharedStyles.tdName}>信頼性</td>
+                                <td>
+                                    RPO /
+                                    RTO、HA、フォールトトレランス、DR、インシデント管理、Postmortem
+                                </td>
+                                <td><span className={`${sharedStyles.pill} ${sharedStyles.pillBlue}`}>★★☆</span></td>
+                            </tr>
+                            <tr>
+                                <td className={sharedStyles.tdName}>サステナビリティ</td>
+                                <td>
+                                    Carbon Footprint ツール、Scope 1/2/3、カーボンニュートラル
+                                    2007年、CFE 24/7
+                                </td>
+                                <td><span className={`${sharedStyles.pill} ${sharedStyles.pillBlue}`}>★★☆</span></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            {/* 公式ソース */}
+            <div className={sharedStyles.detailBlock}>
+                <h3>
+                    <span aria-hidden="true">📚</span> 推奨学習リソース <span className={`${sharedStyles.tag} ${sharedStyles.tagBlue}`}>公式ソース</span>
+                </h3>
+                <div className={sharedStyles.sources}>
+                    <a
+                        className={sharedStyles.sourceLink}
+                        href="https://services.google.com/fh/files/misc/cloud_digital_leader_exam_guide_english.pdf"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        <span className={sharedStyles.sourceIcon} aria-hidden="true">📄</span>
+                        <div className={sharedStyles.sourceText}>
+                            <strong>Cloud Digital Leader 公式試験ガイド（PDF）</strong>
+                            <span className={sharedStyles.sourceUrl}>https://services.google.com/fh/files/misc/cloud_digital_leader_exam_guide_english.pdf</span>
+                        </div>
+                    </a>
+                    <a
+                        className={sharedStyles.sourceLink}
+                        href="https://cloud.google.com/learn/certification/cloud-digital-leader"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        <span className={sharedStyles.sourceIcon} aria-hidden="true">🔗</span>
+                        <div className={sharedStyles.sourceText}>
+                            <strong>Cloud Digital Leader 認定資格 公式ページ</strong>
+                            <span className={sharedStyles.sourceUrl}>https://cloud.google.com/learn/certification/cloud-digital-leader</span>
+                        </div>
+                    </a>
+                    <a
+                        className={sharedStyles.sourceLink}
+                        href="https://cloud.google.com/billing/docs/how-to/budgets"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        <span className={sharedStyles.sourceIcon} aria-hidden="true">🔗</span>
+                        <div className={sharedStyles.sourceText}>
+                            <strong>Cloud Billing — 予算とアラート</strong>
+                            <span className={sharedStyles.sourceUrl}>https://cloud.google.com/billing/docs/how-to/budgets</span>
+                        </div>
+                    </a>
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/app/gcl/cloud-digital-leader/section6/components/SharedSection.module.css
+++ b/app/gcl/cloud-digital-leader/section6/components/SharedSection.module.css
@@ -1,6 +1,14 @@
 .section {
     padding: 64px 24px;
     border-bottom: 1px solid var(--color-card-border);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.section > * {
+    width: 100%;
+    max-width: 1000px;
 }
 
 .sectionAlt {

--- a/app/gcl/cloud-digital-leader/section6/page.tsx
+++ b/app/gcl/cloud-digital-leader/section6/page.tsx
@@ -6,6 +6,7 @@ import { Section3 } from './components/Section3';
 import { Section4 } from './components/Section4';
 import { Section5 } from './components/Section5';
 import { Section6 } from './components/Section6';
+import { Section7 } from './components/Section7';
 
 /**
  * Renders the "Section 6: Scaling with Google Cloud Operations" page layout,
@@ -53,6 +54,7 @@ export default function Section6Page() {
                 <Section4 />
                 <Section5 />
                 <Section6 />
+                <Section7 />
             </main>
         </div>
     );

--- a/app/gcl/professional-cloud-network-engineer/components/Section1.tsx
+++ b/app/gcl/professional-cloud-network-engineer/components/Section1.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import sharedStyles from './SharedSection.module.css';
+
+/**
+ * Renders Section 1 (VPC ネットワークの設計・実装) for the PCNE guide.
+ *
+ * @returns {React.ReactElement} The section component
+ */
+export function Section1() {
+    return (
+        <section className={sharedStyles.section} id="s1" aria-labelledby="s1-title">
+            <div className={sharedStyles.sectionLabel}>Section 1 (21%)</div>
+            <h2 className={sharedStyles.sectionTitle} id="s1-title" style={{ color: 'var(--color-primary)' }}>
+                VPC ネットワークの設計・実装
+            </h2>
+            <p className={sharedStyles.sectionDesc}>
+                Google Cloud のネットワーク基盤である VPC (Virtual Private Cloud) の設計原則、
+                IPアドレス管理、ルーティング、ファイアウォール、通信制御（Private Google Access, Cloud NAT, PSC）について学びます。
+            </p>
+            <div className={sharedStyles.divider}></div>
+
+            <div className={sharedStyles.detailBlock}>
+                <h3>
+                    <span aria-hidden="true">🌐</span> 1.1 VPCの根本概念 ─ グローバルスコープとモード選択
+                </h3>
+                <p>Google Cloud の VPC は AWS や Azure とは異なり、<strong>グローバルリソース</strong>です。サブネットのみがリージョナルリソースとなります。</p>
+                <div className={`table-wrapper ${sharedStyles.tableWrapperMt}`}>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th scope="col">比較要素</th>
+                                <th scope="col">Auto モード（自動）</th>
+                                <th scope="col">Custom モード（カスタム）</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td className={sharedStyles.tdName}>サブネット作成</td>
+                                <td>各リージョンに自動作成（<code>10.128.0.0/9</code> を分割）</td>
+                                <td><strong>手動でIPレンジを指定して作成（試験の推奨・実運用向け）</strong></td>
+                            </tr>
+                            <tr>
+                                <td className={sharedStyles.tdName}>IPの重複リスク</td>
+                                <td>オンプレミスや他VPCとVPN接続時に重複しやすい</td>
+                                <td>設計者がレンジを管理するため重複を防げる</td>
+                            </tr>
+                            <tr>
+                                <td className={sharedStyles.tdName}>変更可能か？</td>
+                                <td>Auto → Custom への変換は<strong>可能</strong></td>
+                                <td>Custom → Auto への変換は<strong>不可</strong></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div className={sharedStyles.examTip}>
+                    <span className={sharedStyles.tipLabel}>試験対策</span>
+                    「会社がオンプレミス環境とVPN/Interconnectで接続する予定である」という要件があれば、<strong>「Custom モード」の VPC を選択</strong>し、オンプレのIPレンジと重複しないサブネットを設計するのが正解です。
+                </div>
+            </div>
+
+            <div className={sharedStyles.detailBlock}>
+                <h3>
+                    <span aria-hidden="true">🛡️</span> 1.2 VPCファイアウォールルール ─ ステートフル・優先度・階層型ポリシー
+                </h3>
+                <p>GCP のファイアウォールルールは<strong>ステートフル</strong>であり、許可した上り（Ingress）トラフィックの戻り（Egress）は自動的に許可されます。</p>
+                <ul>
+                    <li><strong>適用先（Target）の指定方法：</strong>
+                        <ul>
+                            <li><strong>タグ（Network Tags）：</strong> VM インスタンスに直接付与。手軽だが文字列ベースなので運用ミスに注意。</li>
+                            <li><strong>サービスアカウント（推奨）：</strong> インスタンスに関連付けられたサービスアカウントをターゲットとする。IAM で厳密に管理でき、セキュリティレベルが高い。</li>
+                        </ul>
+                    </li>
+                    <li><strong>優先度（Priority）：</strong> <code>0</code>（最高）〜 <code>65535</code>（最低）。デフォルトルールは <code>1000</code> ではなく <code>65534</code>（暗黙のルールが65535）。</li>
+                </ul>
+
+                <div className={sharedStyles.bpBox}>
+                    <h5>階層型ファイアウォールポリシー（Hierarchical Firewall Policies）</h5>
+                    <ul>
+                        <li>VPC 単位ではなく、<strong>組織（Organization）またはフォルダ（Folder）レベル</strong>で適用可能。</li>
+                        <li>配下の全プロジェクト・全 VPC に一括適用されるため、「社内共通のセキュリティ要件（例：全社で SSH は特定 IP からのみ許可）」を強制するのに最適。</li>
+                        <li>各プロジェクトの管理者が VPC ルールで「許可」しても、上位のフォルダレベルで「拒否」されていれば<strong>上位が優先（上書き）</strong>される。</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div className={sharedStyles.detailBlock}>
+                <h3>
+                    <span aria-hidden="true">🤝</span> 1.3 VPCピアリング vs Shared VPC ─ 設計パターンの選択
+                </h3>
+                <p>複数のプロジェクトや VPC 間をどう接続するかは PCNE の最頻出トピックです。</p>
+                <div className={`table-wrapper ${sharedStyles.tableWrapperMt}`}>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th scope="col">機能</th>
+                                <th scope="col">VPC ピアリング (VPC Peering)</th>
+                                <th scope="col">共有 VPC (Shared VPC)</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td className={sharedStyles.tdName}>主な用途</td>
+                                <td>異なる組織間、または独立性の高い部署間の接続</td>
+                                <td><strong>単一組織内</strong>で、ネットワーク管理を中央集権化しつつ、リソース管理は各部署（プロジェクト）に委譲したい場合</td>
+                            </tr>
+                            <tr>
+                                <td className={sharedStyles.tdName}>推移的ルーティング (Transitive Routing)</td>
+                                <td><strong>サポートしない</strong>（A-B, B-C は通信できても、A-C は通信不可）</td>
+                                <td>同じホストプロジェクトの同一VPCに所属すれば通信可能</td>
+                            </tr>
+                            <tr>
+                                <td className={sharedStyles.tdName}>管理の所在</td>
+                                <td>各VPCの管理者がそれぞれのルーティングを管理</td>
+                                <td><strong>ホストプロジェクト</strong>の管理者がサブネット・FWを一元管理し、<strong>サービスプロジェクト</strong>に権限を委譲</td>
+                            </tr>
+                            <tr>
+                                <td className={sharedStyles.tdName}>オンプレへのVPN共有</td>
+                                <td>ピアリングの設定で「カスタムルートのエクスポート/インポート」を有効にすれば可能</td>
+                                <td>ホストプロジェクトで構築したVPNを全サービスプロジェクトで自動共有</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div className={sharedStyles.examTip}>
+                    <span className={sharedStyles.tipLabel}>試験対策</span>
+                    「ネットワークチームがサブネットやファイアウォールを一元管理し、開発チームはVMの作成のみを行えるようにしたい」という要件は、<strong>Shared VPC（共有VPC）</strong>を構築するのが絶対の正解パターンです。
+                </div>
+            </div>
+
+            <div className={sharedStyles.detailBlock}>
+                <h3>
+                    <span aria-hidden="true">🚪</span> 1.4 プライベート通信制御 ─ Cloud NAT・PGA・PSC
+                </h3>
+                <p>外部IPを持たない VM が外部や Google API とどうやって通信するか、使い分けが問われます。</p>
+                <div className={sharedStyles.cards}>
+                    <div className={sharedStyles.card}>
+                        <div className={sharedStyles.cardIcon} aria-hidden="true">NAT</div>
+                        <h4>Cloud NAT</h4>
+                        <p>内部IPのみのVMが<strong>インターネットにアクセス</strong>（OSのアップデートや外部APIの呼び出し）するためのマネージドサービス。<br/>※ インターネットからVMへの受信通信（Ingress）は不可。</p>
+                    </div>
+                    <div className={sharedStyles.card}>
+                        <div className={sharedStyles.cardIcon} aria-hidden="true">PGA</div>
+                        <h4>Private Google Access</h4>
+                        <p>内部IPのみのVMが<strong>Google API（Cloud Storage や BigQuery など）にアクセス</strong>するための機能。インターネットを経由せず、Google 内部網を通る。サブネット単位で有効化する。</p>
+                    </div>
+                    <div className={sharedStyles.card}>
+                        <div className={sharedStyles.cardIcon} aria-hidden="true">PSC</div>
+                        <h4>Private Service Connect</h4>
+                        <p>自社で公開したサービスや、他社・サードパーティのマネージドサービス（MongoDBやElasticなど）を、<strong>自VPCのプライベートIPエンドポイント</strong>としてマッピングし、VPCピアリングなしで接続する最新手法。</p>
+                    </div>
+                </div>
+                <div className={sharedStyles.highlight}>
+                    <strong>💡 PSA (Private Services Access) との違い：</strong>
+                    PGA は「Google の公開API」へアクセス。PSA (Private Services Access) は「Cloud SQL」などのマネージドサービスに対し、VPCピアリングを使って専用のプライベートIP範囲で接続する手法です。
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/app/gcl/professional-cloud-network-engineer/components/Section1.tsx
+++ b/app/gcl/professional-cloud-network-engineer/components/Section1.tsx
@@ -2,9 +2,13 @@ import React from 'react';
 import sharedStyles from './SharedSection.module.css';
 
 /**
- * Renders Section 1 (VPC ネットワークの設計・実装) for the PCNE guide.
+ * Renders the Section 1 content covering VPC design and implementation for the PCNE guide.
  *
- * @returns {React.ReactElement} The section component
+ * This component returns a semantic `<section>` (id="s1") containing accessible headings, explanatory text,
+ * comparison tables, tips, and cards for subsections 1.1–1.4 (VPC concepts, firewall rules, peering vs Shared VPC,
+ * and private communication controls such as Cloud NAT, Private Google Access, and Private Service Connect).
+ *
+ * @returns The React element for Section 1 of the guide
  */
 export function Section1() {
     return (

--- a/app/gcl/professional-cloud-network-engineer/components/Section2.tsx
+++ b/app/gcl/professional-cloud-network-engineer/components/Section2.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import sharedStyles from './SharedSection.module.css';
 
 /**
- * Renders Section 2 (ハイブリッド接続とネットワーク相互接続) for the PCNE guide.
+ * Render the "Section 2" content block describing hybrid connectivity and network interconnect options for the PCNE guide.
  *
- * @returns {React.ReactElement} The section component
+ * @returns The React element for Section 2, including headers, comparison tables, best-practice notes, and exam tips.
  */
 export function Section2() {
     return (

--- a/app/gcl/professional-cloud-network-engineer/components/Section2.tsx
+++ b/app/gcl/professional-cloud-network-engineer/components/Section2.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import sharedStyles from './SharedSection.module.css';
+
+/**
+ * Renders Section 2 (ハイブリッド接続とネットワーク相互接続) for the PCNE guide.
+ *
+ * @returns {React.ReactElement} The section component
+ */
+export function Section2() {
+    return (
+        <section className={sharedStyles.section} id="s2" aria-labelledby="s2-title">
+            <div className={sharedStyles.sectionLabel}>Section 2 (23%)</div>
+            <h2 className={sharedStyles.sectionTitle} id="s2-title" style={{ color: '#4caf50' }}>
+                ハイブリッド接続とネットワーク相互接続
+            </h2>
+            <p className={sharedStyles.sectionDesc}>
+                試験最大配点（約23%）のセクション。Cloud VPN・Interconnect・Cloud Routerの選択基準と設定方法、SLAの違いが頻出。シナリオベースで「どの接続方式を選ぶか」が問われます。
+            </p>
+            <div className={sharedStyles.divider}></div>
+
+            <div className={sharedStyles.detailBlock}>
+                <h3>
+                    <span aria-hidden="true">🌐</span> 2.1 接続方式の全体比較 ─ 帯域・コスト・SLAで選択する
+                </h3>
+                <div className={`table-wrapper ${sharedStyles.tableWrapperMt}`}>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th scope="col">接続方式</th>
+                                <th scope="col">帯域幅</th>
+                                <th scope="col">SLA</th>
+                                <th scope="col">推奨場面</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td className={sharedStyles.tdName}>HA VPN</td>
+                                <td>最大 3Gbps/トンネル</td>
+                                <td><span className={`${sharedStyles.tag} ${sharedStyles.tagBlue}`}>99.99%</span></td>
+                                <td>帯域が少なく、コスト優先の場合</td>
+                            </tr>
+                            <tr>
+                                <td className={sharedStyles.tdName}>Classic VPN</td>
+                                <td>最大 3Gbps/トンネル</td>
+                                <td><span className={`${sharedStyles.tag} ${sharedStyles.tagOrange}`}>99.9%</span></td>
+                                <td><span className={`${sharedStyles.tag} ${sharedStyles.tagOrange}`}>新規非推奨</span></td>
+                            </tr>
+                            <tr>
+                                <td className={sharedStyles.tdName}>Partner Interconnect</td>
+                                <td>50Mbps〜50Gbps</td>
+                                <td><span className={`${sharedStyles.tag} ${sharedStyles.tagBlue}`}>99.9〜99.99%</span></td>
+                                <td>Googleコロケ外・小〜中帯域</td>
+                            </tr>
+                            <tr>
+                                <td className={sharedStyles.tdName}>Dedicated Interconnect</td>
+                                <td>10G / 100G × 最大8回線</td>
+                                <td><span className={`${sharedStyles.tag} ${sharedStyles.tagBlue}`}>99.9〜99.99%</span></td>
+                                <td>大帯域・低レイテンシ必須</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div className={sharedStyles.examTip}>
+                    <span className={sharedStyles.tipLabel}>試験対策</span>
+                    ① 大帯域（数十Gbps以上）+ 低レイテンシ必須 → <strong>Dedicated Interconnect</strong><br />
+                    ② Googleコロケ施設に物理接続できない → <strong>Partner Interconnect</strong><br />
+                    ③ コスト優先・帯域が3Gbps以下で十分 → <strong>HA VPN</strong><br />
+                    ④ Classic VPNは新規構築で使わないこと（99.9% SLAのみ）
+                </div>
+            </div>
+
+            <div className={sharedStyles.detailBlock}>
+                <h3>
+                    <span aria-hidden="true">🔒</span> 2.2 HA VPN ─ 99.99% SLAを実現する高可用性VPN設計
+                </h3>
+                <p>HA VPN（High Availability VPN）は<strong>99.99% SLA</strong>を提供します。2つの独立したインターフェースに2本のトンネルを張り、BGPで動的ルーティングを行います。</p>
+                
+                <div className={sharedStyles.bpBox}>
+                    <h5>ベストプラクティス</h5>
+                    <ul>
+                        <li><strong>新規VPN構築は必ずHA VPN</strong>を使用（Classic VPNは非推奨）</li>
+                        <li><strong>IKEv2</strong>を使用（IKEv1より安全で効率的）</li>
+                        <li>BGP（動的ルーティング）を必ず設定する（静的ルートは管理コストが高い）</li>
+                        <li>帯域不足の場合はECMP（等コストマルチパス）でトンネルをスケールする</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div className={sharedStyles.detailBlock}>
+                <h3>
+                    <span aria-hidden="true">⚡</span> 2.3 Cloud Interconnect ─ 専用線による99.99%冗長設計
+                </h3>
+                <p><strong>Dedicated Interconnect</strong>はGoogleのコロケーション施設に物理的に直接接続する専用線サービスです。10Gbps/100Gbps単位で回線を確保します。</p>
+
+                <div className={sharedStyles.highlight}>
+                    <strong>99.99% SLA冗長構成（本番環境必須）</strong><br/>
+                    Metro-A が完全停止してもMetro-Bで継続 = <strong>99.99% SLA</strong>（異なる2 Metro × 2回線 = 合計4回線）<br/>
+                    同一Metro内2本のみ = 99.9% SLA（非推奨）
+                </div>
+
+                <div className={sharedStyles.bpBox}>
+                    <h5>VLAN Attachmentとは</h5>
+                    <p>1本の物理専用線を論理的に複数に分割する仕組み（VLAN）。各アタッチメントが1つのVPCに対応し、1本の回線で複数のVPCに接続できます。</p>
+                </div>
+            </div>
+
+            <div className={sharedStyles.detailBlock}>
+                <h3>
+                    <span aria-hidden="true">🔀</span> 2.4 Cloud Router と BGP ─ 動的ルーティングの仕組みと設定
+                </h3>
+                <p>Cloud RouterはBGPセッションを管理し、オンプレとGCP間でルートを自動交換します。<strong>データプレーンのトラフィック自体は通過しません</strong>（コントロールプレーンのみ）。</p>
+                <div className={`table-wrapper ${sharedStyles.tableWrapperMt}`}>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th scope="col">モード</th>
+                                <th scope="col">ルートの適用範囲</th>
+                                <th scope="col">用途</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td className={sharedStyles.tdName}>Regional</td>
+                                <td>学習したルートを同一リージョンのサブネットにのみ適用</td>
+                                <td>リージョン内に閉じた構成・コスト最適化</td>
+                            </tr>
+                            <tr>
+                                <td className={sharedStyles.tdName}>Global（推奨）</td>
+                                <td>全リージョンの全サブネットに学習ルートを反映</td>
+                                <td>マルチリージョン構成・HA設計</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div className={sharedStyles.examTip}>
+                    <span className={sharedStyles.tipLabel}>💡 BGP MED (Multi-Exit Discriminator)</span>
+                    複数のBGPパスがある場合に、どのパスを優先するかを制御する属性。MEDが小さい方が優先されます。アクティブ/スタンバイの制御に活用します。
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/app/gcl/professional-cloud-network-engineer/components/Section2.tsx
+++ b/app/gcl/professional-cloud-network-engineer/components/Section2.tsx
@@ -10,7 +10,7 @@ export function Section2() {
     return (
         <section className={sharedStyles.section} id="s2" aria-labelledby="s2-title">
             <div className={sharedStyles.sectionLabel}>Section 2 (23%)</div>
-            <h2 className={sharedStyles.sectionTitle} id="s2-title" style={{ color: '#4caf50' }}>
+            <h2 className={sharedStyles.sectionTitle} id="s2-title" style={{ color: 'var(--color-primary)' }}>
                 ハイブリッド接続とネットワーク相互接続
             </h2>
             <p className={sharedStyles.sectionDesc}>

--- a/app/gcl/professional-cloud-network-engineer/components/SectionIntro.tsx
+++ b/app/gcl/professional-cloud-network-engineer/components/SectionIntro.tsx
@@ -28,7 +28,7 @@ export function SectionIntro() {
                             <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~21%</span>
                         </div>
                         <div className={sharedStyles.weightTrack}>
-                            <div className={sharedStyles.weightFill} style={{ width: '21%', background: '#4f8ef7' }}></div>
+                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS1}`} style={{ width: '21%' }}></div>
                         </div>
                     </div>
                     <div>
@@ -37,7 +37,7 @@ export function SectionIntro() {
                             <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~23%</span>
                         </div>
                         <div className={sharedStyles.weightTrack}>
-                            <div className={sharedStyles.weightFill} style={{ width: '23%', background: '#4caf50' }}></div>
+                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS2}`} style={{ width: '23%' }}></div>
                         </div>
                     </div>
                     <div>
@@ -46,7 +46,7 @@ export function SectionIntro() {
                             <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~19%</span>
                         </div>
                         <div className={sharedStyles.weightTrack}>
-                            <div className={sharedStyles.weightFill} style={{ width: '19%', background: '#ff9800' }}></div>
+                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS3}`} style={{ width: '19%' }}></div>
                         </div>
                     </div>
                     <div>
@@ -55,7 +55,7 @@ export function SectionIntro() {
                             <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~15%</span>
                         </div>
                         <div className={sharedStyles.weightTrack}>
-                            <div className={sharedStyles.weightFill} style={{ width: '15%', background: '#9c27b0' }}></div>
+                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS4}`} style={{ width: '15%' }}></div>
                         </div>
                     </div>
                     <div>
@@ -64,7 +64,7 @@ export function SectionIntro() {
                             <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~12%</span>
                         </div>
                         <div className={sharedStyles.weightTrack}>
-                            <div className={sharedStyles.weightFill} style={{ width: '12%', background: '#f44336' }}></div>
+                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS5}`} style={{ width: '12%' }}></div>
                         </div>
                     </div>
                     <div>
@@ -73,7 +73,7 @@ export function SectionIntro() {
                             <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~10%</span>
                         </div>
                         <div className={sharedStyles.weightTrack}>
-                            <div className={sharedStyles.weightFill} style={{ width: '10%', background: '#ffeb3b' }}></div>
+                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS6}`} style={{ width: '10%' }}></div>
                         </div>
                     </div>
                 </div>
@@ -86,35 +86,35 @@ export function SectionIntro() {
                 </h3>
                 <div className={sharedStyles.flowSteps}>
                     <div className={sharedStyles.flowStep}>
-                        <div className={sharedStyles.flowStepNum} style={{ background: 'color-mix(in srgb, #4f8ef7 15%, transparent)', color: '#4f8ef7', border: '1px solid color-mix(in srgb, #4f8ef7 30%, transparent)' }}>1</div>
+                        <div className={`${sharedStyles.flowStepNum} ${sharedStyles.flowStepNumS1}`}>1</div>
                         <div>
                             <div className={sharedStyles.flowStepTitle}>公式試験ガイドを熟読する（必須）</div>
                             <div className={sharedStyles.flowStepBody}>試験範囲の正式定義を確認。本ガイドと照らし合わせながら学習計画を立てる。</div>
                         </div>
                     </div>
                     <div className={sharedStyles.flowStep}>
-                        <div className={sharedStyles.flowStepNum} style={{ background: 'color-mix(in srgb, #4caf50 15%, transparent)', color: '#4caf50', border: '1px solid color-mix(in srgb, #4caf50 30%, transparent)' }}>2</div>
+                        <div className={`${sharedStyles.flowStepNum} ${sharedStyles.flowStepNumS2}`}>2</div>
                         <div>
                             <div className={sharedStyles.flowStepTitle}>Cloud Skills Boost のPCNEラーニングパスを修了</div>
                             <div className={sharedStyles.flowStepBody}>体系的な動画学習と実践演習。GCPのネットワーキング基礎から始められる。</div>
                         </div>
                     </div>
                     <div className={sharedStyles.flowStep}>
-                        <div className={sharedStyles.flowStepNum} style={{ background: 'color-mix(in srgb, #ff9800 15%, transparent)', color: '#ff9800', border: '1px solid color-mix(in srgb, #ff9800 30%, transparent)' }}>3</div>
+                        <div className={`${sharedStyles.flowStepNum} ${sharedStyles.flowStepNumS3}`}>3</div>
                         <div>
                             <div className={sharedStyles.flowStepTitle}>ハンズオンラボで実際に操作する</div>
                             <div className={sharedStyles.flowStepBody}>VPC・Cloud VPN・Cloud Interconnect・ロードバランサーの実際の構築体験が合否を分ける。</div>
                         </div>
                     </div>
                     <div className={sharedStyles.flowStep}>
-                        <div className={sharedStyles.flowStepNum} style={{ background: 'color-mix(in srgb, #9c27b0 15%, transparent)', color: '#9c27b0', border: '1px solid color-mix(in srgb, #9c27b0 30%, transparent)' }}>4</div>
+                        <div className={`${sharedStyles.flowStepNum} ${sharedStyles.flowStepNumS4}`}>4</div>
                         <div>
                             <div className={sharedStyles.flowStepTitle}>公式サンプル問題・模擬試験で実力測定</div>
                             <div className={sharedStyles.flowStepBody}>弱点を可視化して集中補強。シナリオベースの設問形式に慣れる。</div>
                         </div>
                     </div>
                     <div className={sharedStyles.flowStep}>
-                        <div className={sharedStyles.flowStepNum} style={{ background: 'color-mix(in srgb, #f44336 15%, transparent)', color: '#f44336', border: '1px solid color-mix(in srgb, #f44336 30%, transparent)' }}>5</div>
+                        <div className={`${sharedStyles.flowStepNum} ${sharedStyles.flowStepNumS5}`}>5</div>
                         <div>
                             <div className={sharedStyles.flowStepTitle}>弱点分野を公式ドキュメントで補強して試験登録</div>
                             <div className={sharedStyles.flowStepBody}>本ガイドの各セクションの「参照URL」から公式ドキュメントを直接確認する。</div>

--- a/app/gcl/professional-cloud-network-engineer/components/SectionIntro.tsx
+++ b/app/gcl/professional-cloud-network-engineer/components/SectionIntro.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import sharedStyles from './SharedSection.module.css';
+
+/**
+ * Renders the INTRO (Exam Overview & Prep) section for the PCNE guide.
+ *
+ * @returns {React.ReactElement} The section component
+ */
+export function SectionIntro() {
+    return (
+        <section className={sharedStyles.section} id="overview" aria-labelledby="intro-title">
+            <div className={sharedStyles.sectionLabel}>INTRO</div>
+            <h2 className={sharedStyles.sectionTitle} id="intro-title">試験の全体像と準備方法</h2>
+            <p className={sharedStyles.sectionDesc}>
+                PCNEは、Google Cloudのネットワークインフラを設計・実装・管理・最適化する能力を証明する上級資格です。単なる操作知識でなく、アーキテクチャ設計の判断力が問われます。
+            </p>
+            <div className={sharedStyles.divider}></div>
+
+            {/* 出題配点バー */}
+            <div className={sharedStyles.detailBlock}>
+                <h3>
+                    <span aria-hidden="true">📊</span> 出題セクション別 配点
+                </h3>
+                <div style={{ display: 'grid', gap: '10px', margin: '16px 0 28px' }}>
+                    <div>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '5px', fontSize: '1rem' }}>
+                            <span style={{ color: 'var(--color-foreground)' }}>S1: VPCネットワーク設計</span>
+                            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~21%</span>
+                        </div>
+                        <div className={sharedStyles.weightTrack}>
+                            <div className={sharedStyles.weightFill} style={{ width: '21%', background: '#4f8ef7' }}></div>
+                        </div>
+                    </div>
+                    <div>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '5px', fontSize: '1rem' }}>
+                            <span style={{ color: 'var(--color-foreground)' }}>S2: ハイブリッド接続・ネットワーク相互接続</span>
+                            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~23%</span>
+                        </div>
+                        <div className={sharedStyles.weightTrack}>
+                            <div className={sharedStyles.weightFill} style={{ width: '23%', background: '#4caf50' }}></div>
+                        </div>
+                    </div>
+                    <div>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '5px', fontSize: '1rem' }}>
+                            <span style={{ color: 'var(--color-foreground)' }}>S3: ロードバランシングとトラフィック管理</span>
+                            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~19%</span>
+                        </div>
+                        <div className={sharedStyles.weightTrack}>
+                            <div className={sharedStyles.weightFill} style={{ width: '19%', background: '#ff9800' }}></div>
+                        </div>
+                    </div>
+                    <div>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '5px', fontSize: '1rem' }}>
+                            <span style={{ color: 'var(--color-foreground)' }}>S4: CDN・DNS・IPアドレス管理</span>
+                            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~15%</span>
+                        </div>
+                        <div className={sharedStyles.weightTrack}>
+                            <div className={sharedStyles.weightFill} style={{ width: '15%', background: '#9c27b0' }}></div>
+                        </div>
+                    </div>
+                    <div>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '5px', fontSize: '1rem' }}>
+                            <span style={{ color: 'var(--color-foreground)' }}>S5: ネットワークセキュリティの設計と実装</span>
+                            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~12%</span>
+                        </div>
+                        <div className={sharedStyles.weightTrack}>
+                            <div className={sharedStyles.weightFill} style={{ width: '12%', background: '#f44336' }}></div>
+                        </div>
+                    </div>
+                    <div>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '5px', fontSize: '1rem' }}>
+                            <span style={{ color: 'var(--color-foreground)' }}>S6: ネットワーク操作と監視</span>
+                            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~10%</span>
+                        </div>
+                        <div className={sharedStyles.weightTrack}>
+                            <div className={sharedStyles.weightFill} style={{ width: '10%', background: '#ffeb3b' }}></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {/* 学習ステップ */}
+            <div className={sharedStyles.detailBlock}>
+                <h3>
+                    <span aria-hidden="true">📈</span> 推奨学習ステップ
+                </h3>
+                <div className={sharedStyles.flowSteps}>
+                    <div className={sharedStyles.flowStep}>
+                        <div className={sharedStyles.flowStepNum} style={{ background: 'color-mix(in srgb, #4f8ef7 15%, transparent)', color: '#4f8ef7', border: '1px solid color-mix(in srgb, #4f8ef7 30%, transparent)' }}>1</div>
+                        <div>
+                            <div className={sharedStyles.flowStepTitle}>公式試験ガイドを熟読する（必須）</div>
+                            <div className={sharedStyles.flowStepBody}>試験範囲の正式定義を確認。本ガイドと照らし合わせながら学習計画を立てる。</div>
+                        </div>
+                    </div>
+                    <div className={sharedStyles.flowStep}>
+                        <div className={sharedStyles.flowStepNum} style={{ background: 'color-mix(in srgb, #4caf50 15%, transparent)', color: '#4caf50', border: '1px solid color-mix(in srgb, #4caf50 30%, transparent)' }}>2</div>
+                        <div>
+                            <div className={sharedStyles.flowStepTitle}>Cloud Skills Boost のPCNEラーニングパスを修了</div>
+                            <div className={sharedStyles.flowStepBody}>体系的な動画学習と実践演習。GCPのネットワーキング基礎から始められる。</div>
+                        </div>
+                    </div>
+                    <div className={sharedStyles.flowStep}>
+                        <div className={sharedStyles.flowStepNum} style={{ background: 'color-mix(in srgb, #ff9800 15%, transparent)', color: '#ff9800', border: '1px solid color-mix(in srgb, #ff9800 30%, transparent)' }}>3</div>
+                        <div>
+                            <div className={sharedStyles.flowStepTitle}>ハンズオンラボで実際に操作する</div>
+                            <div className={sharedStyles.flowStepBody}>VPC・Cloud VPN・Cloud Interconnect・ロードバランサーの実際の構築体験が合否を分ける。</div>
+                        </div>
+                    </div>
+                    <div className={sharedStyles.flowStep}>
+                        <div className={sharedStyles.flowStepNum} style={{ background: 'color-mix(in srgb, #9c27b0 15%, transparent)', color: '#9c27b0', border: '1px solid color-mix(in srgb, #9c27b0 30%, transparent)' }}>4</div>
+                        <div>
+                            <div className={sharedStyles.flowStepTitle}>公式サンプル問題・模擬試験で実力測定</div>
+                            <div className={sharedStyles.flowStepBody}>弱点を可視化して集中補強。シナリオベースの設問形式に慣れる。</div>
+                        </div>
+                    </div>
+                    <div className={sharedStyles.flowStep}>
+                        <div className={sharedStyles.flowStepNum} style={{ background: 'color-mix(in srgb, #f44336 15%, transparent)', color: '#f44336', border: '1px solid color-mix(in srgb, #f44336 30%, transparent)' }}>5</div>
+                        <div>
+                            <div className={sharedStyles.flowStepTitle}>弱点分野を公式ドキュメントで補強して試験登録</div>
+                            <div className={sharedStyles.flowStepBody}>本ガイドの各セクションの「参照URL」から公式ドキュメントを直接確認する。</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {/* 公式リソース */}
+            <div className={sharedStyles.detailBlock}>
+                <h3>
+                    <span aria-hidden="true">📚</span> 公式リソース
+                </h3>
+                <div className={sharedStyles.sources}>
+                    <a className={sharedStyles.sourceLink} href="https://cloud.google.com/learn/certification/cloud-network-engineer" target="_blank" rel="noopener noreferrer">
+                        <span className={sharedStyles.sourceIcon} aria-hidden="true">🔗</span>
+                        <div className={sharedStyles.sourceText}>
+                            <strong>公式試験ページ — Professional Cloud Network Engineer</strong>
+                            <span className={sharedStyles.sourceUrl}>cloud.google.com/learn/certification/cloud-network-engineer</span>
+                        </div>
+                    </a>
+                    <a className={sharedStyles.sourceLink} href="https://cloud.google.com/learn/certification/guides/cloud-network-engineer" target="_blank" rel="noopener noreferrer">
+                        <span className={sharedStyles.sourceIcon} aria-hidden="true">📄</span>
+                        <div className={sharedStyles.sourceText}>
+                            <strong>公式試験ガイド（出題範囲の詳細）</strong>
+                            <span className={sharedStyles.sourceUrl}>cloud.google.com/learn/certification/guides/cloud-network-engineer</span>
+                        </div>
+                    </a>
+                    <a className={sharedStyles.sourceLink} href="https://services.google.com/fh/files/misc/042426_professional_cloud_network_engineer_exam_guide_english.pdf" target="_blank" rel="noopener noreferrer">
+                        <span className={sharedStyles.sourceIcon} aria-hidden="true">📑</span>
+                        <div className={sharedStyles.sourceText}>
+                            <strong>最新試験ガイド PDF（英語・2024年4月版）</strong>
+                            <span className={sharedStyles.sourceUrl}>services.google.com/fh/files/misc/042426_...exam_guide_english.pdf</span>
+                        </div>
+                    </a>
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/app/gcl/professional-cloud-network-engineer/components/SectionIntro.tsx
+++ b/app/gcl/professional-cloud-network-engineer/components/SectionIntro.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import sharedStyles from './SharedSection.module.css';
 
 /**
- * Renders the INTRO (Exam Overview & Prep) section for the PCNE guide.
+ * Renders the INTRO section presenting the PCNE exam overview and preparation guidance.
  *
- * @returns {React.ReactElement} The section component
+ * @returns The section element containing the exam description, a score breakdown for S1–S6, recommended learning steps, and links to official resources.
  */
 export function SectionIntro() {
     return (

--- a/app/gcl/professional-cloud-network-engineer/components/SectionIntro.tsx
+++ b/app/gcl/professional-cloud-network-engineer/components/SectionIntro.tsx
@@ -21,59 +21,59 @@ export function SectionIntro() {
                 <h3>
                     <span aria-hidden="true">📊</span> 出題セクション別 配点
                 </h3>
-                <div style={{ display: 'grid', gap: '10px', margin: '16px 0 28px' }}>
-                    <div>
-                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '5px', fontSize: '1rem' }}>
-                            <span style={{ color: 'var(--color-foreground)' }}>S1: VPCネットワーク設計</span>
-                            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~21%</span>
+                <div className={sharedStyles.weightRow}>
+                    <div className={sharedStyles.weightItem}>
+                        <div className={sharedStyles.weightHeader}>
+                            <span className={sharedStyles.weightLabel}>S1: VPCネットワーク設計</span>
+                            <span className={sharedStyles.weightPercent}>~21%</span>
                         </div>
                         <div className={sharedStyles.weightTrack}>
-                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS1}`} style={{ width: '21%' }}></div>
+                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS1} ${sharedStyles.weightW21}`}></div>
                         </div>
                     </div>
-                    <div>
-                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '5px', fontSize: '1rem' }}>
-                            <span style={{ color: 'var(--color-foreground)' }}>S2: ハイブリッド接続・ネットワーク相互接続</span>
-                            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~23%</span>
+                    <div className={sharedStyles.weightItem}>
+                        <div className={sharedStyles.weightHeader}>
+                            <span className={sharedStyles.weightLabel}>S2: ハイブリッド接続・ネットワーク相互接続</span>
+                            <span className={sharedStyles.weightPercent}>~23%</span>
                         </div>
                         <div className={sharedStyles.weightTrack}>
-                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS2}`} style={{ width: '23%' }}></div>
+                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS2} ${sharedStyles.weightW23}`}></div>
                         </div>
                     </div>
-                    <div>
-                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '5px', fontSize: '1rem' }}>
-                            <span style={{ color: 'var(--color-foreground)' }}>S3: ロードバランシングとトラフィック管理</span>
-                            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~19%</span>
+                    <div className={sharedStyles.weightItem}>
+                        <div className={sharedStyles.weightHeader}>
+                            <span className={sharedStyles.weightLabel}>S3: ロードバランシングとトラフィック管理</span>
+                            <span className={sharedStyles.weightPercent}>~19%</span>
                         </div>
                         <div className={sharedStyles.weightTrack}>
-                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS3}`} style={{ width: '19%' }}></div>
+                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS3} ${sharedStyles.weightW19}`}></div>
                         </div>
                     </div>
-                    <div>
-                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '5px', fontSize: '1rem' }}>
-                            <span style={{ color: 'var(--color-foreground)' }}>S4: CDN・DNS・IPアドレス管理</span>
-                            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~15%</span>
+                    <div className={sharedStyles.weightItem}>
+                        <div className={sharedStyles.weightHeader}>
+                            <span className={sharedStyles.weightLabel}>S4: CDN・DNS・IPアドレス管理</span>
+                            <span className={sharedStyles.weightPercent}>~15%</span>
                         </div>
                         <div className={sharedStyles.weightTrack}>
-                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS4}`} style={{ width: '15%' }}></div>
+                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS4} ${sharedStyles.weightW15}`}></div>
                         </div>
                     </div>
-                    <div>
-                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '5px', fontSize: '1rem' }}>
-                            <span style={{ color: 'var(--color-foreground)' }}>S5: ネットワークセキュリティの設計と実装</span>
-                            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~12%</span>
+                    <div className={sharedStyles.weightItem}>
+                        <div className={sharedStyles.weightHeader}>
+                            <span className={sharedStyles.weightLabel}>S5: ネットワークセキュリティの設計と実装</span>
+                            <span className={sharedStyles.weightPercent}>~12%</span>
                         </div>
                         <div className={sharedStyles.weightTrack}>
-                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS5}`} style={{ width: '12%' }}></div>
+                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS5} ${sharedStyles.weightW12}`}></div>
                         </div>
                     </div>
-                    <div>
-                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '5px', fontSize: '1rem' }}>
-                            <span style={{ color: 'var(--color-foreground)' }}>S6: ネットワーク操作と監視</span>
-                            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-primary)' }}>~10%</span>
+                    <div className={sharedStyles.weightItem}>
+                        <div className={sharedStyles.weightHeader}>
+                            <span className={sharedStyles.weightLabel}>S6: ネットワーク操作と監視</span>
+                            <span className={sharedStyles.weightPercent}>~10%</span>
                         </div>
                         <div className={sharedStyles.weightTrack}>
-                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS6}`} style={{ width: '10%' }}></div>
+                            <div className={`${sharedStyles.weightFill} ${sharedStyles.weightFillS6} ${sharedStyles.weightW10}`}></div>
                         </div>
                     </div>
                 </div>

--- a/app/gcl/professional-cloud-network-engineer/components/SharedSection.module.css
+++ b/app/gcl/professional-cloud-network-engineer/components/SharedSection.module.css
@@ -52,7 +52,7 @@
     border-radius: 12px;
     padding: 32px;
     margin-bottom: 32px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.02);
+    box-shadow: 0 4px 12px color-mix(in srgb, var(--color-foreground) 2%, transparent);
 }
 
 .detailBlock h3 {
@@ -266,6 +266,34 @@
 .weightFillS4 { background: color-mix(in srgb, var(--color-primary) 55%, transparent); }
 .weightFillS5 { background: color-mix(in srgb, var(--color-primary) 40%, transparent); }
 .weightFillS6 { background: color-mix(in srgb, var(--color-primary) 25%, transparent); }
+
+.weightRow {
+    display: grid;
+    gap: 10px;
+    margin: 16px 0 28px;
+}
+.weightItem {
+    /* Container for each section's weight bar */
+}
+.weightHeader {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 5px;
+    font-size: 1rem;
+}
+.weightLabel {
+    color: var(--color-foreground);
+}
+.weightPercent {
+    font-family: var(--font-mono);
+    color: var(--color-primary);
+}
+.weightW21 { width: 21%; }
+.weightW23 { width: 23%; }
+.weightW19 { width: 19%; }
+.weightW15 { width: 15%; }
+.weightW12 { width: 12%; }
+.weightW10 { width: 10%; }
 
 .flowSteps {
     display: flex;

--- a/app/gcl/professional-cloud-network-engineer/components/SharedSection.module.css
+++ b/app/gcl/professional-cloud-network-engineer/components/SharedSection.module.css
@@ -1,6 +1,14 @@
 .section {
     padding: 64px 24px;
     border-bottom: 1px solid var(--color-border);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.section > * {
+    width: 100%;
+    max-width: 1000px;
 }
 
 .sectionAlt {

--- a/app/gcl/professional-cloud-network-engineer/components/SharedSection.module.css
+++ b/app/gcl/professional-cloud-network-engineer/components/SharedSection.module.css
@@ -260,6 +260,12 @@
     height: 100%;
     border-radius: 4px;
 }
+.weightFillS1 { background: var(--color-primary); }
+.weightFillS2 { background: color-mix(in srgb, var(--color-primary) 85%, transparent); }
+.weightFillS3 { background: color-mix(in srgb, var(--color-primary) 70%, transparent); }
+.weightFillS4 { background: color-mix(in srgb, var(--color-primary) 55%, transparent); }
+.weightFillS5 { background: color-mix(in srgb, var(--color-primary) 40%, transparent); }
+.weightFillS6 { background: color-mix(in srgb, var(--color-primary) 25%, transparent); }
 
 .flowSteps {
     display: flex;
@@ -285,6 +291,11 @@
     font-weight: 700;
     font-family: var(--font-mono);
     flex-shrink: 0;
+}
+.flowStepNumS1, .flowStepNumS2, .flowStepNumS3, .flowStepNumS4, .flowStepNumS5 {
+    background: color-mix(in srgb, var(--color-primary) 15%, transparent);
+    color: var(--color-primary);
+    border: 1px solid color-mix(in srgb, var(--color-primary) 30%, transparent);
 }
 .flowStepTitle {
     font-weight: 600;

--- a/app/gcl/professional-cloud-network-engineer/components/SharedSection.module.css
+++ b/app/gcl/professional-cloud-network-engineer/components/SharedSection.module.css
@@ -67,11 +67,11 @@
 }
 
 .tagBlue { background: color-mix(in srgb, var(--color-primary) 10%, transparent); color: var(--color-primary); border: 1px solid color-mix(in srgb, var(--color-primary) 20%, transparent); }
-.tagOrange { background: color-mix(in srgb, #ff9800 10%, transparent); color: #ff9800; border: 1px solid color-mix(in srgb, #ff9800 20%, transparent); }
+.tagOrange { background: color-mix(in srgb, var(--color-primary) 10%, transparent); color: var(--color-primary); border: 1px solid color-mix(in srgb, var(--color-primary) 20%, transparent); }
 
 .highlight {
-    background: color-mix(in srgb, #ffeb3b 10%, transparent);
-    border-left: 4px solid #ffeb3b;
+    background: color-mix(in srgb, var(--color-primary) 10%, transparent);
+    border-left: 4px solid var(--color-primary);
     padding: 16px;
     border-radius: 4px;
     margin: 16px 0;
@@ -171,7 +171,7 @@
     content: "✓";
     position: absolute;
     left: 0;
-    color: #4caf50;
+    color: var(--color-primary);
     font-weight: bold;
 }
 

--- a/app/gcl/professional-cloud-network-engineer/components/SharedSection.module.css
+++ b/app/gcl/professional-cloud-network-engineer/components/SharedSection.module.css
@@ -1,0 +1,290 @@
+.section {
+    padding: 64px 24px;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.sectionAlt {
+    background-color: color-mix(in srgb, var(--color-card) 40%, transparent);
+}
+
+.sectionLabel {
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    letter-spacing: 0.1em;
+    color: var(--color-primary);
+    text-transform: uppercase;
+    margin-bottom: 12px;
+}
+
+.sectionTitle {
+    font-size: clamp(2rem, 3vw, 2.5rem);
+    font-weight: 800;
+    color: var(--color-foreground);
+    margin-bottom: 16px;
+    line-height: 1.2;
+}
+
+.sectionDesc {
+    font-size: 1.1rem;
+    color: var(--color-muted-foreground);
+    margin-bottom: 32px;
+    line-height: 1.6;
+    max-width: 800px;
+}
+
+.divider {
+    height: 1px;
+    background: var(--color-border);
+    margin: 40px 0;
+}
+
+.detailBlock {
+    background: var(--color-card);
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 32px;
+    margin-bottom: 32px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.02);
+}
+
+.detailBlock h3 {
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: var(--color-foreground);
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.tag {
+    font-size: 0.75rem;
+    padding: 4px 10px;
+    border-radius: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+    font-family: var(--font-mono);
+}
+
+.tagBlue { background: color-mix(in srgb, var(--color-primary) 10%, transparent); color: var(--color-primary); border: 1px solid color-mix(in srgb, var(--color-primary) 20%, transparent); }
+.tagOrange { background: color-mix(in srgb, #ff9800 10%, transparent); color: #ff9800; border: 1px solid color-mix(in srgb, #ff9800 20%, transparent); }
+
+.highlight {
+    background: color-mix(in srgb, #ffeb3b 10%, transparent);
+    border-left: 4px solid #ffeb3b;
+    padding: 16px;
+    border-radius: 4px;
+    margin: 16px 0;
+    color: var(--color-foreground);
+    font-size: 0.95rem;
+    line-height: 1.6;
+}
+
+.cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 20px;
+    margin-top: 24px;
+}
+
+.card {
+    background: var(--color-background);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 24px;
+}
+
+.cardIcon {
+    font-size: 1.5rem;
+    margin-bottom: 12px;
+    display: inline-block;
+}
+
+.card h4 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--color-foreground);
+    margin-bottom: 8px;
+}
+
+.card p {
+    font-size: 0.95rem;
+    color: var(--color-muted-foreground);
+    line-height: 1.6;
+}
+
+.examTip {
+    background: color-mix(in srgb, var(--color-primary) 5%, transparent);
+    border: 1px solid color-mix(in srgb, var(--color-primary) 20%, transparent);
+    border-left: 3px solid var(--color-primary);
+    border-radius: 10px;
+    padding: 16px 20px;
+    margin: 16px 0;
+    font-size: 1rem;
+    line-height: 1.65;
+    color: var(--color-foreground);
+}
+
+.tipLabel {
+    font-family: var(--font-mono);
+    font-size: 1rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-primary);
+    display: block;
+    margin-bottom: 6px;
+}
+
+.bpBox {
+    background: var(--color-background);
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 32px;
+    margin-bottom: 32px;
+}
+
+.bpBox h5 {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--color-foreground);
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.bpBox ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.bpBox li {
+    position: relative;
+    padding-left: 24px;
+    margin-bottom: 12px;
+    color: var(--color-foreground);
+    line-height: 1.6;
+}
+
+.bpBox li::before {
+    content: "✓";
+    position: absolute;
+    left: 0;
+    color: #4caf50;
+    font-weight: bold;
+}
+
+.sources {
+    margin-top: 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.sourceLink {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 16px;
+    background: var(--color-background);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    text-decoration: none;
+    transition: all 0.2s ease;
+}
+
+.sourceLink:hover {
+    border-color: var(--color-primary);
+    background: color-mix(in srgb, var(--color-primary) 5%, transparent);
+}
+
+.sourceIcon {
+    font-size: 1.2rem;
+}
+
+.sourceText {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.sourceText strong {
+    color: var(--color-foreground);
+    font-weight: 600;
+}
+
+.sourceUrl {
+    color: var(--color-muted-foreground);
+    font-size: 0.85rem;
+    word-break: break-all;
+}
+
+.tdName {
+    font-weight: 600;
+    color: var(--color-foreground);
+}
+
+.tableWrapperMt {
+    margin-top: 1.5rem;
+}
+
+.diagramWrapper {
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.diagramWrapperScrollable {
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+    overflow-x: auto;
+}
+
+/* PCNE Specific classes */
+.weightTrack {
+    height: 8px;
+    background: var(--color-border);
+    border-radius: 4px;
+    overflow: hidden;
+    margin-bottom: 12px;
+}
+.weightFill {
+    height: 100%;
+    border-radius: 4px;
+}
+
+.flowSteps {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-top: 24px;
+}
+.flowStep {
+    display: flex;
+    gap: 16px;
+    background: var(--color-card);
+    border: 1px solid var(--color-border);
+    padding: 20px;
+    border-radius: 8px;
+}
+.flowStepNum {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    font-weight: 700;
+    font-family: var(--font-mono);
+    flex-shrink: 0;
+}
+.flowStepTitle {
+    font-weight: 600;
+    color: var(--color-foreground);
+    margin-bottom: 8px;
+}
+.flowStepBody {
+    color: var(--color-muted-foreground);
+    font-size: 0.95rem;
+    line-height: 1.5;
+}

--- a/app/gcl/professional-cloud-network-engineer/constants.ts
+++ b/app/gcl/professional-cloud-network-engineer/constants.ts
@@ -1,0 +1,31 @@
+export type HeroBadge = {
+    label: string;
+    color: 'blue' | 'red' | 'yellow' | 'green' | 'purple' | 'orange' | 'cyan';
+};
+
+export const HERO_BADGES: readonly HeroBadge[] = [
+    { label: '🌐 VPC 設計', color: 'blue' },
+    { label: '🔗 ハイブリッド接続', color: 'green' },
+    { label: '⚖️ ロードバランシング', color: 'orange' },
+    { label: '🖧 ネットワークサービス', color: 'purple' },
+    { label: '🛡️ セキュリティ', color: 'red' },
+    { label: '🔍 監視・トラブルシュート', color: 'yellow' },
+];
+
+export type NavLink = {
+    id: string;
+    num: string;
+    label: string;
+};
+
+export const NAV_LINKS: readonly NavLink[] = [
+    { id: 'overview', num: 'INTRO', label: '全体像' },
+    { id: 's1', num: '01', label: 'VPCネットワーク' },
+    { id: 's2', num: '02', label: 'ハイブリッド接続' },
+    { id: 's3', num: '03', label: 'ロードバランシング' },
+    { id: 's4', num: '04', label: 'ネットワークサービス' },
+    { id: 's5', num: '05', label: 'セキュリティ' },
+    { id: 's6', num: '06', label: '監視・トラブル' },
+    { id: 'cheatsheet', num: 'まとめ', label: 'チートシート' },
+    { id: 'confusion', num: 'まとめ', label: '混同しやすい' },
+];

--- a/app/gcl/professional-cloud-network-engineer/layout.tsx
+++ b/app/gcl/professional-cloud-network-engineer/layout.tsx
@@ -5,6 +5,12 @@ export const metadata: Metadata = {
     description: 'Google Cloud Professional Cloud Network Engineer (PCNE) 完全試験対策ガイド。VPC設計からハイブリッド接続、ロードバランシング、セキュリティ、監視まで網羅。',
 };
 
+/**
+ * Root layout that renders its `children` unchanged.
+ *
+ * @param children - Content to be rendered within this layout
+ * @returns The provided `children` rendered as the layout's output
+ */
 export default function Layout({
     children,
 }: {

--- a/app/gcl/professional-cloud-network-engineer/layout.tsx
+++ b/app/gcl/professional-cloud-network-engineer/layout.tsx
@@ -1,3 +1,4 @@
+import './pcne.module.css'; // Import PCNE theme CSS
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {

--- a/app/gcl/professional-cloud-network-engineer/layout.tsx
+++ b/app/gcl/professional-cloud-network-engineer/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+    title: 'Professional Cloud Network Engineer | Google Cloud Certification',
+    description: 'Google Cloud Professional Cloud Network Engineer (PCNE) 完全試験対策ガイド。VPC設計からハイブリッド接続、ロードバランシング、セキュリティ、監視まで網羅。',
+};
+
+export default function Layout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return <>{children}</>;
+}

--- a/app/gcl/professional-cloud-network-engineer/page.tsx
+++ b/app/gcl/professional-cloud-network-engineer/page.tsx
@@ -2,6 +2,7 @@ import { HERO_BADGES, NAV_LINKS } from './constants';
 import styles from './pcne.module.css';
 import { SectionIntro } from './components/SectionIntro';
 import { Section1 } from './components/Section1';
+import { Section2 } from './components/Section2';
 
 /**
  * Renders the "Professional Cloud Network Engineer" page layout,
@@ -55,6 +56,7 @@ export default function PcnePage() {
                 {/* SECTIONS */}
                 <SectionIntro />
                 <Section1 />
+                <Section2 />
                 {/* Sections will be added here step by step */}
             </main>
         </div>

--- a/app/gcl/professional-cloud-network-engineer/page.tsx
+++ b/app/gcl/professional-cloud-network-engineer/page.tsx
@@ -1,0 +1,58 @@
+import { HERO_BADGES, NAV_LINKS } from './constants';
+import styles from './pcne.module.css';
+
+/**
+ * Renders the "Professional Cloud Network Engineer" page layout,
+ * including a hero header, a sticky in-page navigation bar, and the section content blocks.
+ *
+ * @returns A JSX element representing the complete PCNE page layout
+ */
+export default function PcnePage() {
+    return (
+        <div className="pcne-page">
+            <main className={styles.pcneMain}>
+                {/* HERO */}
+                <div className={styles.hero} id="overview">
+                    <div className={styles.heroBadge}>Professional Cloud Network Engineer</div>
+                    <h1 className={styles.heroTitle}>
+                        Professional Cloud<br />
+                        <span className={styles.heroAccent}>Network Engineer</span><br />
+                        完全試験対策ガイド
+                    </h1>
+                    <p className={styles.heroDesc}>
+                        ネットワーク初学者から中級者まで対応。VPC設計からハイブリッド接続、ロードバランシング、セキュリティ、監視まで、試験に出るすべての技術領域をステップバイステップで解説します。
+                    </p>
+
+                    <div className={styles.heroStats}>
+                        <span className={styles.heroStat}><span className={styles.heroStatDot}>◆</span> 試験時間: 120分</span>
+                        <span className={styles.heroStat}><span className={styles.heroStatDot}>◆</span> 問題数: 50〜60問</span>
+                        <span className={styles.heroStat}><span className={styles.heroStatDot}>◆</span> 受験料: $200</span>
+                        <span className={styles.heroStat}><span className={styles.heroStatDot}>◆</span> 推奨経験: 3年以上</span>
+                        <span className={styles.heroStat}><span className={styles.heroStatDot}>◆</span> 更新: 2年ごと</span>
+                    </div>
+
+                    <div className={styles.heroTags}>
+                        {HERO_BADGES.map((badge) => (
+                            <span key={badge.label} className={styles.heroTag}>
+                                {badge.label}
+                            </span>
+                        ))}
+                    </div>
+                </div>
+
+                {/* NAV */}
+                <nav aria-label="Quick navigation" className={styles.navSticky}>
+                    <span className={styles.navLabel}>PCNE</span>
+                    {NAV_LINKS.map((link) => (
+                        <a key={link.id} href={`#${link.id}`}>
+                            {link.num} {link.label}
+                        </a>
+                    ))}
+                </nav>
+
+                {/* SECTIONS */}
+                {/* Sections will be added here step by step */}
+            </main>
+        </div>
+    );
+}

--- a/app/gcl/professional-cloud-network-engineer/page.tsx
+++ b/app/gcl/professional-cloud-network-engineer/page.tsx
@@ -1,5 +1,6 @@
 import { HERO_BADGES, NAV_LINKS } from './constants';
 import styles from './pcne.module.css';
+import { SectionIntro } from './components/SectionIntro';
 
 /**
  * Renders the "Professional Cloud Network Engineer" page layout,
@@ -51,6 +52,7 @@ export default function PcnePage() {
                 </nav>
 
                 {/* SECTIONS */}
+                <SectionIntro />
                 {/* Sections will be added here step by step */}
             </main>
         </div>

--- a/app/gcl/professional-cloud-network-engineer/page.tsx
+++ b/app/gcl/professional-cloud-network-engineer/page.tsx
@@ -15,7 +15,7 @@ export default function PcnePage() {
         <div className="pcne-page">
             <main className={styles.pcneMain}>
                 {/* HERO */}
-                <div className={styles.hero} id="overview">
+                <div className={styles.hero} id="hero-overview">
                     <div className={styles.heroBadge}>Professional Cloud Network Engineer</div>
                     <h1 className={styles.heroTitle}>
                         Professional Cloud<br />

--- a/app/gcl/professional-cloud-network-engineer/page.tsx
+++ b/app/gcl/professional-cloud-network-engineer/page.tsx
@@ -1,6 +1,7 @@
 import { HERO_BADGES, NAV_LINKS } from './constants';
 import styles from './pcne.module.css';
 import { SectionIntro } from './components/SectionIntro';
+import { Section1 } from './components/Section1';
 
 /**
  * Renders the "Professional Cloud Network Engineer" page layout,
@@ -53,6 +54,7 @@ export default function PcnePage() {
 
                 {/* SECTIONS */}
                 <SectionIntro />
+                <Section1 />
                 {/* Sections will be added here step by step */}
             </main>
         </div>

--- a/app/gcl/professional-cloud-network-engineer/pcne.module.css
+++ b/app/gcl/professional-cloud-network-engineer/pcne.module.css
@@ -72,7 +72,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 2px 8px color-mix(in srgb, var(--color-foreground) 5%, transparent);
 }
 
 .heroStatDot {
@@ -98,7 +98,7 @@
     font-size: 0.9rem;
     font-weight: 500;
     white-space: nowrap;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 2px 8px color-mix(in srgb, var(--color-foreground) 5%, transparent);
 }
 
 .navSticky {

--- a/app/gcl/professional-cloud-network-engineer/pcne.module.css
+++ b/app/gcl/professional-cloud-network-engineer/pcne.module.css
@@ -1,0 +1,130 @@
+.pcneMain {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    background-color: var(--color-background);
+}
+
+.hero {
+    position: relative;
+    padding: 80px 24px 64px;
+    background: linear-gradient(135deg, color-mix(in srgb, var(--color-primary) 15%, transparent) 0%, color-mix(in srgb, var(--color-brand-end) 15%, transparent) 100%);
+    border-bottom: 1px solid var(--color-border);
+    text-align: center;
+    overflow: hidden;
+}
+
+.heroBadge {
+    display: inline-block;
+    padding: 6px 12px;
+    background: var(--color-card);
+    border: 1px solid var(--color-primary);
+    color: var(--color-primary);
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    margin-bottom: 24px;
+}
+
+.heroTitle {
+    font-size: clamp(2.5rem, 5vw, 4rem);
+    font-weight: 800;
+    line-height: 1.1;
+    color: var(--color-foreground);
+    margin-bottom: 24px;
+    letter-spacing: -0.02em;
+}
+
+.heroAccent {
+    background: linear-gradient(135deg, var(--color-primary), var(--color-brand-end));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    display: inline-block;
+}
+
+.heroDesc {
+    font-size: clamp(1.1rem, 2vw, 1.25rem);
+    color: var(--color-muted-foreground);
+    max-width: 800px;
+    margin: 0 auto 32px;
+    line-height: 1.6;
+}
+
+.heroStats {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 16px;
+    max-width: 800px;
+    margin: 0 auto 32px;
+}
+
+.heroStat {
+    background: var(--color-card);
+    border: 1px solid var(--color-border);
+    color: var(--color-foreground);
+    padding: 8px 16px;
+    border-radius: 12px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    white-space: nowrap;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.heroStatDot {
+    color: var(--color-primary);
+    font-size: 1.2rem;
+}
+
+.heroTags {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 12px;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.heroTag {
+    background: var(--color-card);
+    border: 1px solid var(--color-border);
+    color: var(--color-foreground);
+    padding: 6px 16px;
+    border-radius: 20px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    white-space: nowrap;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.navSticky {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: color-mix(in srgb, var(--color-background) 90%, transparent);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--color-border);
+    padding: 12px 24px;
+    display: flex;
+    align-items: center;
+    gap: 24px;
+    overflow-x: auto;
+    scrollbar-width: none;
+}
+
+.navSticky::-webkit-scrollbar {
+    display: none;
+}
+
+.navLabel {
+    font-weight: 700;
+    color: var(--color-foreground);
+    white-space: nowrap;
+    padding-right: 24px;
+    border-right: 1px solid var(--color-border);
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -352,6 +352,12 @@ export function Header() {
                             desc="信頼性とセキュリティ"
                             onClick={() => setOpenMenu(null)}
                         />
+                        <DropdownItem
+                            href="/gcl/cloud-digital-leader/section6"
+                            label="Section 6"
+                            desc="Scaling with Operations"
+                            onClick={() => setOpenMenu(null)}
+                        />
                     </div>
                 </div>
 
@@ -413,24 +419,6 @@ export function Header() {
                             label="概要"
                             desc="Professional Cloud Network Engineer とは"
                             ariaLabel="Professional Cloud Network Engineer 概要"
-                            onClick={() => setOpenMenu(null)}
-                        />
-                        <DropdownItem
-                            href="/gcl/professional-cloud-network-engineer#s1"
-                            label="Section 1"
-                            desc="VPC ネットワークの設計・実装"
-                            onClick={() => setOpenMenu(null)}
-                        />
-                        <DropdownItem
-                            href="/gcl/professional-cloud-network-engineer#s2"
-                            label="Section 2"
-                            desc="ハイブリッド接続とネットワーク相互接続"
-                            onClick={() => setOpenMenu(null)}
-                        />
-                        <DropdownItem
-                            href="/gcl/professional-cloud-network-engineer#s3"
-                            label="Section 3"
-                            desc="ロードバランシングと最適化"
                             onClick={() => setOpenMenu(null)}
                         />
                     </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,11 +5,12 @@ import Link from 'next/link';
 import { cn } from '@/lib/utils';
 
 /**
- * Renders the sticky top navigation bar with dropdowns for Generative AI Leader, Associate Cloud Engineer, and Cloud Digital Leader.
+ * Renders a sticky top navigation bar with center-aligned dropdown menus for site sections.
  *
- * Manages which dropdown is open, closes menus when the user clicks outside or presses Escape, and ensures selecting a dropdown link closes its parent menu.
+ * Manages which dropdown is open, closes an open menu when the user clicks outside it or presses Escape,
+ * and closes the parent menu when a dropdown link is selected.
  *
- * @returns The header's JSX element containing the home link and center-aligned dropdown navigation
+ * @returns The header JSX element containing the brand/home link and centered dropdown navigation
  */
 export function Header() {
     const [openMenu, setOpenMenu] = useState<'genai' | 'ace' | 'cdl' | 'pcne' | null>(null);

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -12,15 +12,16 @@ import { cn } from '@/lib/utils';
  * @returns The header's JSX element containing the home link and center-aligned dropdown navigation
  */
 export function Header() {
-    const [openMenu, setOpenMenu] = useState<'genai' | 'ace' | 'cdl' | null>(null);
+    const [openMenu, setOpenMenu] = useState<'genai' | 'ace' | 'cdl' | 'pcne' | null>(null);
     const genAiRef = useRef<HTMLDivElement>(null);
     const aceRef = useRef<HTMLDivElement>(null);
     const cdlRef = useRef<HTMLDivElement>(null);
+    const pcneRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (openMenu === null) return;
 
-        const refMap = { genai: genAiRef, ace: aceRef, cdl: cdlRef } as const;
+        const refMap = { genai: genAiRef, ace: aceRef, cdl: cdlRef, pcne: pcneRef } as const;
 
         const handleClickOutside = (e: MouseEvent) => {
             const ref = refMap[openMenu];
@@ -348,6 +349,87 @@ export function Header() {
                             href="/gcl/cloud-digital-leader/section5"
                             label="Section 5"
                             desc="信頼性とセキュリティ"
+                            onClick={() => setOpenMenu(null)}
+                        />
+                    </div>
+                </div>
+
+                {/* Professional Cloud Network Engineer */}
+                <div
+                    className="relative"
+                    ref={pcneRef}
+                    onMouseEnter={() => setOpenMenu('pcne')}
+                    onMouseLeave={() => setOpenMenu(null)}
+                >
+                    <button
+                        type="button"
+                        onClick={() => setOpenMenu((v) => (v === 'pcne' ? null : 'pcne'))}
+                        aria-haspopup="true"
+                        aria-expanded={openMenu === 'pcne'}
+                        className={cn(
+                            'flex items-center gap-2.5 rounded-xl px-5 py-3 font-medium transition-all duration-150',
+                            openMenu === 'pcne'
+                                ? 'bg-white/8 text-[var(--color-foreground)]'
+                                : 'text-[var(--color-muted-foreground)] hover:bg-white/5 hover:text-[var(--color-foreground)]',
+                        )}
+                    >
+                        <span
+                            className="icon-theme-pcne flex h-4 w-4 items-center justify-center rounded text-[10px]"
+                            aria-hidden
+                        >
+                            🖧
+                        </span>
+                        Professional Cloud Network Engineer
+                        <svg
+                            width="12"
+                            height="12"
+                            viewBox="0 0 12 12"
+                            fill="none"
+                            aria-hidden
+                            className={cn(
+                                'transition-transform duration-150',
+                                openMenu === 'pcne' && 'rotate-180',
+                            )}
+                        >
+                            <path
+                                d="M2 4l4 4 4-4"
+                                stroke="currentColor"
+                                strokeWidth="1.5"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            />
+                        </svg>
+                    </button>
+
+                    <div
+                        className={cn(
+                            'invisible absolute right-0 top-full z-50 mt-2 flex w-[24rem] origin-top-right flex-col gap-1.5 rounded-xl border border-white/[0.08] bg-[#0e1117]/95 p-4 opacity-0 shadow-2xl backdrop-blur-xl transition-all duration-150',
+                            openMenu === 'pcne' && 'visible opacity-100',
+                        )}
+                    >
+                        <DropdownItem
+                            href="/gcl/professional-cloud-network-engineer"
+                            label="概要"
+                            desc="Professional Cloud Network Engineer とは"
+                            ariaLabel="Professional Cloud Network Engineer 概要"
+                            onClick={() => setOpenMenu(null)}
+                        />
+                        <DropdownItem
+                            href="/gcl/professional-cloud-network-engineer#s1"
+                            label="Section 1"
+                            desc="VPC ネットワークの設計・実装"
+                            onClick={() => setOpenMenu(null)}
+                        />
+                        <DropdownItem
+                            href="/gcl/professional-cloud-network-engineer#s2"
+                            label="Section 2"
+                            desc="ハイブリッド接続とネットワーク相互接続"
+                            onClick={() => setOpenMenu(null)}
+                        />
+                        <DropdownItem
+                            href="/gcl/professional-cloud-network-engineer#s3"
+                            label="Section 3"
+                            desc="ロードバランシングと最適化"
                             onClick={() => setOpenMenu(null)}
                         />
                     </div>


### PR DESCRIPTION
主に Cloud Digital Leader (CDL) の完成と、新しく Professional Cloud Network Engineer (PCNE) の移行作業を開始しました。

  1. Cloud Digital Leader (CDL) Section 6 の完了
   - 試験対策セクションの実装 (a81e6e1): Section7.tsx
     を作成し、頻出問題パターン、キーワードマップ、推奨リソースを移行しました。
   - スタイルの最終調整: リンクのデザインを統一し、アクセシビリティ（JSDocの追加、aria-labelの日本語化など）を改善しました。

  2. Professional Cloud Network Engineer (PCNE) ガイドの開始
   - ベースセットアップ (bd8e4eb): PCNE専用のディレクトリ構成、レイアウト、および constants.ts を作成しました。
   - INTRO セクションの実装 (5704a47): 試験の配点分布、学習ステップ、公式リソースを移行。インラインスタイルの CSS Modules
     化によるリファクタリングも実施。
   - Section 1 (VPC) の実装 (182220e): VPCモード比較、ファイアウォールルール、共有VPC等の解説を TDD で実装しました。
   - Section 2 (ハイブリッド接続) の実装 (3330549): VPN、Interconnect、Cloud Router に関する詳細な解説を移行しました。

  3. グローバルナビゲーションとドキュメントの更新
   - Header の更新 (8447802, d741894): ヘッダーメニューに PCNE
     へのリンクとドロップダウンを追加し、全画面から遷移可能にしました。
   - 進捗管理とドキュメント: MIGRATION_PROGRESS.md を更新し、GEMINI.md にメニュー運用の仕様を追記しました。
   - スタイルの共通化 (f921190): SharedSection.module.css を通じて、PCNE と CDL
     のセクション幅やカードのデザインを統一しました。