### PR TITLE
fix(gcl): correct content errors and a11y issues across ACE/CDL/GenAI…

### DIFF
--- a/Gws-admin-section2-guide.html
+++ b/Gws-admin-section2-guide.html
@@ -1,0 +1,3064 @@
+<!doctype html>
+<html lang="ja">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>AGWA Section 2 完全学習ガイド | Google Workspace コアサービス管理</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+            href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=Space+Mono:wght@400;700&display=swap"
+            rel="stylesheet"
+        />
+        <style>
+            :root {
+                --bg: #f7f6f2;
+                --surface: #ffffff;
+                --surface2: #f0ede6;
+                --border: #e2ddd5;
+                --text: #1a1916;
+                --text-muted: #6b6860;
+                --text-light: #9b9890;
+                --accent-blue: #1a56db;
+                --accent-blue-bg: #eff5ff;
+                --accent-blue-border: #c3d9ff;
+                --accent-green: #057a55;
+                --accent-green-bg: #e3fcef;
+                --accent-green-border: #84e1bc;
+                --accent-amber: #b45309;
+                --accent-amber-bg: #fffbeb;
+                --accent-amber-border: #fcd34d;
+                --accent-red: #991b1b;
+                --accent-red-bg: #fef2f2;
+                --accent-red-border: #fca5a5;
+                --accent-purple: #5521b5;
+                --accent-purple-bg: #f5f3ff;
+                --accent-purple-border: #c4b5fd;
+                --sidebar-w: 260px;
+                --radius: 8px;
+                --radius-lg: 12px;
+            }
+            * {
+                box-sizing: border-box;
+                margin: 0;
+                padding: 0;
+            }
+            body {
+                font-family: 'DM Sans', sans-serif;
+                background: var(--bg);
+                color: var(--text);
+                font-size: 15px;
+                line-height: 1.65;
+            }
+            a {
+                color: var(--accent-blue);
+                text-decoration: none;
+            }
+            a:hover {
+                text-decoration: underline;
+            }
+
+            /* LAYOUT */
+            .layout {
+                display: flex;
+                min-height: 100vh;
+            }
+
+            /* SIDEBAR */
+            .sidebar {
+                width: var(--sidebar-w);
+                min-height: 100vh;
+                background: var(--text);
+                color: #fff;
+                position: fixed;
+                left: 0;
+                top: 0;
+                overflow-y: auto;
+                z-index: 100;
+                padding-bottom: 2rem;
+            }
+            .sidebar-header {
+                padding: 1.5rem 1.25rem 1rem;
+                border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+            }
+            .sidebar-badge {
+                display: inline-block;
+                background: #facc15;
+                color: #1a1916;
+                font-family: 'Space Mono', monospace;
+                font-size: 10px;
+                font-weight: 700;
+                padding: 3px 8px;
+                border-radius: 4px;
+                letter-spacing: 0.05em;
+                margin-bottom: 0.5rem;
+            }
+            .sidebar-title {
+                font-size: 13px;
+                font-weight: 500;
+                line-height: 1.4;
+                color: rgba(255, 255, 255, 0.9);
+            }
+            .sidebar-section-label {
+                font-family: 'Space Mono', monospace;
+                font-size: 10px;
+                letter-spacing: 0.12em;
+                text-transform: uppercase;
+                color: rgba(255, 255, 255, 0.4);
+                padding: 1.25rem 1.25rem 0.4rem;
+            }
+            .sidebar nav a {
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                padding: 0.55rem 1.25rem;
+                font-size: 13px;
+                color: rgba(255, 255, 255, 0.7);
+                text-decoration: none;
+                border-left: 3px solid transparent;
+                transition: all 0.15s;
+            }
+            .sidebar nav a:hover,
+            .sidebar nav a.active {
+                color: #fff;
+                background: rgba(255, 255, 255, 0.08);
+                border-left-color: #facc15;
+            }
+            .sidebar nav a .dot {
+                width: 7px;
+                height: 7px;
+                border-radius: 50%;
+                background: rgba(255, 255, 255, 0.25);
+                flex-shrink: 0;
+            }
+            .sidebar nav a.active .dot {
+                background: #facc15;
+            }
+
+            /* MAIN */
+            .main {
+                margin-left: var(--sidebar-w);
+                flex: 1;
+                padding: 0 2rem 4rem;
+                max-width: calc(100% - var(--sidebar-w));
+            }
+
+            /* HERO */
+            .hero {
+                background: var(--text);
+                color: #fff;
+                padding: 3rem 2.5rem;
+                margin: 0 -2rem 2.5rem;
+                position: relative;
+                overflow: hidden;
+            }
+            .hero::before {
+                content: '';
+                position: absolute;
+                top: -40px;
+                right: -40px;
+                width: 200px;
+                height: 200px;
+                border: 40px solid rgba(250, 204, 21, 0.15);
+                border-radius: 50%;
+            }
+            .hero::after {
+                content: '';
+                position: absolute;
+                bottom: -60px;
+                right: 80px;
+                width: 140px;
+                height: 140px;
+                border: 30px solid rgba(250, 204, 21, 0.08);
+                border-radius: 50%;
+            }
+            .hero-tag {
+                font-family: 'Space Mono', monospace;
+                font-size: 11px;
+                color: #facc15;
+                letter-spacing: 0.1em;
+                margin-bottom: 0.75rem;
+            }
+            .hero h1 {
+                font-size: clamp(1.6rem, 3vw, 2.4rem);
+                font-weight: 600;
+                line-height: 1.2;
+                margin-bottom: 0.75rem;
+                position: relative;
+            }
+            .hero p {
+                color: rgba(255, 255, 255, 0.7);
+                max-width: 600px;
+                font-size: 14px;
+                position: relative;
+            }
+            .hero-meta {
+                display: flex;
+                gap: 1.5rem;
+                margin-top: 1.25rem;
+                flex-wrap: wrap;
+            }
+            .hero-chip {
+                display: flex;
+                align-items: center;
+                gap: 6px;
+                font-size: 12px;
+                color: rgba(255, 255, 255, 0.6);
+            }
+            .hero-chip span {
+                color: #facc15;
+                font-weight: 600;
+            }
+
+            /* SECTION CARD */
+            .section-card {
+                background: var(--surface);
+                border: 1px solid var(--border);
+                border-radius: var(--radius-lg);
+                margin-bottom: 1.5rem;
+                overflow: hidden;
+            }
+            .section-header {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+                padding: 1.25rem 1.5rem;
+                border-bottom: 1px solid var(--border);
+                cursor: pointer;
+                background: var(--surface);
+                transition: background 0.15s;
+            }
+            .section-header:hover {
+                background: var(--surface2);
+            }
+            .section-num {
+                font-family: 'Space Mono', monospace;
+                font-size: 11px;
+                font-weight: 700;
+                color: var(--accent-purple);
+                background: var(--accent-purple-bg);
+                border: 1px solid var(--accent-purple-border);
+                padding: 2px 8px;
+                border-radius: 4px;
+                flex-shrink: 0;
+            }
+            .section-title {
+                font-size: 16px;
+                font-weight: 600;
+                flex: 1;
+            }
+            .section-exam-weight {
+                font-size: 12px;
+                font-weight: 500;
+                color: var(--accent-amber);
+                background: var(--accent-amber-bg);
+                border: 1px solid var(--accent-amber-border);
+                padding: 2px 10px;
+                border-radius: 20px;
+            }
+            .chevron {
+                width: 18px;
+                height: 18px;
+                border: none;
+                background: none;
+                cursor: pointer;
+                color: var(--text-muted);
+                font-size: 16px;
+                transition: transform 0.2s;
+                flex-shrink: 0;
+            }
+            .chevron.open {
+                transform: rotate(180deg);
+            }
+            .section-body {
+                padding: 1.5rem;
+                display: none;
+            }
+            .section-body.open {
+                display: block;
+            }
+
+            /* TOPIC */
+            .topic {
+                margin-bottom: 2rem;
+            }
+            .topic:last-child {
+                margin-bottom: 0;
+            }
+            .topic-title {
+                font-size: 14px;
+                font-weight: 600;
+                margin-bottom: 0.6rem;
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                padding-bottom: 0.5rem;
+                border-bottom: 2px solid var(--surface2);
+            }
+            .topic-title::before {
+                content: '';
+                width: 4px;
+                height: 16px;
+                background: var(--accent-blue);
+                border-radius: 2px;
+                flex-shrink: 0;
+            }
+            .topic p {
+                margin-bottom: 0.75rem;
+                color: #333;
+                font-size: 14px;
+            }
+            .topic p:last-child {
+                margin-bottom: 0;
+            }
+
+            /* CALLOUT BOXES */
+            .callout {
+                border-radius: var(--radius);
+                padding: 1rem 1.25rem;
+                margin: 1rem 0;
+                font-size: 13.5px;
+                border-left: 4px solid;
+            }
+            .callout-icon {
+                font-weight: 700;
+                margin-bottom: 0.25rem;
+                font-size: 12px;
+                letter-spacing: 0.06em;
+            }
+            .callout.info {
+                background: var(--accent-blue-bg);
+                border-color: var(--accent-blue);
+            }
+            .callout.info .callout-icon {
+                color: var(--accent-blue);
+            }
+            .callout.success {
+                background: var(--accent-green-bg);
+                border-color: var(--accent-green);
+            }
+            .callout.success .callout-icon {
+                color: var(--accent-green);
+            }
+            .callout.warning {
+                background: var(--accent-amber-bg);
+                border-color: var(--accent-amber);
+            }
+            .callout.warning .callout-icon {
+                color: var(--accent-amber);
+            }
+            .callout.danger {
+                background: var(--accent-red-bg);
+                border-color: var(--accent-red);
+            }
+            .callout.danger .callout-icon {
+                color: var(--accent-red);
+            }
+            .callout.exam {
+                background: var(--accent-purple-bg);
+                border-color: var(--accent-purple);
+            }
+            .callout.exam .callout-icon {
+                color: var(--accent-purple);
+            }
+
+            /* TABLE */
+            .data-table {
+                width: 100%;
+                border-collapse: collapse;
+                font-size: 13px;
+                margin: 1rem 0;
+            }
+            .data-table th {
+                background: var(--surface2);
+                font-weight: 600;
+                text-align: left;
+                padding: 8px 12px;
+                border: 1px solid var(--border);
+                font-size: 12px;
+            }
+            .data-table td {
+                padding: 8px 12px;
+                border: 1px solid var(--border);
+                vertical-align: top;
+                line-height: 1.5;
+            }
+            .data-table tr:nth-child(even) td {
+                background: #fafaf8;
+            }
+
+            /* CODE BLOCK */
+            .code-block {
+                background: #1a1916;
+                color: #f0ede6;
+                border-radius: var(--radius);
+                padding: 1rem 1.25rem;
+                font-family: 'Space Mono', monospace;
+                font-size: 12px;
+                line-height: 1.7;
+                overflow-x: auto;
+                margin: 0.75rem 0;
+            }
+            .code-block .comment {
+                color: #6b6860;
+            }
+            .code-block .key {
+                color: #facc15;
+            }
+            .code-block .val {
+                color: #86efac;
+            }
+            .code-block .op {
+                color: #f9a8d4;
+            }
+
+            /* BEST PRACTICES */
+            .bp-grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+                gap: 0.75rem;
+                margin: 1rem 0;
+            }
+            .bp-card {
+                background: var(--accent-green-bg);
+                border: 1px solid var(--accent-green-border);
+                border-radius: var(--radius);
+                padding: 0.875rem 1rem;
+                font-size: 13px;
+                display: flex;
+                gap: 10px;
+                align-items: flex-start;
+            }
+            .bp-num {
+                width: 22px;
+                height: 22px;
+                flex-shrink: 0;
+                background: var(--accent-green);
+                color: #fff;
+                border-radius: 50%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-family: 'Space Mono', monospace;
+                font-size: 11px;
+                font-weight: 700;
+                margin-top: 1px;
+            }
+            .bp-card p {
+                margin: 0;
+                line-height: 1.5;
+                color: #065f46;
+            }
+            .bp-card strong {
+                color: #047857;
+            }
+
+            /* SOURCES */
+            .sources {
+                background: var(--surface2);
+                border: 1px solid var(--border);
+                border-radius: var(--radius);
+                padding: 1rem 1.25rem;
+                margin-top: 1.5rem;
+            }
+            .sources-title {
+                font-size: 12px;
+                font-weight: 600;
+                color: var(--text-muted);
+                margin-bottom: 0.5rem;
+                letter-spacing: 0.06em;
+                text-transform: uppercase;
+            }
+            .sources ul {
+                list-style: none;
+            }
+            .sources li {
+                font-size: 12.5px;
+                margin-bottom: 0.35rem;
+            }
+            .sources li::before {
+                content: '↗ ';
+                color: var(--accent-blue);
+            }
+
+            /* STEP LIST */
+            .steps {
+                counter-reset: step;
+            }
+            .step {
+                display: flex;
+                gap: 14px;
+                margin-bottom: 0.875rem;
+                align-items: flex-start;
+            }
+            .step-n {
+                width: 26px;
+                height: 26px;
+                flex-shrink: 0;
+                background: var(--text);
+                color: #fff;
+                border-radius: 50%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-family: 'Space Mono', monospace;
+                font-size: 11px;
+                font-weight: 700;
+                margin-top: 1px;
+            }
+            .step-body {
+                font-size: 13.5px;
+                padding-top: 3px;
+            }
+            .step-body strong {
+                display: block;
+                font-weight: 600;
+                margin-bottom: 2px;
+            }
+
+            /* TAG */
+            .tag {
+                display: inline-block;
+                font-size: 11px;
+                font-weight: 600;
+                padding: 2px 8px;
+                border-radius: 4px;
+                margin-right: 4px;
+            }
+            .tag-blue {
+                background: var(--accent-blue-bg);
+                color: var(--accent-blue);
+                border: 1px solid var(--accent-blue-border);
+            }
+            .tag-green {
+                background: var(--accent-green-bg);
+                color: var(--accent-green);
+                border: 1px solid var(--accent-green-border);
+            }
+            .tag-amber {
+                background: var(--accent-amber-bg);
+                color: var(--accent-amber);
+                border: 1px solid var(--accent-amber-border);
+            }
+            .tag-red {
+                background: var(--accent-red-bg);
+                color: var(--accent-red);
+                border: 1px solid var(--accent-red-border);
+            }
+            .tag-purple {
+                background: var(--accent-purple-bg);
+                color: var(--accent-purple);
+                border: 1px solid var(--accent-purple-border);
+            }
+
+            /* NAV OVERVIEW */
+            .overview-grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+                gap: 1rem;
+                margin: 1.5rem 0;
+            }
+            .overview-card {
+                background: var(--surface);
+                border: 1px solid var(--border);
+                border-radius: var(--radius-lg);
+                padding: 1.25rem;
+                text-decoration: none;
+                color: var(--text);
+                transition: all 0.15s;
+                border-top: 3px solid var(--accent-blue);
+            }
+            .overview-card:hover {
+                box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+                transform: translateY(-1px);
+                text-decoration: none;
+            }
+            .overview-card .oc-num {
+                font-family: 'Space Mono', monospace;
+                font-size: 11px;
+                color: var(--accent-blue);
+                margin-bottom: 0.5rem;
+            }
+            .overview-card .oc-title {
+                font-weight: 600;
+                font-size: 14px;
+                margin-bottom: 0.25rem;
+            }
+            .overview-card .oc-pct {
+                font-size: 12px;
+                color: var(--text-muted);
+            }
+
+            /* DIVIDER */
+            .divider {
+                border: none;
+                border-top: 1px solid var(--border);
+                margin: 1.5rem 0;
+            }
+
+            /* FLOW DIAGRAM */
+            .flow {
+                display: flex;
+                align-items: center;
+                gap: 0;
+                flex-wrap: wrap;
+                margin: 1rem 0;
+            }
+            .flow-item {
+                background: var(--surface2);
+                border: 1px solid var(--border);
+                border-radius: var(--radius);
+                padding: 0.5rem 0.875rem;
+                font-size: 12.5px;
+                font-weight: 500;
+                text-align: center;
+                min-width: 90px;
+            }
+            .flow-arrow {
+                color: var(--text-muted);
+                font-size: 18px;
+                padding: 0 4px;
+            }
+
+            /* COMPARISON */
+            .compare-grid {
+                display: grid;
+                grid-template-columns: 1fr 1fr;
+                gap: 1rem;
+                margin: 1rem 0;
+            }
+            .compare-card {
+                border: 1px solid var(--border);
+                border-radius: var(--radius);
+                overflow: hidden;
+                font-size: 13px;
+            }
+            .compare-card-header {
+                padding: 0.6rem 1rem;
+                font-weight: 600;
+                font-size: 13px;
+            }
+            .compare-card-body {
+                padding: 0.75rem 1rem;
+            }
+            .compare-card-body li {
+                margin-bottom: 0.35rem;
+                padding-left: 0.5rem;
+            }
+            .compare-bad .compare-card-header {
+                background: var(--accent-red-bg);
+                color: var(--accent-red);
+                border-bottom: 1px solid var(--accent-red-border);
+            }
+            .compare-good .compare-card-header {
+                background: var(--accent-green-bg);
+                color: var(--accent-green);
+                border-bottom: 1px solid var(--accent-green-border);
+            }
+
+            /* MOBILE */
+            @media (max-width: 768px) {
+                .sidebar {
+                    width: 100%;
+                    position: relative;
+                    min-height: auto;
+                }
+                .main {
+                    margin-left: 0;
+                    max-width: 100%;
+                    padding: 0 1rem 3rem;
+                }
+                .layout {
+                    flex-direction: column;
+                }
+                .compare-grid {
+                    grid-template-columns: 1fr;
+                }
+            }
+
+            /* PRINT / scroll offset for anchors */
+            :target::before {
+                content: '';
+                display: block;
+                height: 80px;
+                margin-top: -80px;
+            }
+
+            /* TOP BANNER */
+            .top-banner {
+                background: var(--accent-blue);
+                color: #fff;
+                text-align: center;
+                padding: 0.5rem 1rem;
+                font-size: 12.5px;
+            }
+            .top-banner a {
+                color: #facc15;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="top-banner">
+            📋 Associate Google Workspace Administrator (AGWA) 試験対策 — Section 2: Managing Core
+            Workspace Services &nbsp;·&nbsp;
+            <a
+                href="https://cloud.google.com/learn/certification/associate-google-workspace-administrator"
+                target="_blank"
+                >公式認定ページ</a
+            >
+            &nbsp;·&nbsp;
+            <a
+                href="https://services.google.com/fh/files/misc/associate_google_workspace_administrator_exam_guide_english.pdf"
+                target="_blank"
+                >試験ガイド PDF</a
+            >
+        </div>
+
+        <div class="layout">
+            <!-- SIDEBAR -->
+            <aside class="sidebar">
+                <div class="sidebar-header">
+                    <div class="sidebar-badge">AGWA EXAM</div>
+                    <div class="sidebar-title">Section 2<br />コアサービス管理</div>
+                </div>
+                <div class="sidebar-section-label">学習セクション</div>
+                <nav>
+                    <a href="#overview" class="active"><span class="dot"></span>概要・試験構成</a>
+                    <a href="#s21"><span class="dot"></span>2.1 Gmail の設定</a>
+                    <a href="#mx"><span class="dot"></span>→ MXレコード</a>
+                    <a href="#routing"><span class="dot"></span>→ メールルーティング</a>
+                    <a href="#spf-dkim-dmarc"><span class="dot"></span>→ SPF/DKIM/DMARC</a>
+                    <a href="#spam"><span class="dot"></span>→ スパム・フィッシング</a>
+                    <a href="#compliance-footer"><span class="dot"></span>→ フッター・隔離</a>
+                    <a href="#sandbox"><span class="dot"></span>→ セキュリティSB</a>
+                    <a href="#s22"><span class="dot"></span>2.2 Drive & Docs</a>
+                    <a href="#sharing"><span class="dot"></span>→ 共有設定</a>
+                    <a href="#trust-rules"><span class="dot"></span>→ 信頼ルール</a>
+                    <a href="#shared-drives"><span class="dot"></span>→ 共有ドライブ</a>
+                    <a href="#dlp"><span class="dot"></span>→ DLP & ラベル</a>
+                    <a href="#s23"><span class="dot"></span>2.3 Calendar</a>
+                    <a href="#resources"><span class="dot"></span>→ リソース管理</a>
+                    <a href="#cal-sharing"><span class="dot"></span>→ 共有設定</a>
+                    <a href="#s24"><span class="dot"></span>2.4 Google Meet</a>
+                    <a href="#s25"><span class="dot"></span>2.5 Google Chat</a>
+                    <a href="#s26"><span class="dot"></span>2.6 Gemini AI</a>
+                    <a href="#s27"><span class="dot"></span>2.7 開発サポート</a>
+                    <a href="#checklist"><span class="dot"></span>試験直前チェック</a>
+                </nav>
+            </aside>
+
+            <!-- MAIN CONTENT -->
+            <main class="main">
+                <!-- HERO -->
+                <div class="hero" id="overview">
+                    <div class="hero-tag">SECTION 2 / MANAGING CORE WORKSPACE SERVICES</div>
+                    <h1>Google Workspace<br />コアサービス管理<br />完全学習ガイド</h1>
+                    <p>
+                        初学者でもわかる、AGWA試験 Section 2
+                        の全トピックをステップバイステップで解説。各サービスの設定方法・ベストプラクティス・試験ポイントを網羅。
+                    </p>
+                    <div class="hero-meta">
+                        <div class="hero-chip">配点比率 <span>≈ 23%</span></div>
+                        <div class="hero-chip">トピック数 <span>7つのサービス</span></div>
+                        <div class="hero-chip">重要度 <span>★★★★★</span></div>
+                    </div>
+                </div>
+
+                <!-- OVERVIEW CARDS -->
+                <h2
+                    style="
+                        font-size: 16px;
+                        font-weight: 600;
+                        margin-bottom: 0.75rem;
+                        color: var(--text-muted);
+                        letter-spacing: 0.04em;
+                    "
+                >
+                    このセクションのカバー範囲
+                </h2>
+                <div class="overview-grid">
+                    <a href="#s21" class="overview-card">
+                        <div class="oc-num">2.1</div>
+                        <div class="oc-title">Gmail の設定</div>
+                        <div class="oc-pct">MX・SPF・DKIM・DMARC・ルーティング・スパム対策</div>
+                    </a>
+                    <a href="#s22" class="overview-card" style="border-top-color: #059669">
+                        <div class="oc-num" style="color: #059669">2.2</div>
+                        <div class="oc-title">Drive & Docs</div>
+                        <div class="oc-pct">共有設定・信頼ルール・共有ドライブ・DLP・ラベル</div>
+                    </a>
+                    <a href="#s23" class="overview-card" style="border-top-color: #b45309">
+                        <div class="oc-num" style="color: #b45309">2.3</div>
+                        <div class="oc-title">Google Calendar</div>
+                        <div class="oc-pct">リソース管理・予約ポリシー・外部共有設定</div>
+                    </a>
+                    <a href="#s24" class="overview-card" style="border-top-color: #7c3aed">
+                        <div class="oc-num" style="color: #7c3aed">2.4</div>
+                        <div class="oc-title">Google Meet</div>
+                        <div class="oc-pct">安全設定・ノックイン・録画・ビデオ設定</div>
+                    </a>
+                    <a href="#s25" class="overview-card" style="border-top-color: #0891b2">
+                        <div class="oc-num" style="color: #0891b2">2.5</div>
+                        <div class="oc-title">Google Chat</div>
+                        <div class="oc-pct">履歴・外部共有・招待制限・モデレーション</div>
+                    </a>
+                    <a href="#s26" class="overview-card" style="border-top-color: #dc2626">
+                        <div class="oc-num" style="color: #dc2626">2.6</div>
+                        <div class="oc-title">Gemini AI</div>
+                        <div class="oc-pct">データプライバシー・有効化・拡張機能設定</div>
+                    </a>
+                </div>
+
+                <!-- ============================
+     SECTION 2.1: GMAIL
+     ============================ -->
+                <div class="section-card" id="s21">
+                    <div class="section-header" onclick="toggleSection(this)">
+                        <span class="section-num">2.1</span>
+                        <span class="section-title">Gmail の設定</span>
+                        <span class="section-exam-weight">試験頻出度 ★★★★★</span>
+                        <span class="chevron open">▾</span>
+                    </div>
+                    <div class="section-body open">
+                        <!-- MX RECORDS -->
+                        <div class="topic" id="mx">
+                            <div class="topic-title">MX レコード — メール配送の入口</div>
+                            <p>
+                                MX（Mail
+                                Exchanger）レコードは、外部サーバーに「このドメイン宛のメールをどこに届けるか」を伝えるDNSレコードです。Google
+                                Workspace で Gmail を使う際の最初のステップです。
+                            </p>
+
+                            <div class="flow">
+                                <div class="flow-item">外部メールサーバー</div>
+                                <div class="flow-arrow">→</div>
+                                <div class="flow-item">DNS でMXを照会</div>
+                                <div class="flow-arrow">→</div>
+                                <div class="flow-item">Googleサーバー発見</div>
+                                <div class="flow-arrow">→</div>
+                                <div class="flow-item">Gmail受信箱に配信</div>
+                            </div>
+
+                            <table class="data-table">
+                                <tr>
+                                    <th>設定方式</th>
+                                    <th>優先度</th>
+                                    <th>メールサーバー（Value）</th>
+                                    <th>推奨</th>
+                                </tr>
+                                <tr>
+                                    <td rowspan="1">
+                                        <span class="tag tag-green">新しい推奨設定</span>
+                                    </td>
+                                    <td>1</td>
+                                    <td><code>smtp.google.com</code></td>
+                                    <td>✅ 現在の推奨</td>
+                                </tr>
+                                <tr>
+                                    <td rowspan="5">
+                                        <span class="tag tag-amber">レガシー互換設定</span>
+                                    </td>
+                                    <td>1</td>
+                                    <td><code>ASPMX.L.GOOGLE.COM</code></td>
+                                    <td rowspan="5">既存環境で使用中の場合は維持可</td>
+                                </tr>
+                                <tr>
+                                    <td>5</td>
+                                    <td><code>ALT1.ASPMX.L.GOOGLE.COM</code></td>
+                                </tr>
+                                <tr>
+                                    <td>5</td>
+                                    <td><code>ALT2.ASPMX.L.GOOGLE.COM</code></td>
+                                </tr>
+                                <tr>
+                                    <td>10</td>
+                                    <td><code>ALT3.ASPMX.L.GOOGLE.COM</code></td>
+                                </tr>
+                                <tr>
+                                    <td>10</td>
+                                    <td><code>ALT4.ASPMX.L.GOOGLE.COM</code></td>
+                                </tr>
+                            </table>
+
+                            <div class="callout warning">
+                                <div class="callout-icon">⚠ 注意</div>
+                                MXレコード変更後、DNS伝播には最大
+                                <strong>72時間</strong>
+                                かかります。移行時は旧MXレコードを保持したまま新設定を追加し、動作確認後に旧レコードを削除してください。
+                            </div>
+
+                            <div class="callout info">
+                                <div class="callout-icon">🔧 確認ツール</div>
+                                設定後は
+                                <a
+                                    href="https://toolbox.googleapps.com/apps/checkmx/"
+                                    target="_blank"
+                                    >Admin Toolbox MX チェッカー</a
+                                >
+                                で正しく設定されているか確認しましょう。
+                            </div>
+
+                            <div class="bp-grid">
+                                <div class="bp-card">
+                                    <div class="bp-num">1</div>
+                                    <p>
+                                        <strong>段階的移行を実施する</strong> —
+                                        切り替え前にTTLを下げ（例：300秒）、旧レコードを保持したままGoogleのMXを追加して動作確認後に旧レコードを削除する
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">2</div>
+                                    <p>
+                                        <strong>Admin Toolboxで定期確認</strong> —
+                                        MXレコードの設定は変更されることがあるため、定期的にツールで検証する
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">3</div>
+                                    <p>
+                                        <strong>移行後は旧MXを必ず削除</strong> —
+                                        古いMXレコードが残るとセキュリティリスクと不要な遅延が生じる
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <hr class="divider" />
+
+                        <!-- ROUTING -->
+                        <div class="topic" id="routing">
+                            <div class="topic-title">
+                                高度なメールルーティング — 分割配信・二重配信
+                            </div>
+                            <p>
+                                組織の移行フェーズや複数システム運用時に、メールのトラフィックを適切なサーバーに振り分ける設定です。
+                            </p>
+
+                            <div class="compare-grid">
+                                <div
+                                    class="compare-card compare-bad"
+                                    style="border: 1px solid var(--border)"
+                                >
+                                    <div
+                                        class="compare-card-header"
+                                        style="
+                                            background: var(--accent-blue-bg);
+                                            color: var(--accent-blue);
+                                            border-bottom: 1px solid var(--accent-blue-border);
+                                        "
+                                    >
+                                        分割配信（Split Delivery）
+                                    </div>
+                                    <div class="compare-card-body">
+                                        <p
+                                            style="
+                                                font-size: 12px;
+                                                color: var(--text-muted);
+                                                margin-bottom: 0.5rem;
+                                            "
+                                        >
+                                            Google
+                                            サーバーで受信後、宛先ユーザーの存在に応じて配信先を振り分け
+                                        </p>
+                                        <ul style="font-size: 13px; padding-left: 1.25rem">
+                                            <li>Google ユーザー → Gmail に配信</li>
+                                            <li>
+                                                Google に存在しないユーザー → レガシーサーバーへ転送
+                                            </li>
+                                            <li>
+                                                <strong>用途:</strong>
+                                                段階的移行、特定部署のみオンプレミス継続
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div
+                                    class="compare-card compare-good"
+                                    style="border: 1px solid var(--border)"
+                                >
+                                    <div
+                                        class="compare-card-header"
+                                        style="
+                                            background: var(--accent-purple-bg);
+                                            color: var(--accent-purple);
+                                            border-bottom: 1px solid var(--accent-purple-border);
+                                        "
+                                    >
+                                        二重配信（Dual Delivery）
+                                    </div>
+                                    <div class="compare-card-body">
+                                        <p
+                                            style="
+                                                font-size: 12px;
+                                                color: var(--text-muted);
+                                                margin-bottom: 0.5rem;
+                                            "
+                                        >
+                                            全メールを Gmail と外部サーバーの両方に同時配信
+                                        </p>
+                                        <ul style="font-size: 13px; padding-left: 1.25rem">
+                                            <li>移行前の並行稼働テストに最適</li>
+                                            <li>サードパーティアーカイブへの全件転送</li>
+                                            <li>
+                                                <strong>用途:</strong>
+                                                移行テスト、コンプライアンスアーカイブ
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <p
+                                style="
+                                    font-weight: 600;
+                                    font-size: 13px;
+                                    margin-top: 1rem;
+                                    margin-bottom: 0.5rem;
+                                "
+                            >
+                                分割配信の設定手順
+                            </p>
+                            <div class="steps">
+                                <div class="step">
+                                    <div class="step-n">1</div>
+                                    <div class="step-body">
+                                        <strong>ホストを登録</strong>
+                                        管理コンソール → アプリ → Google Workspace → Gmail → ホスト
+                                        から転送先の外部サーバー（FQDN または IP）を登録
+                                    </div>
+                                </div>
+                                <div class="step">
+                                    <div class="step-n">2</div>
+                                    <div class="step-body">
+                                        <strong>ルーティングルールを作成</strong>
+                                        Gmail → ルーティング → 新しいルールを追加 →
+                                        対象を「受信」に設定
+                                    </div>
+                                </div>
+                                <div class="step">
+                                    <div class="step-n">3</div>
+                                    <div class="step-body">
+                                        <strong>アクションを設定</strong>
+                                        「メッセージを変更」→「ルートを変更」→
+                                        手順1で作成したホストを選択
+                                    </div>
+                                </div>
+                                <div class="step">
+                                    <div class="step-n">4</div>
+                                    <div class="step-body">
+                                        <strong>フィルターを適用</strong>
+                                        Googleに存在しないアカウント（Catch-all）のみを転送対象にするようフィルタリングを設定
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="callout info">
+                                <div class="callout-icon">📍 設定場所</div>
+                                管理コンソール → アプリ → Google Workspace → Gmail →
+                                <strong>ルーティング</strong>
+                            </div>
+                        </div>
+
+                        <hr class="divider" />
+
+                        <!-- SPF DKIM DMARC -->
+                        <div class="topic" id="spf-dkim-dmarc">
+                            <div class="topic-title">
+                                ★最重要★ メール認証：SPF・DKIM・DMARC の完全理解
+                            </div>
+
+                            <div class="callout exam">
+                                <div class="callout-icon">🎯 試験最頻出トピック</div>
+                                SPF・DKIM・DMARC
+                                は試験で最も頻出するトピックです。それぞれの役割の違い、設定手順、DMARC
+                                の段階的導入を完全に理解してください。
+                            </div>
+
+                            <p style="font-weight: 600; font-size: 14px; margin-top: 1rem">
+                                SPF（Sender Policy Framework）
+                            </p>
+                            <p>
+                                「このドメインからメールを送信できるサーバーはここです」とDNSに宣言する仕組み。なりすましメールの送信元IP偽装を防ぎます。
+                            </p>
+
+                            <div class="code-block">
+                                <span class="comment"># Gmail のみを使う場合（最もシンプル）</span>
+                                <span class="key">v</span>=<span class="val">spf1</span>
+                                <span class="key">include</span>:<span class="val"
+                                    >_spf.google.com</span
+                                >
+                                <span class="op">~all</span>
+
+                                <span class="comment"
+                                    ># Gmail + Salesforce など複数サービスを使う場合</span
+                                >
+                                <span class="key">v</span>=<span class="val">spf1</span>
+                                <span class="key">include</span>:<span class="val"
+                                    >_spf.google.com</span
+                                >
+                                <span class="key">include</span>:<span class="val"
+                                    >_spf.salesforce.com</span
+                                >
+                                <span class="op">~all</span>
+
+                                <span class="comment"># 終端ポリシーの意味</span>
+                                <span class="op">-all</span> → FAIL（厳格に拒否）
+                                <span class="op">~all</span> → SOFTFAIL（スパム扱い）← 移行期に推奨
+                                <span class="op">?all</span> → NEUTRAL（何もしない）
+                            </div>
+
+                            <div class="callout warning">
+                                <div class="callout-icon">⚠ SPF の制限</div>
+                                SPFレコードには
+                                <strong>最大10回のDNS参照</strong>
+                                という制限があります。Mailchimp、Salesforce
+                                など複数のサードパーティサービスを追加しすぎると上限を超えてしまいます。
+                            </div>
+
+                            <p style="font-weight: 600; font-size: 14px; margin-top: 1.25rem">
+                                DKIM（DomainKeys Identified Mail）
+                            </p>
+                            <p>
+                                送信メールにデジタル署名を付与し、「本当にそのドメインから送られており、改ざんされていない」ことを保証します。
+                            </p>
+
+                            <div class="code-block">
+                                <span class="comment"># DNS に追加する TXT レコード（例）</span>
+                                <span class="comment"
+                                    ># ホスト名: google._domainkey.example.com</span
+                                >
+                                <span class="key">v</span>=<span class="val">DKIM1</span>;
+                                <span class="key">k</span>=<span class="val">rsa</span>;
+                                <span class="key">p</span>=<span class="val">MIGfMA0GCSQ...</span>
+                                <span class="comment">(公開鍵)</span>
+                            </div>
+
+                            <p style="font-weight: 600; font-size: 13px; margin-top: 0.75rem">
+                                DKIM 設定手順：
+                            </p>
+                            <div class="steps">
+                                <div class="step">
+                                    <div class="step-n">1</div>
+                                    <div class="step-body">
+                                        <strong>鍵を生成</strong> — 管理コンソール → Gmail →
+                                        メールの認証 → DKIM キーを生成（2048ビット推奨）
+                                    </div>
+                                </div>
+                                <div class="step">
+                                    <div class="step-n">2</div>
+                                    <div class="step-body">
+                                        <strong>DNS に追加</strong> —
+                                        生成されたTXTレコードをDNSレジストラで
+                                        <code>google._domainkey.ドメイン名</code> に登録
+                                    </div>
+                                </div>
+                                <div class="step">
+                                    <div class="step-n">3</div>
+                                    <div class="step-body">
+                                        <strong>署名を開始</strong> — 管理コンソールに戻り「DKIM
+                                        を開始」をクリック
+                                    </div>
+                                </div>
+                                <div class="step">
+                                    <div class="step-n">4</div>
+                                    <div class="step-body">
+                                        <strong>動作確認</strong> — Admin Toolbox
+                                        でDKIMが正しく機能しているか確認
+                                    </div>
+                                </div>
+                            </div>
+
+                            <p style="font-weight: 600; font-size: 14px; margin-top: 1.25rem">
+                                DMARC（Domain-based Message Authentication, Reporting, and
+                                Conformance）
+                            </p>
+                            <p>
+                                SPFとDKIMの検証失敗時の処理ポリシーを受信サーバーに伝え、レポートを受け取る仕組みです。
+                            </p>
+
+                            <div class="code-block">
+                                <span class="comment"># フェーズ1: 監視（最初に設定）</span>
+                                <span class="key">v</span>=<span class="val">DMARC1</span>;
+                                <span class="key">p</span>=<span class="val">none</span>;
+                                <span class="key">rua</span>=<span class="val"
+                                    >mailto:dmarc-reports@example.com</span
+                                >
+
+                                <span class="comment"
+                                    ># フェーズ2: 隔離モード（段階的に適用割合を増やす）</span
+                                >
+                                <span class="key">v</span>=<span class="val">DMARC1</span>;
+                                <span class="key">p</span>=<span class="val">quarantine</span>;
+                                <span class="key">pct</span>=<span class="val">10</span>;
+                                <span class="key">rua</span>=<span class="val"
+                                    >mailto:dmarc-reports@example.com</span
+                                >
+                                <span class="key">v</span>=<span class="val">DMARC1</span>;
+                                <span class="key">p</span>=<span class="val">quarantine</span>;
+                                <span class="key">pct</span>=<span class="val">100</span>;
+                                <span class="key">rua</span>=<span class="val"
+                                    >mailto:dmarc-reports@example.com</span
+                                >
+
+                                <span class="comment"># フェーズ3: 完全拒否（最終目標）</span>
+                                <span class="key">v</span>=<span class="val">DMARC1</span>;
+                                <span class="key">p</span>=<span class="val">reject</span>;
+                                <span class="key">pct</span>=<span class="val">100</span>;
+                                <span class="key">rua</span>=<span class="val"
+                                    >mailto:dmarc-reports@example.com</span
+                                >
+                            </div>
+
+                            <table class="data-table" style="margin-top: 0.75rem">
+                                <tr>
+                                    <th>ポリシー(p=)</th>
+                                    <th>意味</th>
+                                    <th>認証失敗時の動作</th>
+                                    <th>推奨フェーズ</th>
+                                </tr>
+                                <tr>
+                                    <td><span class="tag tag-amber">none</span></td>
+                                    <td>監視のみ</td>
+                                    <td>何もしない（レポートのみ）</td>
+                                    <td>Phase 1（1〜2週間）</td>
+                                </tr>
+                                <tr>
+                                    <td><span class="tag tag-blue">quarantine</span></td>
+                                    <td>隔離</td>
+                                    <td>スパムフォルダに移動</td>
+                                    <td>Phase 2（段階的拡大）</td>
+                                </tr>
+                                <tr>
+                                    <td><span class="tag tag-green">reject</span></td>
+                                    <td>拒否</td>
+                                    <td>メールを完全に拒否</td>
+                                    <td>Phase 3（最終目標）</td>
+                                </tr>
+                            </table>
+
+                            <div class="callout danger">
+                                <div class="callout-icon">❌ アンチパターン</div>
+                                DMARC を最初から
+                                <code>p=reject</code>
+                                に設定するのは危険です。SPFに含まれていない正規の送信サービスからのメールまでブロックされてしまいます。必ず
+                                <strong>p=none で監視 → 段階的に強化</strong> してください。
+                            </div>
+
+                            <div class="bp-grid">
+                                <div class="bp-card">
+                                    <div class="bp-num">1</div>
+                                    <p>
+                                        <strong>三点セットで設定する</strong> — SPF・DKIM・DMARC
+                                        は必ず3つセットで設定。1つや2つだけでは完全な認証にならない
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">2</div>
+                                    <p>
+                                        <strong>DMARC は段階的に導入</strong> — p=none →
+                                        p=quarantine（pct=10→100）→ p=reject の順に進める
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">3</div>
+                                    <p>
+                                        <strong>DMARC レポートを分析ツールで可視化</strong> —
+                                        Postmark、dmarcian 等のツールを使いレポートを解析する
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">4</div>
+                                    <p>
+                                        <strong>サードパーティサービスを SPF に含める</strong> —
+                                        Salesforce、Mailchimp 等のIPも忘れずSPFに追加する
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">5</div>
+                                    <p>
+                                        <strong>DKIM キーは 2048 ビットを使用</strong> —
+                                        1024ビットより安全。年1回のローテーションも推奨
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div class="sources">
+                                <div class="sources-title">📎 公式ソース</div>
+                                <ul>
+                                    <li>
+                                        <a
+                                            href="https://support.google.com/a/answer/33786"
+                                            target="_blank"
+                                            >SPF の設定 — Google Workspace Admin Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://support.google.com/a/answer/174124"
+                                            target="_blank"
+                                            >DKIM の設定 — Google Workspace Admin Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://support.google.com/a/answer/2466580"
+                                            target="_blank"
+                                            >DMARC の設定 — Google Workspace Admin Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://toolbox.googleapps.com/apps/checkmx/"
+                                            target="_blank"
+                                            >Admin Toolbox — MX/SPF/DKIM チェッカー</a
+                                        >
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+
+                        <hr class="divider" />
+
+                        <!-- SPAM PHISHING -->
+                        <div class="topic" id="spam">
+                            <div class="topic-title">スパム・フィッシング・マルウェア対策設定</div>
+                            <p>
+                                Gmail
+                                は多層的なセキュリティフィルタリングを提供しています。管理者はこれらの設定を組み合わせて防御を強化します。
+                            </p>
+
+                            <div class="callout info">
+                                <div class="callout-icon">📍 設定場所</div>
+                                管理コンソール → アプリ → Google Workspace → Gmail →
+                                <strong>スパム、フィッシング、マルウェア</strong>
+                            </div>
+
+                            <table class="data-table">
+                                <tr>
+                                    <th>設定名</th>
+                                    <th>機能</th>
+                                    <th>推奨設定</th>
+                                </tr>
+                                <tr>
+                                    <td>スパムフィルタ強化</td>
+                                    <td>迷惑メールの検出強度</td>
+                                    <td>「強化されたスパム対策」を有効化</td>
+                                </tr>
+                                <tr>
+                                    <td>メールの許可リスト</td>
+                                    <td>常に受信箱に届けるメールアドレス/ドメイン</td>
+                                    <td>信頼できるビジネスパートナーのみ登録。過度な登録はNG</td>
+                                </tr>
+                                <tr>
+                                    <td>IP 許可リスト</td>
+                                    <td>特定IPからのメールをスパムフィルタ免除</td>
+                                    <td>受信ゲートウェイのIPのみ登録</td>
+                                </tr>
+                                <tr>
+                                    <td>ブロックリスト</td>
+                                    <td>特定のアドレス・ドメインをブロック</td>
+                                    <td>スパム送信者、不審なドメイン</td>
+                                </tr>
+                                <tr>
+                                    <td>フィッシング対策</td>
+                                    <td>偽サイトへのリンク検出、なりすまし検出</td>
+                                    <td>まず「警告表示」から始め、誤検知確認後に「隔離」へ</td>
+                                </tr>
+                            </table>
+
+                            <div class="callout warning">
+                                <div class="callout-icon">
+                                    ⚠ 許可リストとIP許可リストの違い（試験頻出）
+                                </div>
+                                <ul style="margin-top: 0.5rem; padding-left: 1.25rem">
+                                    <li>
+                                        <strong>Email Allowlist（メール許可リスト）</strong
+                                        >：特定のIPから送られたメールをスパムフィルタをスキップして受信箱へ届ける
+                                    </li>
+                                    <li>
+                                        <strong>IP Allowlist（IP許可リスト）</strong
+                                        >：受信ゲートウェイとして機能するIPを登録。このIPを経由したメールは「既にスパムチェック済み」と認識され、スパム分類が緩和される（完全スキップではない）
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+
+                        <hr class="divider" />
+
+                        <!-- COMPLIANCE FOOTER & QUARANTINE -->
+                        <div class="topic" id="compliance-footer">
+                            <div class="topic-title">
+                                コンプライアンスフッター・メール隔離・コンテンツコンプライアンス
+                            </div>
+
+                            <p>
+                                <strong>コンプライアンスフッター</strong
+                                >は送信メールに自動的に法的免責事項などのテキストを追加する機能です。組織部門（OU）ごとにカスタマイズ可能です。
+                            </p>
+
+                            <div class="callout info">
+                                <div class="callout-icon">📍 設定場所</div>
+                                管理コンソール → Gmail → <strong>コンプライアンス</strong> →
+                                コンプライアンスフッター / メールの隔離 / コンテンツコンプライアンス
+                            </div>
+
+                            <p
+                                style="
+                                    font-weight: 600;
+                                    font-size: 13px;
+                                    margin-top: 1rem;
+                                    margin-bottom: 0.5rem;
+                                "
+                            >
+                                コンテンツコンプライアンスルール — できること
+                            </p>
+                            <table class="data-table">
+                                <tr>
+                                    <th>条件</th>
+                                    <th>アクション</th>
+                                    <th>実例</th>
+                                </tr>
+                                <tr>
+                                    <td>件名・本文・添付ファイルに特定キーワード/正規表現を含む</td>
+                                    <td>メールを拒否</td>
+                                    <td>「社外秘」を含む送信メールを組織外にブロック</td>
+                                </tr>
+                                <tr>
+                                    <td>特定の添付ファイルタイプ（.exe等）</td>
+                                    <td>隔離（管理者レビュー）</td>
+                                    <td>実行ファイルを管理者承認なしに受信不可にする</td>
+                                </tr>
+                                <tr>
+                                    <td>送信先が特定ドメイン</td>
+                                    <td>BCC コピーを追加</td>
+                                    <td>競合企業ドメインへの送信をコンプライアンス担当にCC</td>
+                                </tr>
+                                <tr>
+                                    <td>特定パターンのメッセージ</td>
+                                    <td>ヘッダー変更・転送</td>
+                                    <td>カスタムヘッダーの追加</td>
+                                </tr>
+                            </table>
+
+                            <div class="bp-grid">
+                                <div class="bp-card">
+                                    <div class="bp-num">1</div>
+                                    <p>
+                                        <strong>隔離機能を活用</strong> —
+                                        単純なブロックではなく隔離にすることで、誤検知時に管理者が判断して解放できる
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">2</div>
+                                    <p>
+                                        <strong>OU ごとにフッターをカスタマイズ</strong> —
+                                        営業部門には促進情報、法務部門には守秘義務条項を自動付与する
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <hr class="divider" />
+
+                        <!-- SECURITY SANDBOX -->
+                        <div class="topic" id="sandbox">
+                            <div class="topic-title">
+                                セキュリティサンドボックス — 未知のマルウェアを仮想環境で検出
+                            </div>
+                            <p>
+                                標準のウイルス対策を回避するゼロデイマルウェアを、添付ファイルを仮想環境で実際に実行することで動的に検出します。
+                            </p>
+
+                            <div class="callout warning">
+                                <div class="callout-icon">⚠ エディション要件</div>
+                                セキュリティサンドボックスは
+                                <strong>Business Standard 以上</strong>
+                                のエディションで利用可能です。試験でエディションが記載されている問題に注意してください。
+                            </div>
+
+                            <div class="steps">
+                                <div class="step">
+                                    <div class="step-n">1</div>
+                                    <div class="step-body">
+                                        <strong>有効化</strong> — 管理コンソール → Gmail →
+                                        スパム、フィッシング、マルウェア →
+                                        セキュリティサンドボックス を ON
+                                    </div>
+                                </div>
+                                <div class="step">
+                                    <div class="step-n">2</div>
+                                    <div class="step-body">
+                                        <strong>スキャン対象の設定</strong> — 全ての添付ファイル対象
+                                        OR 特定ルール（不審送信元・特定拡張子）に限定
+                                    </div>
+                                </div>
+                                <div class="step">
+                                    <div class="step-n">3</div>
+                                    <div class="step-body">
+                                        <strong>注意点</strong> —
+                                        スキャン完了まで数分かかる場合がある。業務スピードとのバランスを考慮して設定
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="sources">
+                                <div class="sources-title">📎 公式ソース</div>
+                                <ul>
+                                    <li>
+                                        <a
+                                            href="https://knowledge.workspace.google.com/admin/gmail/advanced/gmail-security-sandbox-overview"
+                                            target="_blank"
+                                            >Gmail Security Sandbox overview — Workspace Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://support.google.com/a/answer/2368132"
+                                            target="_blank"
+                                            >スパム・フィッシング・マルウェア設定 — Admin Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://support.google.com/a/answer/174125"
+                                            target="_blank"
+                                            >MX レコードの設定 — Admin Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://knowledge.workspace.google.com/admin/gmail/advanced/email-routing-and-delivery-options-for-google-workspace"
+                                            target="_blank"
+                                            >メールルーティングオプション — Workspace Help</a
+                                        >
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- /section-body -->
+                </div>
+                <!-- /section-card -->
+
+                <!-- ============================
+     SECTION 2.2: DRIVE & DOCS
+     ============================ -->
+                <div class="section-card" id="s22">
+                    <div class="section-header" onclick="toggleSection(this)">
+                        <span class="section-num">2.2</span>
+                        <span class="section-title">Google Drive と Docs の設定</span>
+                        <span class="section-exam-weight">試験頻出度 ★★★★☆</span>
+                        <span class="chevron open">▾</span>
+                    </div>
+                    <div class="section-body open">
+                        <!-- SHARING SETTINGS -->
+                        <div class="topic" id="sharing">
+                            <div class="topic-title">共有設定の階層と外部共有制御</div>
+                            <p>
+                                Drive
+                                の共有設定は階層構造になっており、上位の設定が下位を継承（上書きも可）します。
+                            </p>
+
+                            <div
+                                class="flow"
+                                style="flex-direction: column; align-items: flex-start; gap: 4px"
+                            >
+                                <div style="display: flex; align-items: center; gap: 8px">
+                                    <div
+                                        class="flow-item"
+                                        style="
+                                            background: var(--accent-blue-bg);
+                                            border-color: var(--accent-blue-border);
+                                            color: var(--accent-blue);
+                                        "
+                                    >
+                                        管理コンソール（最上位ポリシー）
+                                    </div>
+                                </div>
+                                <div style="padding-left: 20px; color: var(--text-muted)">
+                                    ↓ 継承または上書き
+                                </div>
+                                <div
+                                    style="
+                                        display: flex;
+                                        align-items: center;
+                                        gap: 8px;
+                                        padding-left: 20px;
+                                    "
+                                >
+                                    <div class="flow-item">OU 単位の設定</div>
+                                </div>
+                                <div style="padding-left: 40px; color: var(--text-muted)">
+                                    ↓ 継承または上書き
+                                </div>
+                                <div
+                                    style="
+                                        display: flex;
+                                        align-items: center;
+                                        gap: 8px;
+                                        padding-left: 40px;
+                                    "
+                                >
+                                    <div class="flow-item">共有ドライブの設定</div>
+                                </div>
+                                <div style="padding-left: 60px; color: var(--text-muted)">
+                                    ↓ 管理者が許可した範囲内
+                                </div>
+                                <div
+                                    style="
+                                        display: flex;
+                                        align-items: center;
+                                        gap: 8px;
+                                        padding-left: 60px;
+                                    "
+                                >
+                                    <div class="flow-item" style="background: var(--surface2)">
+                                        ユーザー個人の設定
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="callout info">
+                                <div class="callout-icon">📍 設定場所</div>
+                                管理コンソール → アプリ → Google Workspace →
+                                <strong>Drive と Docs</strong> → 共有設定
+                            </div>
+
+                            <table class="data-table" style="margin-top: 0.75rem">
+                                <tr>
+                                    <th>設定項目</th>
+                                    <th>選択肢</th>
+                                    <th>セキュリティ推奨</th>
+                                </tr>
+                                <tr>
+                                    <td>外部共有</td>
+                                    <td>許可 / 禁止 / ドメイン限定</td>
+                                    <td>部門OU ごとに制御。財務・法務は禁止推奨</td>
+                                </tr>
+                                <tr>
+                                    <td>新規ファイルのデフォルト共有</td>
+                                    <td>制限付き / リンクを知っている組織内全員</td>
+                                    <td>「制限付き（組織内のみ）」がセキュアなデフォルト</td>
+                                </tr>
+                                <tr>
+                                    <td>リンク付きで共有</td>
+                                    <td>「リンクを知っている全員」許可/禁止</td>
+                                    <td>機密情報部門は「禁止」</td>
+                                </tr>
+                                <tr>
+                                    <td>ドメイン外への一般公開</td>
+                                    <td>許可 / 禁止</td>
+                                    <td>原則禁止（特定部門のみ許可）</td>
+                                </tr>
+                            </table>
+
+                            <div class="callout exam">
+                                <div class="callout-icon">🎯 試験ポイント</div>
+                                OU
+                                ごとに異なる外部共有ポリシーを適用したい場合は、ルート組織でデフォルトを設定し、特定OUで「上書き（Override）」を使って個別設定します。
+                            </div>
+                        </div>
+
+                        <hr class="divider" />
+
+                        <!-- TRUST RULES -->
+                        <div class="topic" id="trust-rules">
+                            <div class="topic-title">
+                                Drive 信頼ルール（Trust Rules）— 精密な外部共有制御
+                            </div>
+                            <p>
+                                通常の共有設定より細粒度のアクセス制御が必要な場合に使用するエンタープライズ機能です。
+                            </p>
+
+                            <div class="callout warning">
+                                <div class="callout-icon">⚠ エディション要件</div>
+                                信頼ルールは <strong>Enterprise エディション</strong> が必要です。
+                            </div>
+
+                            <div class="compare-grid">
+                                <div class="compare-card" style="border: 1px solid var(--border)">
+                                    <div
+                                        class="compare-card-header"
+                                        style="
+                                            background: var(--surface2);
+                                            border-bottom: 1px solid var(--border);
+                                        "
+                                    >
+                                        通常の共有設定
+                                    </div>
+                                    <div class="compare-card-body">
+                                        <ul style="font-size: 13px; padding-left: 1.25rem">
+                                            <li>「組織外への共有を許可/禁止」</li>
+                                            <li>おおまかな制御のみ</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div
+                                    class="compare-card"
+                                    style="border: 1px solid var(--accent-blue-border)"
+                                >
+                                    <div
+                                        class="compare-card-header"
+                                        style="
+                                            background: var(--accent-blue-bg);
+                                            color: var(--accent-blue);
+                                            border-bottom: 1px solid var(--accent-blue-border);
+                                        "
+                                    >
+                                        Trust Rules（精密制御）
+                                    </div>
+                                    <div class="compare-card-body">
+                                        <ul style="font-size: 13px; padding-left: 1.25rem">
+                                            <li>「営業OU は partner.com のみ共有可」</li>
+                                            <li>「人事OU は外部共有一切禁止」</li>
+                                            <li>OU・グループ・特定ドメイン単位で設定</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="callout info">
+                                <div class="callout-icon">📍 設定場所</div>
+                                管理コンソール → Drive と Docs → <strong>信頼ルール</strong> →
+                                ルールを作成
+                            </div>
+                        </div>
+
+                        <hr class="divider" />
+
+                        <!-- SHARED DRIVES -->
+                        <div class="topic" id="shared-drives">
+                            <div class="topic-title">共有ドライブ（Shared Drives）の管理</div>
+                            <p>
+                                マイドライブとの最大の違いは「ファイルの帰属」です。共有ドライブは組織所有のため、メンバーが退職してもファイルは失われません。
+                            </p>
+
+                            <table class="data-table">
+                                <tr>
+                                    <th>比較項目</th>
+                                    <th>マイドライブ</th>
+                                    <th>共有ドライブ</th>
+                                </tr>
+                                <tr>
+                                    <td>ファイルの帰属</td>
+                                    <td>個人ユーザー</td>
+                                    <td>組織（チーム）</td>
+                                </tr>
+                                <tr>
+                                    <td>退職時の影響</td>
+                                    <td>⚠ ファイルが失われる危険</td>
+                                    <td>✅ ファイルはそのまま残る</td>
+                                </tr>
+                                <tr>
+                                    <td>アクセス管理</td>
+                                    <td>ユーザー個人</td>
+                                    <td>管理者またはマネージャー</td>
+                                </tr>
+                                <tr>
+                                    <td>用途</td>
+                                    <td>個人ファイル</td>
+                                    <td>チームの共有資料・プロジェクト</td>
+                                </tr>
+                            </table>
+
+                            <p
+                                style="
+                                    font-weight: 600;
+                                    font-size: 13px;
+                                    margin-top: 1rem;
+                                    margin-bottom: 0.5rem;
+                                "
+                            >
+                                共有ドライブの権限レベル（試験頻出）
+                            </p>
+                            <table class="data-table">
+                                <tr>
+                                    <th>役割</th>
+                                    <th>できること</th>
+                                    <th>推奨対象</th>
+                                </tr>
+                                <tr>
+                                    <td><span class="tag tag-red">マネージャー</span></td>
+                                    <td>メンバー管理・設定変更・全ファイル操作</td>
+                                    <td>チームリーダー、IT管理担当者</td>
+                                </tr>
+                                <tr>
+                                    <td><span class="tag tag-amber">コンテンツ管理者</span></td>
+                                    <td>追加・編集・削除・移動（メンバー管理不可）</td>
+                                    <td>プロジェクトのメインメンバー（デフォルト推奨）</td>
+                                </tr>
+                                <tr>
+                                    <td><span class="tag tag-blue">投稿者</span></td>
+                                    <td>追加・編集のみ（削除・移動不可）</td>
+                                    <td>外部協力者、一般メンバー</td>
+                                </tr>
+                                <tr>
+                                    <td><span class="tag tag-purple">コメント投稿者</span></td>
+                                    <td>閲覧・コメントのみ</td>
+                                    <td>レビュー担当者</td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <span
+                                            class="tag tag-green"
+                                            style="
+                                                background: var(--surface2);
+                                                color: var(--text-muted);
+                                                border-color: var(--border);
+                                            "
+                                            >閲覧者</span
+                                        >
+                                    </td>
+                                    <td>閲覧のみ</td>
+                                    <td>参照のみの他部署ユーザー</td>
+                                </tr>
+                            </table>
+
+                            <div class="callout exam">
+                                <div class="callout-icon">🎯 試験ポイント</div>
+                                外部ユーザーを共有ドライブに招待する際は「投稿者」以下の権限に留め、ファイルの削除・移動を防ぐことがベストプラクティスです。
+                            </div>
+
+                            <div class="bp-grid">
+                                <div class="bp-card">
+                                    <div class="bp-num">1</div>
+                                    <p>
+                                        <strong>マイドライブより共有ドライブを推奨</strong> —
+                                        チームの業務ファイルは共有ドライブで管理し、退職時の引き継ぎ問題を根本解決する
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">2</div>
+                                    <p>
+                                        <strong>外部ユーザーは「投稿者」以下に設定</strong> —
+                                        削除・移動権限を与えない。ファイル単体での共有も活用する
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">3</div>
+                                    <p>
+                                        <strong>定期的に共有ドライブの監査を実施</strong> —
+                                        管理コンソール → 共有ドライブを管理
+                                        から不要なメンバーやアクセス権を確認・削除
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <hr class="divider" />
+
+                        <!-- DLP & LABELS -->
+                        <div class="topic" id="dlp">
+                            <div class="topic-title">
+                                DLP（データ損失防止）と Drive ラベルの統合
+                            </div>
+                            <p>
+                                DLP
+                                ポリシーはドライブのドキュメントをリアルタイムでスキャンし、機密情報の検出とアクションを自動化します。
+                            </p>
+
+                            <table class="data-table">
+                                <tr>
+                                    <th>DLP ルールの構成要素</th>
+                                    <th>選択肢</th>
+                                    <th>例</th>
+                                </tr>
+                                <tr>
+                                    <td>スキャン対象</td>
+                                    <td>組織全体 / 特定OU / グループ</td>
+                                    <td>財務部門OU のドキュメント</td>
+                                </tr>
+                                <tr>
+                                    <td>検出条件</td>
+                                    <td>事前定義検出器 / 正規表現（Regex）</td>
+                                    <td>クレジットカード番号、マイナンバー</td>
+                                </tr>
+                                <tr>
+                                    <td>アクション</td>
+                                    <td>共有ブロック / 警告表示 / 監査ログ記録</td>
+                                    <td>「このファイルには機密情報が含まれます」と警告</td>
+                                </tr>
+                            </table>
+
+                            <p style="font-weight: 600; font-size: 13px; margin-top: 1rem">
+                                Drive ラベル — DLP との連携
+                            </p>
+                            <p>
+                                ラベルはファイルに分類情報（機密レベルなど）を付与し、DLP・Vault・検索と連携します。
+                            </p>
+
+                            <table class="data-table">
+                                <tr>
+                                    <th>ラベル例</th>
+                                    <th>値の例</th>
+                                    <th>使用場面</th>
+                                </tr>
+                                <tr>
+                                    <td>機密レベル</td>
+                                    <td>公開 / 社内限 / 機密 / 極秘</td>
+                                    <td>情報管理ポリシーの自動適用</td>
+                                </tr>
+                                <tr>
+                                    <td>プロジェクト</td>
+                                    <td>Project-A / Project-B</td>
+                                    <td>プロジェクト別の分類と検索</td>
+                                </tr>
+                                <tr>
+                                    <td>ステータス</td>
+                                    <td>ドラフト / 承認待ち / 承認済み</td>
+                                    <td>承認ワークフロー管理</td>
+                                </tr>
+                            </table>
+
+                            <div class="callout info">
+                                <div class="callout-icon">📍 設定場所</div>
+                                管理コンソール → Drive と Docs → <strong>ラベル</strong> →
+                                ラベルを作成
+                            </div>
+
+                            <div class="sources">
+                                <div class="sources-title">📎 公式ソース</div>
+                                <ul>
+                                    <li>
+                                        <a
+                                            href="https://knowledge.workspace.google.com/admin/drive/manage-shared-drives-as-an-admin"
+                                            target="_blank"
+                                            >共有ドライブの管理 — Workspace Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://knowledge.workspace.google.com/admin/security/create-and-manage-trust-rules-for-drive-sharing"
+                                            target="_blank"
+                                            >Drive 信頼ルールの作成と管理 — Workspace Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://support.google.com/a/answer/9292382"
+                                            target="_blank"
+                                            >Drive ラベルの管理 — Admin Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://support.google.com/a/answer/9934697"
+                                            target="_blank"
+                                            >ターゲットオーディエンス — Admin Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://support.google.com/a/answer/60781"
+                                            target="_blank"
+                                            >外部共有の管理 — Admin Help</a
+                                        >
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ============================
+     SECTION 2.3: CALENDAR
+     ============================ -->
+                <div class="section-card" id="s23">
+                    <div class="section-header" onclick="toggleSection(this)">
+                        <span class="section-num">2.3</span>
+                        <span class="section-title">Google Calendar の設定</span>
+                        <span class="section-exam-weight">試験頻出度 ★★★☆☆</span>
+                        <span class="chevron open">▾</span>
+                    </div>
+                    <div class="section-body open">
+                        <!-- RESOURCES -->
+                        <div class="topic" id="resources">
+                            <div class="topic-title">リソースカレンダーの作成と管理</div>
+                            <p>
+                                会議室、設備、車などの物理的なリソースをカレンダーで予約・管理できます。構造化されたリソース設定がベストプラクティスです。
+                            </p>
+
+                            <div class="callout info">
+                                <div class="callout-icon">📍 設定場所</div>
+                                管理コンソール → ディレクトリ → <strong>建物とリソース</strong> →
+                                建物/リソースを追加
+                            </div>
+
+                            <table class="data-table">
+                                <tr>
+                                    <th>設定要素</th>
+                                    <th>内容</th>
+                                    <th>重要ポイント</th>
+                                </tr>
+                                <tr>
+                                    <td>建物（Buildings）</td>
+                                    <td>会議室が存在する拠点情報</td>
+                                    <td>正確な住所を入力するとルームインサイトで地理分析が可能</td>
+                                </tr>
+                                <tr>
+                                    <td>機能（Features）</td>
+                                    <td>リソースの特徴タグ</td>
+                                    <td>大型モニター、車椅子対応、TV会議システム搭載 など</td>
+                                </tr>
+                                <tr>
+                                    <td>リソース（Resources）</td>
+                                    <td>実際の会議室名・備品名</td>
+                                    <td>建物と機能に関連付け。キャパシティも正確に入力</td>
+                                </tr>
+                            </table>
+
+                            <div class="bp-grid">
+                                <div class="bp-card">
+                                    <div class="bp-num">1</div>
+                                    <p>
+                                        <strong>命名規則を統一する</strong> —
+                                        [拠点名]-[階数]-[部屋名]（例：TK-3F-RoomA）のように、一目で場所がわかる名称にする
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">2</div>
+                                    <p>
+                                        <strong>キャパシティを正確に入力</strong> —
+                                        収容人数を入力すると「Find a
+                                        time」機能が参加人数に最適な部屋を自動提案できる
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">3</div>
+                                    <p>
+                                        <strong>ルームインサイトを活用</strong> — 管理コンソール →
+                                        建物とリソース → インサイト
+                                        で利用率が低い部屋や満室が多い拠点を特定
+                                    </p>
+                                </div>
+                            </div>
+
+                            <p
+                                style="
+                                    font-weight: 600;
+                                    font-size: 13px;
+                                    margin-top: 1rem;
+                                    margin-bottom: 0.5rem;
+                                "
+                            >
+                                予約承認フローの種類
+                            </p>
+                            <table class="data-table">
+                                <tr>
+                                    <th>承認タイプ</th>
+                                    <th>仕組み</th>
+                                    <th>用途</th>
+                                </tr>
+                                <tr>
+                                    <td>自動承認</td>
+                                    <td>予約者 → 即時確定</td>
+                                    <td>一般会議室</td>
+                                </tr>
+                                <tr>
+                                    <td>手動承認</td>
+                                    <td>予約者 → リソースオーナーが承認/拒否</td>
+                                    <td>役員室、高価な機材</td>
+                                </tr>
+                                <tr>
+                                    <td>特定ユーザーのみ自動</td>
+                                    <td>承認不要ユーザー:即時 / その他:承認フロー</td>
+                                    <td>ハイブリッド運用</td>
+                                </tr>
+                            </table>
+                        </div>
+
+                        <hr class="divider" />
+
+                        <!-- CALENDAR SHARING -->
+                        <div class="topic" id="cal-sharing">
+                            <div class="topic-title">カレンダー共有設定と外部共有</div>
+
+                            <div class="callout info">
+                                <div class="callout-icon">📍 設定場所</div>
+                                管理コンソール → アプリ → Google Workspace →
+                                <strong>Calendar</strong> → 共有設定
+                            </div>
+
+                            <table class="data-table">
+                                <tr>
+                                    <th>外部共有設定レベル</th>
+                                    <th>説明</th>
+                                    <th>推奨</th>
+                                </tr>
+                                <tr>
+                                    <td>外部との共有なし</td>
+                                    <td>組織外の誰にも予定情報を共有しない</td>
+                                    <td>機密性が高い組織向け</td>
+                                </tr>
+                                <tr>
+                                    <td>空き時間のみ共有</td>
+                                    <td>予定の詳細は非公開、空き/予定ありのみ</td>
+                                    <td>✅ デフォルト推奨</td>
+                                </tr>
+                                <tr>
+                                    <td>すべての予定詳細を共有</td>
+                                    <td>組織外のユーザーにも予定詳細が見える</td>
+                                    <td>特定部門のみ</td>
+                                </tr>
+                                <tr>
+                                    <td>一般公開</td>
+                                    <td>公開URLでカレンダーを公開</td>
+                                    <td>⚠ 原則非推奨（会議タイトルが公開されるリスク）</td>
+                                </tr>
+                            </table>
+
+                            <div class="callout exam">
+                                <div class="callout-icon">🎯 試験ポイント</div>
+                                外部共有のデフォルト推奨は
+                                <strong>「空き時間のみ表示（詳細は非公開）」</strong>
+                                です。「一般公開」設定では「A社買収に関する会議」などの機密情報が外部に漏れる可能性があります。
+                            </div>
+
+                            <div class="sources">
+                                <div class="sources-title">📎 公式ソース</div>
+                                <ul>
+                                    <li>
+                                        <a
+                                            href="https://knowledge.workspace.google.com/admin/calendar/create-buildings-features-and-calendar-resources"
+                                            target="_blank"
+                                            >建物・機能・リソースの作成 — Workspace Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://support.google.com/a/answer/60765"
+                                            target="_blank"
+                                            >Calendar の管理設定 — Admin Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://support.google.com/a/answer/60185"
+                                            target="_blank"
+                                            >外部共有オプション — Admin Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://workspace.google.com/blog/productivity-collaboration/three-ways-you-can-optimize-meetings-your-organization-hint-room-matters"
+                                            target="_blank"
+                                            >ルームインサイトの活用 — Workspace Blog</a
+                                        >
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ============================
+     SECTION 2.4: MEET
+     ============================ -->
+                <div class="section-card" id="s24">
+                    <div class="section-header" onclick="toggleSection(this)">
+                        <span class="section-num">2.4</span>
+                        <span class="section-title">Google Meet の設定</span>
+                        <span class="section-exam-weight">試験頻出度 ★★★☆☆</span>
+                        <span class="chevron">▾</span>
+                    </div>
+                    <div class="section-body">
+                        <div class="topic">
+                            <div class="topic-title">
+                                安全設定（Safety Settings）— 外部参加者の制御
+                            </div>
+
+                            <div class="callout info">
+                                <div class="callout-icon">📍 設定場所</div>
+                                管理コンソール → アプリ → Google Workspace →
+                                <strong>Google Meet</strong> → Meet の安全設定
+                            </div>
+
+                            <table class="data-table">
+                                <tr>
+                                    <th>設定名</th>
+                                    <th>説明</th>
+                                    <th>推奨設定</th>
+                                </tr>
+                                <tr>
+                                    <td><strong>ノックイン（ノックをする）</strong></td>
+                                    <td>組織外ユーザーが参加前にホストの承認が必要</td>
+                                    <td>✅ 必ず有効化</td>
+                                </tr>
+                                <tr>
+                                    <td>ホストの管理</td>
+                                    <td>ホストが参加者をミュート・退出させられる</td>
+                                    <td>✅ 有効（特に教育機関・ウェビナーで重要）</td>
+                                </tr>
+                                <tr>
+                                    <td>会議終了時に全員退出</td>
+                                    <td>ホスト退出後に残存参加者を自動退出</td>
+                                    <td>✅ 有効</td>
+                                </tr>
+                                <tr>
+                                    <td>安全チェック</td>
+                                    <td>ユーザーが安全でない状況を報告できる</td>
+                                    <td>✅ 有効</td>
+                                </tr>
+                            </table>
+
+                            <div class="callout exam">
+                                <div class="callout-icon">🎯 試験ポイント（超頻出）</div>
+                                外部参加者が無断で会議に入ってくる問題への対策は
+                                <strong>ノックイン機能の有効化</strong>
+                                です。これが最頻出の問題パターンです。
+                            </div>
+                        </div>
+
+                        <hr class="divider" />
+
+                        <div class="topic">
+                            <div class="topic-title">録画・文字起こし・AI機能の管理</div>
+
+                            <table class="data-table">
+                                <tr>
+                                    <th>機能</th>
+                                    <th>説明</th>
+                                    <th>注意点</th>
+                                </tr>
+                                <tr>
+                                    <td>録画の許可</td>
+                                    <td>会議の録画を許可するか</td>
+                                    <td>録画は主催者のGoogle Driveに自動保存される</td>
+                                </tr>
+                                <tr>
+                                    <td>自動文字起こし（Transcript）</td>
+                                    <td>会議音声を自動テキスト化</td>
+                                    <td>Business Standard 以上が必要</td>
+                                </tr>
+                                <tr>
+                                    <td>AI ノートテイキング</td>
+                                    <td>Gemini が自動的にメモを作成</td>
+                                    <td>Gemini対応エディションが必要</td>
+                                </tr>
+                            </table>
+
+                            <div class="bp-grid">
+                                <div class="bp-card">
+                                    <div class="bp-num">1</div>
+                                    <p>
+                                        <strong>外部参加者にノックインを必須化</strong> —
+                                        不審な参加者の防止に最も効果的な設定
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">2</div>
+                                    <p>
+                                        <strong>録画の保存先を組織の共有ドライブに指定</strong> —
+                                        個人ドライブへの散逸を防ぎ、アクセス管理を統一する
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">3</div>
+                                    <p>
+                                        <strong>録画後はアクセス権を見直す</strong> —
+                                        「リンクを知っている全員」設定のまま放置しないようユーザーに周知
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div class="sources">
+                                <div class="sources-title">📎 公式ソース</div>
+                                <ul>
+                                    <li>
+                                        <a
+                                            href="https://knowledge.workspace.google.com/admin/meet/google-meet-security-and-privacy-for-it-admins"
+                                            target="_blank"
+                                            >Google Meet セキュリティとプライバシー — Workspace
+                                            Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://knowledge.workspace.google.com/admin/meet/manage-meet-settings"
+                                            target="_blank"
+                                            >Meet 設定の管理 — Workspace Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://support.google.com/a/answer/9768550"
+                                            target="_blank"
+                                            >Meet セーフティ設定 — Admin Help</a
+                                        >
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ============================
+     SECTION 2.5: CHAT
+     ============================ -->
+                <div class="section-card" id="s25">
+                    <div class="section-header" onclick="toggleSection(this)">
+                        <span class="section-num">2.5</span>
+                        <span class="section-title">Google Chat の設定</span>
+                        <span class="section-exam-weight">試験頻出度 ★★★★☆</span>
+                        <span class="chevron">▾</span>
+                    </div>
+                    <div class="section-body">
+                        <div class="topic">
+                            <div class="topic-title">
+                                チャット履歴とコンプライアンス — 最重要設定
+                            </div>
+
+                            <div class="callout danger">
+                                <div class="callout-icon">❌ 重大なリスク（試験頻出）</div>
+                                チャット履歴が <strong>オフ</strong> になっている場合：<br />
+                                • メッセージが保存されない<br />
+                                • Google Vault での検索・保持ができない（eDiscovery 不可）<br />
+                                • DLP（データ損失防止）が機能しない<br />
+                                <br />
+                                <strong
+                                    >法的調査・コンプライアンス要件がある組織では、チャット履歴を必ずオンに設定してください。</strong
+                                >
+                            </div>
+
+                            <div class="callout info">
+                                <div class="callout-icon">📍 設定場所</div>
+                                管理コンソール → アプリ → Google Workspace →
+                                <strong>Google Chat</strong> → 設定 → チャット履歴
+                            </div>
+
+                            <table class="data-table">
+                                <tr>
+                                    <th>設定名</th>
+                                    <th>説明</th>
+                                    <th>コンプライアンス要件がある場合</th>
+                                </tr>
+                                <tr>
+                                    <td>チャット履歴</td>
+                                    <td>メッセージを保存するか</td>
+                                    <td>✅ 必ずオンに固定</td>
+                                </tr>
+                                <tr>
+                                    <td>外部ユーザーとのスペース</td>
+                                    <td>組織外ユーザーとのChatスペースへの参加</td>
+                                    <td>許可リスト（信頼ドメイン）でのみ許可</td>
+                                </tr>
+                                <tr>
+                                    <td>アプリ（ボット）</td>
+                                    <td>Chat への外部アプリの追加</td>
+                                    <td>承認済みアプリのみ許可</td>
+                                </tr>
+                                <tr>
+                                    <td>コンテンツのモデレーション</td>
+                                    <td>不適切なメッセージの報告・管理</td>
+                                    <td>✅ 有効化推奨</td>
+                                </tr>
+                            </table>
+
+                            <div class="callout exam">
+                                <div class="callout-icon">🎯 試験ポイント</div>
+                                「法的調査のため過去のチャットを提出する必要があったが、履歴がオフだったためデータがなかった」というシナリオは試験の典型問題です。予防策として
+                                <strong
+                                    >チャット履歴をオンに設定し、Vault で保持ルールを設定</strong
+                                >
+                                することが正解です。
+                            </div>
+
+                            <div class="bp-grid">
+                                <div class="bp-card">
+                                    <div class="bp-num">1</div>
+                                    <p>
+                                        <strong>履歴は必ずオン</strong> —
+                                        コンプライアンス要件がある業界では、Chat
+                                        履歴をオンに固定し、ユーザーが変更できないようにする
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">2</div>
+                                    <p>
+                                        <strong>外部ドメインは許可リストで管理</strong> —
+                                        組織外とのChatは許可リストに登録されたドメインのみに制限する
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">3</div>
+                                    <p>
+                                        <strong>Chat アプリは承認制に</strong> —
+                                        未承認のアプリを介したデータ流出（シャドーIT）を防ぐため、管理者承認済みアプリのみ許可
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div class="sources">
+                                <div class="sources-title">📎 公式ソース</div>
+                                <ul>
+                                    <li>
+                                        <a
+                                            href="https://knowledge.workspace.google.com/admin/chat/set-up-chat-for-your-organization"
+                                            target="_blank"
+                                            >Chat の設定 — Workspace Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://support.google.com/a/answer/9540647"
+                                            target="_blank"
+                                            >Chat の管理設定 — Admin Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://support.google.com/a/answer/14174987"
+                                            target="_blank"
+                                            >Chat コンテンツのモデレーション — Admin Help</a
+                                        >
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ============================
+     SECTION 2.6: GEMINI AI
+     ============================ -->
+                <div class="section-card" id="s26">
+                    <div class="section-header" onclick="toggleSection(this)">
+                        <span class="section-num">2.6</span>
+                        <span class="section-title"
+                            >生成 AI（Gemini for Workspace）の活用と管理</span
+                        >
+                        <span class="section-exam-weight">試験頻出度 ★★★★☆</span>
+                        <span class="chevron">▾</span>
+                    </div>
+                    <div class="section-body">
+                        <div class="topic">
+                            <div class="topic-title">
+                                データのプライバシーとセキュリティ — 試験必須知識
+                            </div>
+
+                            <div class="callout exam">
+                                <div class="callout-icon">🎯 試験最頻出ポイント</div>
+                                Gemini for Google Workspace
+                                のデータ取り扱いについて、以下の3点を必ず覚えてください。
+                            </div>
+
+                            <div class="bp-grid" style="grid-template-columns: 1fr">
+                                <div class="bp-card">
+                                    <div class="bp-num">1</div>
+                                    <p>
+                                        <strong>組織データをモデル学習に使用しない</strong> —
+                                        プロンプトや参照したドキュメントの内容は、組織外の不特定多数が利用するAIモデルのトレーニングには使用されない（無料版Geminiとは異なる）
+                                    </p>
+                                </div>
+                                <div class="bp-card" style="margin-top: 0.5rem">
+                                    <div class="bp-num">2</div>
+                                    <p>
+                                        <strong>既存の権限を完全に尊重する</strong> — Gemini
+                                        はユーザーが元々アクセス権を持っていないデータにはアクセスできない。DriveやGmailの既存ACLがそのまま適用される
+                                    </p>
+                                </div>
+                                <div class="bp-card" style="margin-top: 0.5rem">
+                                    <div class="bp-num">3</div>
+                                    <p>
+                                        <strong>エンタープライズグレードのコンプライアンス</strong>
+                                        —
+                                        ISO認証・SOC監査・FedRAMP等のコンプライアンス基準がGeminiにも適用される
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <hr class="divider" />
+
+                        <div class="topic">
+                            <div class="topic-title">Gemini の有効化と OU 単位での制御</div>
+
+                            <div class="callout info">
+                                <div class="callout-icon">📍 設定場所</div>
+                                管理コンソール → アプリ → Google Workspace →
+                                <strong>Gemini for Workspace</strong> → [OU を選択] → 機能のON/OFF
+                            </div>
+
+                            <table class="data-table">
+                                <tr>
+                                    <th>部門</th>
+                                    <th>推奨設定</th>
+                                    <th>理由</th>
+                                </tr>
+                                <tr>
+                                    <td>一般業務部門</td>
+                                    <td>✅ 有効</td>
+                                    <td>生産性向上、業務効率化</td>
+                                </tr>
+                                <tr>
+                                    <td>法務・コンプライアンス</td>
+                                    <td>✅ 有効（ガイドライン策定必須）</td>
+                                    <td>契約書レビュー等での活用</td>
+                                </tr>
+                                <tr>
+                                    <td>機密研究部門</td>
+                                    <td>⚠ 無効 or 制限</td>
+                                    <td>機密情報の保護を優先</td>
+                                </tr>
+                            </table>
+
+                            <p style="font-weight: 600; font-size: 13px; margin-top: 1rem">
+                                Workspace 拡張機能（Extensions）
+                            </p>
+                            <p>
+                                GeminiアプリがGmail・Drive・Calendar等のWorkspaceデータにアクセスできる機能です。管理者は各サービスへのアクセスをON/OFFで制御できます。
+                            </p>
+
+                            <div class="bp-grid">
+                                <div class="bp-card">
+                                    <div class="bp-num">1</div>
+                                    <p>
+                                        <strong>Gemini 利用ポリシーを策定する</strong> —
+                                        特に機密情報の取り扱い方法をユーザーに周知。「生成された回答は必ずファクトチェックする」という文化を醸成
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">2</div>
+                                    <p>
+                                        <strong>段階的ロールアウトを実施</strong> —
+                                        パイロットグループ（30〜50名）→
+                                        全社展開の順で進め、問題点を早期に発見する
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">3</div>
+                                    <p>
+                                        <strong>利用状況レポートを定期確認</strong> — 管理コンソール
+                                        → レポート → Gemini
+                                        で利用状況を分析し、未使用ユーザーにトレーニングを提供
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div class="sources">
+                                <div class="sources-title">📎 公式ソース</div>
+                                <ul>
+                                    <li>
+                                        <a
+                                            href="https://knowledge.workspace.google.com/admin/gemini/generative-ai-in-google-workspace-privacy-hub"
+                                            target="_blank"
+                                            >Gemini in Workspace プライバシーハブ — Workspace
+                                            Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://knowledge.workspace.google.com/admin/gemini/set-up-gemini-for-google-workspace"
+                                            target="_blank"
+                                            >Gemini for Workspace の設定 — Workspace Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://support.google.com/a/answer/13961526"
+                                            target="_blank"
+                                            >Gemini の有効化設定 — Admin Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://workspace.google.com/security/ai-privacy/"
+                                            target="_blank"
+                                            >Generative AI Security, Compliance and Privacy —
+                                            Workspace</a
+                                        >
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ============================
+     SECTION 2.7: DEVELOPMENT
+     ============================ -->
+                <div class="section-card" id="s27">
+                    <div class="section-header" onclick="toggleSection(this)">
+                        <span class="section-num">2.7</span>
+                        <span class="section-title"
+                            >Workspace 開発サポート（AppSheet & Apps Script）</span
+                        >
+                        <span class="section-exam-weight">試験頻出度 ★★☆☆☆</span>
+                        <span class="chevron">▾</span>
+                    </div>
+                    <div class="section-body">
+                        <div class="topic">
+                            <div class="topic-title">AppSheet と Apps Script の使い分け</div>
+
+                            <div class="compare-grid">
+                                <div
+                                    class="compare-card"
+                                    style="border: 1px solid var(--accent-blue-border)"
+                                >
+                                    <div
+                                        class="compare-card-header"
+                                        style="
+                                            background: var(--accent-blue-bg);
+                                            color: var(--accent-blue);
+                                            border-bottom: 1px solid var(--accent-blue-border);
+                                        "
+                                    >
+                                        AppSheet（ノーコード）
+                                    </div>
+                                    <div class="compare-card-body">
+                                        <p
+                                            style="
+                                                font-size: 12px;
+                                                color: var(--text-muted);
+                                                margin-bottom: 0.5rem;
+                                            "
+                                        >
+                                            プログラミング不要でモバイル/Webアプリを構築
+                                        </p>
+                                        <ul style="font-size: 13px; padding-left: 1.25rem">
+                                            <li>在庫管理アプリ</li>
+                                            <li>現場報告フォームアプリ</li>
+                                            <li>経費申請の承認ワークフロー</li>
+                                            <li>スプレッドシートベースの簡易CRM</li>
+                                        </ul>
+                                        <p
+                                            style="
+                                                font-size: 12px;
+                                                color: var(--text-muted);
+                                                margin-top: 0.5rem;
+                                            "
+                                        >
+                                            <strong
+                                                >→
+                                                エンジニア不要で業務アプリを迅速に作りたい場合</strong
+                                            >
+                                        </p>
+                                    </div>
+                                </div>
+                                <div
+                                    class="compare-card"
+                                    style="border: 1px solid var(--accent-purple-border)"
+                                >
+                                    <div
+                                        class="compare-card-header"
+                                        style="
+                                            background: var(--accent-purple-bg);
+                                            color: var(--accent-purple);
+                                            border-bottom: 1px solid var(--accent-purple-border);
+                                        "
+                                    >
+                                        Apps Script（ローコード/スクリプト）
+                                    </div>
+                                    <div class="compare-card-body">
+                                        <p
+                                            style="
+                                                font-size: 12px;
+                                                color: var(--text-muted);
+                                                margin-bottom: 0.5rem;
+                                            "
+                                        >
+                                            Google Workspace
+                                            の機能を拡張・自動化するJavaScriptプラットフォーム
+                                        </p>
+                                        <ul style="font-size: 13px; padding-left: 1.25rem">
+                                            <li>Gmail の自動返信・自動分類</li>
+                                            <li>Forms 送信後の自動メール通知</li>
+                                            <li>定期レポートの自動生成</li>
+                                            <li>Admin SDK を使ったユーザー管理の自動化</li>
+                                        </ul>
+                                        <p
+                                            style="
+                                                font-size: 12px;
+                                                color: var(--text-muted);
+                                                margin-top: 0.5rem;
+                                            "
+                                        >
+                                            <strong
+                                                >→ Workspace サービスを API
+                                                レベルで拡張・自動化したい場合</strong
+                                            >
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <hr class="divider" />
+
+                        <div class="topic">
+                            <div class="topic-title">AppSheet と Apps Script の管理設定</div>
+
+                            <div class="callout info">
+                                <div class="callout-icon">📍 設定場所（AppSheet）</div>
+                                管理コンソール → アプリ → Google Workspace →
+                                <strong>AppSheet</strong> → [OU 選択] → ON/OFF
+                            </div>
+
+                            <div class="callout info" style="margin-top: 0.5rem">
+                                <div class="callout-icon">📍 設定場所（Apps Script）</div>
+                                管理コンソール → アプリ → Google Workspace →
+                                <strong>Apps Script</strong> → [OU 選択] → ON/OFF
+                            </div>
+
+                            <div class="bp-grid">
+                                <div class="bp-card">
+                                    <div class="bp-num">1</div>
+                                    <p>
+                                        <strong>Apps Script のスコープを最小限に</strong> —
+                                        「ドメイン全体の委任」を必要とするスクリプトは慎重に審査し、不必要に広いスコープを許可しない
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">2</div>
+                                    <p>
+                                        <strong>AppSheet のデータソースアクセスを制限</strong> —
+                                        機密データを含むスプレッドシートに接続する場合はアクセス権を厳密に設定する
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">3</div>
+                                    <p>
+                                        <strong>Apps Script のトリガーを定期審査</strong> —
+                                        不要なトリガーが動作し続けていないか、定期的に監査ログで確認する
+                                    </p>
+                                </div>
+                                <div class="bp-card">
+                                    <div class="bp-num">4</div>
+                                    <p>
+                                        <strong>AppSheet アプリの共有範囲を組織内に限定</strong> —
+                                        外部ユーザーへの共有は原則禁止し、必要な場合は承認フローを経る
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div class="sources">
+                                <div class="sources-title">📎 公式ソース</div>
+                                <ul>
+                                    <li>
+                                        <a
+                                            href="https://knowledge.workspace.google.com/admin/appsheet/manage-appsheet-in-your-organization"
+                                            target="_blank"
+                                            >AppSheet の管理 — Workspace Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://knowledge.workspace.google.com/admin/users/access/turn-apps-script-on-or-off-for-users"
+                                            target="_blank"
+                                            >Apps Script の有効化 — Workspace Help</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://knowledge.workspace.google.com/admin/appsheet/control-access-to-appsheet-features"
+                                            target="_blank"
+                                            >AppSheet 機能へのアクセス制御 — Workspace Help</a
+                                        >
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ============================
+     EXAM CHECKLIST
+     ============================ -->
+                <div
+                    class="section-card"
+                    id="checklist"
+                    style="border-color: var(--accent-purple-border)"
+                >
+                    <div
+                        class="section-header"
+                        onclick="toggleSection(this)"
+                        style="background: var(--accent-purple-bg)"
+                    >
+                        <span
+                            class="section-num"
+                            style="background: var(--accent-purple); color: #fff; border: none"
+                            >📝</span
+                        >
+                        <span class="section-title">試験直前チェックリスト — Section 2 全項目</span>
+                        <span class="section-exam-weight">合格確認</span>
+                        <span class="chevron open">▾</span>
+                    </div>
+                    <div class="section-body open">
+                        <div
+                            style="
+                                display: grid;
+                                grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+                                gap: 1rem;
+                            "
+                        >
+                            <div>
+                                <p
+                                    style="
+                                        font-weight: 600;
+                                        font-size: 13px;
+                                        color: var(--accent-blue);
+                                        margin-bottom: 0.5rem;
+                                    "
+                                >
+                                    📧 Gmail（2.1）
+                                </p>
+                                <div id="checklist-gmail"></div>
+                            </div>
+
+                            <div>
+                                <p
+                                    style="
+                                        font-weight: 600;
+                                        font-size: 13px;
+                                        color: #059669;
+                                        margin-bottom: 0.5rem;
+                                    "
+                                >
+                                    💾 Drive（2.2）
+                                </p>
+                                <div id="checklist-drive"></div>
+                            </div>
+
+                            <div>
+                                <p
+                                    style="
+                                        font-weight: 600;
+                                        font-size: 13px;
+                                        color: #b45309;
+                                        margin-bottom: 0.5rem;
+                                    "
+                                >
+                                    📅 Calendar（2.3）
+                                </p>
+                                <div id="checklist-cal"></div>
+                            </div>
+
+                            <div>
+                                <p
+                                    style="
+                                        font-weight: 600;
+                                        font-size: 13px;
+                                        color: #7c3aed;
+                                        margin-bottom: 0.5rem;
+                                    "
+                                >
+                                    🎥 Meet（2.4）
+                                </p>
+                                <div id="checklist-meet"></div>
+                            </div>
+
+                            <div>
+                                <p
+                                    style="
+                                        font-weight: 600;
+                                        font-size: 13px;
+                                        color: #0891b2;
+                                        margin-bottom: 0.5rem;
+                                    "
+                                >
+                                    💬 Chat（2.5）
+                                </p>
+                                <div id="checklist-chat"></div>
+                            </div>
+
+                            <div>
+                                <p
+                                    style="
+                                        font-weight: 600;
+                                        font-size: 13px;
+                                        color: #dc2626;
+                                        margin-bottom: 0.5rem;
+                                    "
+                                >
+                                    🤖 Gemini（2.6）
+                                </p>
+                                <div id="checklist-gemini"></div>
+                            </div>
+                        </div>
+
+                        <div
+                            style="
+                                margin-top: 1.5rem;
+                                padding: 1rem;
+                                background: var(--accent-amber-bg);
+                                border: 1px solid var(--accent-amber-border);
+                                border-radius: var(--radius);
+                            "
+                        >
+                            <p
+                                style="
+                                    font-weight: 600;
+                                    font-size: 13px;
+                                    color: var(--accent-amber);
+                                    margin-bottom: 0.5rem;
+                                "
+                            >
+                                🏆 試験合格への最短ルート
+                            </p>
+                            <p style="font-size: 13px">
+                                ①<strong>SPF・DKIM・DMARC の三点セット</strong
+                                >（役割と設定手順を完全理解）&nbsp; ②<strong
+                                    >DMARC の段階的導入</strong
+                                >（none→quarantine→reject）&nbsp; ③<strong
+                                    >Chat 履歴オン＝Vault で保持可能</strong
+                                >という連携の理解&nbsp; ④<strong>Meet のノックイン機能</strong
+                                >が外部参加者対策の答え&nbsp; ⑤<strong
+                                    >Geminiは組織データをモデル学習に使わない</strong
+                                >
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- FOOTER -->
+                <div
+                    style="
+                        margin-top: 2rem;
+                        padding: 1.5rem;
+                        background: var(--surface);
+                        border: 1px solid var(--border);
+                        border-radius: var(--radius-lg);
+                    "
+                >
+                    <p style="font-size: 12px; color: var(--text-muted); text-align: center">
+                        📚 参考:
+                        <a
+                            href="https://cloud.google.com/learn/certification/associate-google-workspace-administrator"
+                            target="_blank"
+                            >AGWA 認定ページ</a
+                        >
+                        &nbsp;·&nbsp;
+                        <a
+                            href="https://services.google.com/fh/files/misc/associate_google_workspace_administrator_exam_guide_english.pdf"
+                            target="_blank"
+                            >試験ガイド PDF</a
+                        >
+                        &nbsp;·&nbsp;
+                        <a href="https://support.google.com/a" target="_blank"
+                            >Workspace Admin Help</a
+                        >
+                        &nbsp;·&nbsp;
+                        <a href="https://knowledge.workspace.google.com/admin" target="_blank"
+                            >Workspace Knowledge Center</a
+                        >
+                        &nbsp;·&nbsp;
+                        <a href="https://toolbox.googleapps.com/apps/main/" target="_blank"
+                            >Admin Toolbox</a
+                        >
+                    </p>
+                </div>
+            </main>
+        </div>
+
+        <script>
+            function toggleSection(header) {
+                const body = header.nextElementSibling;
+                const chevron = header.querySelector('.chevron');
+                const isOpen = body.classList.contains('open');
+                body.classList.toggle('open', !isOpen);
+                if (chevron) chevron.classList.toggle('open', !isOpen);
+            }
+
+            const checklists = {
+                gmail: [
+                    'MXレコードの設定値（smtp.google.com / ASPMX系）とDNS伝播時間（最大72時間）を知っている',
+                    'SPF・DKIM・DMARC の役割の違いを説明できる',
+                    'SPFレコードを DNS に追加できる（v=spf1 include:_spf.google.com ~all）',
+                    'DKIM の設定手順（鍵生成 → DNS追加 → 署名開始）を知っている',
+                    'DMARC の段階的導入（none→quarantine→reject）の重要性を説明できる',
+                    'メール許可リストとIP許可リストの違いを説明できる',
+                    'セキュリティサンドボックスに必要なエディション（Business Standard以上）を知っている',
+                    '分割配信と二重配信の違いと用途を説明できる',
+                    '自動転送の禁止がデータ漏洩防止に重要であることを知っている',
+                    'コンテンツコンプライアンスルールでメールをフィルタリング・隔離できる',
+                ],
+                drive: [
+                    '共有設定の階層（管理コンソール→OU→ユーザー）を理解している',
+                    '新規ファイルのデフォルト共有は「制限付き（組織内のみ）」が推奨と知っている',
+                    'ターゲットオーディエンスの役割と設定方法を説明できる',
+                    '共有ドライブのアクセス権5レベル（マネージャー〜閲覧者）を説明できる',
+                    'Drive 信頼ルールがEnterprise機能であることを知っている',
+                    'Drive ラベルでDLPやVaultと連携できることを知っている',
+                    'オフラインアクセスにはChrome拡張機能が必要であることを知っている',
+                    'マイドライブより共有ドライブを推奨する理由（退職時のファイル保護）を説明できる',
+                ],
+                cal: [
+                    'カレンダーの外部共有のデフォルト推奨は「空き時間のみ」であることを知っている',
+                    'リソース設定（建物・機能・リソース）の3要素を説明できる',
+                    '予約承認フロー（自動承認・手動承認）の設定方法を知っている',
+                    'ルームインサイトで利用率分析ができることを知っている',
+                    '「一般公開」設定では会議タイトルが外部に漏れるリスクがあることを知っている',
+                ],
+                meet: [
+                    'ノックイン機能が外部参加者制御の主要な設定であることを知っている',
+                    '録画の保存先（Google Drive）と管理方法を知っている',
+                    '自動文字起こしにはBusiness Standard以上が必要なことを知っている',
+                    'ホスト管理機能の重要性（教育機関・ウェビナーで特に重要）を知っている',
+                ],
+                chat: [
+                    'チャット履歴をオンにしないとVaultでの保持・検索ができないことを知っている',
+                    'Chat 履歴オフ = eDiscovery 不可、DLP 機能しない、という連鎖を説明できる',
+                    'Chat アプリの承認制でシャドーITを防止できることを知っている',
+                    '外部ドメインとのChatは許可リストで制限できることを知っている',
+                    'コンテンツモデレーションの設定と運用方法を知っている',
+                ],
+                gemini: [
+                    'Gemini for Workspace は組織データをモデル学習に使用しないことを知っている',
+                    'Gemini は既存のドライブ・Gmailのアクセス権（ACL）を尊重することを知っている',
+                    'OU 単位で Gemini を有効化/無効化できることを知っている',
+                    'Workspace 拡張機能（Extensions）でGmailやDriveへのアクセスを制御できることを知っている',
+                    '段階的ロールアウト（パイロット→全社）がベストプラクティスであることを知っている',
+                ],
+            };
+
+            function renderChecklist(containerId, items) {
+                const el = document.getElementById(containerId);
+                if (!el) return;
+                el.innerHTML = items
+                    .map(
+                        (item, i) => `
+    <label style="display:flex;gap:8px;align-items:flex-start;margin-bottom:6px;cursor:pointer;font-size:12.5px;line-height:1.4;">
+      <input type="checkbox" id="ck-${containerId}-${i}" style="margin-top:2px;flex-shrink:0;width:14px;height:14px;cursor:pointer;">
+      <span id="lbl-${containerId}-${i}">${item}</span>
+    </label>
+  `,
+                    )
+                    .join('');
+
+                el.querySelectorAll('input[type=checkbox]').forEach((cb, i) => {
+                    const key = `ck-${containerId}-${i}`;
+                    cb.checked = localStorage.getItem(key) === '1';
+                    if (cb.checked) {
+                        document.getElementById(`lbl-${containerId}-${i}`).style.textDecoration =
+                            'line-through';
+                        document.getElementById(`lbl-${containerId}-${i}`).style.color =
+                            'var(--text-light)';
+                    }
+                    cb.addEventListener('change', () => {
+                        localStorage.setItem(key, cb.checked ? '1' : '0');
+                        const lbl = document.getElementById(`lbl-${containerId}-${i}`);
+                        lbl.style.textDecoration = cb.checked ? 'line-through' : 'none';
+                        lbl.style.color = cb.checked ? 'var(--text-light)' : 'var(--text)';
+                    });
+                });
+            }
+
+            Object.entries(checklists).forEach(([key, items]) => {
+                renderChecklist(`checklist-${key}`, items);
+            });
+
+            // Sidebar active link update on scroll
+            const sections = document.querySelectorAll('[id]');
+            const navLinks = document.querySelectorAll('.sidebar nav a');
+            window.addEventListener('scroll', () => {
+                let current = '';
+                sections.forEach((s) => {
+                    if (window.scrollY >= s.offsetTop - 120) current = s.id;
+                });
+                navLinks.forEach((l) => {
+                    l.classList.remove('active');
+                    if (l.getAttribute('href') === '#' + current) l.classList.add('active');
+                });
+            });
+        </script>
+    </body>
+</html>

--- a/app/gcl/associate-cloud-engineer/page.tsx
+++ b/app/gcl/associate-cloud-engineer/page.tsx
@@ -19,9 +19,9 @@ function Section1() {
                 <div className="pct-badge pb1">~23%</div>
             </div>
 
-            {/* 1.1 Resource Hierarchy */}
+            {/* 1.1.1 Resource Hierarchy */}
             <div className="tcard">
-                <div className="ttitle"><span className="tid">1.1</span>リソース階層（Resource Hierarchy）の設計</div>
+                <div className="ttitle"><span className="tid">1.1.1</span>リソース階層（Resource Hierarchy）の設計</div>
                 <p style={{ fontSize: '14px', marginBottom: '14px' }}>GCPのリソースは <strong style={{ color: 'var(--ace-cyan)' }}>組織 → フォルダ → プロジェクト → リソース</strong> の4層構造で管理される。ポリシーは上位から下位へ継承される。</p>
 
                 <div className="tgrid">
@@ -73,9 +73,9 @@ function Section1() {
                 </div>
             </div>
 
-            {/* 1.1 IAM */}
+            {/* 1.1.2 IAM */}
             <div className="tcard">
-                <div className="ttitle"><span className="tid">1.1</span>IAM（Identity and Access Management）の基礎</div>
+                <div className="ttitle"><span className="tid">1.1.2</span>IAM（Identity and Access Management）の基礎</div>
                 <p style={{ fontSize: '14px', marginBottom: '14px' }}>IAMは「<strong style={{ color: 'var(--ace-cyan)' }}>誰が（Member）・何を（Permission）・どのリソースに（Resource）できるか</strong>」を定義する。ロールはアクセス制御の最小単位。</p>
 
                 <table className="ctable">
@@ -112,9 +112,9 @@ function Section1() {
                 </pre>
             </div>
 
-            {/* 1.1 Cloud Identity */}
+            {/* 1.1.3 Cloud Identity */}
             <div className="tcard">
-                <div className="ttitle"><span className="tid">1.1</span>Cloud Identity とユーザー管理</div>
+                <div className="ttitle"><span className="tid">1.1.3</span>Cloud Identity とユーザー管理</div>
                 <div className="tgrid">
                     <div className="titem">
                         <div className="tname">Cloud Identity</div>
@@ -144,9 +144,9 @@ function Section1() {
                 </div>
             </div>
 
-            {/* 1.1 APIs & Quotas */}
+            {/* 1.1.4 APIs & Quotas */}
             <div className="tcard">
-                <div className="ttitle"><span className="tid">1.1</span>API 有効化・割り当て（Quota）管理</div>
+                <div className="ttitle"><span className="tid">1.1.4</span>API 有効化・割り当て（Quota）管理</div>
                 <div className="ib">
                     <div className="ibt">重要ポイント</div>
                     <p>GCP の各サービスは使用前に API を有効化する必要がある。大規模トラフィックの前には Quota 増加を事前申請すること。クォータ超過はアプリダウンの原因となる。</p>

--- a/app/gcl/cloud-digital-leader/constants.ts
+++ b/app/gcl/cloud-digital-leader/constants.ts
@@ -105,7 +105,7 @@ export const RESOURCES: Resource[] = [
     { name: '試験概要ページ', url: 'cloud.google.com/learn/certification/cloud-digital-leader' },
     { name: '公式試験ガイド', url: 'cloud.google.com/learn/certification/guides/cloud-digital-leader' },
     { name: 'Cloud Skills Boost 学習パス', url: 'cloudskillsboost.google/paths/9' },
-    { name: '公式サンプル問題', url: 'cloud.google.com/learn/certification/cloud-digital-leader' },
+    { name: '公式サンプル問題', url: 'docs.google.com/forms/d/e/1FAIpQLSedAmf77MGS7FGEaylFzY51KtBd7kkIZJIMDsV5zSRSmpKIOA/viewform' },
     { name: '試験登録', url: 'cp.certmetrics.com/google/en/login' },
     { name: 'Google Cloud ドキュメント', url: 'cloud.google.com/docs' },
     { name: 'IAM ドキュメント', url: 'cloud.google.com/iam/docs' },

--- a/app/gcl/genai-leader/section3/page.tsx
+++ b/app/gcl/genai-leader/section3/page.tsx
@@ -528,60 +528,62 @@ function Section32() {
                     </ul>
                 </div>
 
-                <table className="ctbl" style={{ marginTop: '20px' }}>
-                    <thead>
-                        <tr>
-                            <th>技法</th>
-                            <th>難易度</th>
-                            <th>主なユースケース</th>
-                            <th>コスト（トークン）</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td><strong style={{ color: 'var(--teal)' }}>Zero-shot</strong></td>
-                            <td>★☆☆</td>
-                            <td>翻訳・要約・分類（明確なタスク）</td>
-                            <td>最小</td>
-                        </tr>
-                        <tr>
-                            <td><strong style={{ color: 'var(--teal)' }}>One-shot</strong></td>
-                            <td>★☆☆</td>
-                            <td>フォーマット指定・構造化出力</td>
-                            <td>小</td>
-                        </tr>
-                        <tr>
-                            <td><strong style={{ color: 'var(--lime)' }}>Few-shot</strong></td>
-                            <td>★★☆</td>
-                            <td>パターン学習・カスタム分類</td>
-                            <td>中</td>
-                        </tr>
-                        <tr>
-                            <td><strong style={{ color: 'var(--lime)' }}>Role Prompting</strong></td>
-                            <td>★★☆</td>
-                            <td>専門家視点・特定スタイルの文章生成</td>
-                            <td>中</td>
-                        </tr>
-                        <tr>
-                            <td><strong style={{ color: 'var(--lime)' }}>Prompt Chaining</strong></td>
-                            <td>★★☆</td>
-                            <td>多段階処理・ワークフロー自動化</td>
-                            <td>中〜大</td>
-                        </tr>
-                        <tr>
-                            <td><strong style={{ color: 'var(--amber)' }}>Chain-of-Thought</strong></td>
-                            <td>★★★</td>
-                            <td>数学・論理推論・説明可能性向上</td>
-                            <td>大</td>
-                        </tr>
-                        <tr>
-                            <td><strong style={{ color: 'var(--rose)' }}>ReAct</strong></td>
-                            <td>★★★</td>
-                            <td>AIエージェント・外部ツール連携</td>
-                            <td>最大</td>
-                        </tr>
-                    </tbody>
-                </table>
+                <div className="table-wrapper">
+                    <table className="ctbl" style={{ marginTop: '20px' }}>
+                        <thead>
+                            <tr>
+                                <th>技法</th>
+                                <th>難易度</th>
+                                <th>主なユースケース</th>
+                                <th>コスト（トークン）</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><strong style={{ color: 'var(--teal)' }}>Zero-shot</strong></td>
+                                <td>★☆☆</td>
+                                <td>翻訳・要約・分類（明確なタスク）</td>
+                                <td>最小</td>
+                            </tr>
+                            <tr>
+                                <td><strong style={{ color: 'var(--teal)' }}>One-shot</strong></td>
+                                <td>★☆☆</td>
+                                <td>フォーマット指定・構造化出力</td>
+                                <td>小</td>
+                            </tr>
+                            <tr>
+                                <td><strong style={{ color: 'var(--lime)' }}>Few-shot</strong></td>
+                                <td>★★☆</td>
+                                <td>パターン学習・カスタム分類</td>
+                                <td>中</td>
+                            </tr>
+                            <tr>
+                                <td><strong style={{ color: 'var(--lime)' }}>Role Prompting</strong></td>
+                                <td>★★☆</td>
+                                <td>専門家視点・特定スタイルの文章生成</td>
+                                <td>中</td>
+                            </tr>
+                            <tr>
+                                <td><strong style={{ color: 'var(--lime)' }}>Prompt Chaining</strong></td>
+                                <td>★★☆</td>
+                                <td>多段階処理・ワークフロー自動化</td>
+                                <td>中〜大</td>
+                            </tr>
+                            <tr>
+                                <td><strong style={{ color: 'var(--amber)' }}>Chain-of-Thought</strong></td>
+                                <td>★★★</td>
+                                <td>数学・論理推論・説明可能性向上</td>
+                                <td>大</td>
+                            </tr>
+                            <tr>
+                                <td><strong style={{ color: 'var(--rose)' }}>ReAct</strong></td>
+                                <td>★★★</td>
+                                <td>AIエージェント・外部ツール連携</td>
+                                <td>最大</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
 
                 <div className="src">
                     <div className="srct">📎 参照リソース</div>
@@ -808,48 +810,50 @@ function Section33() {
                     </div>
                 </div>
 
-                <table className="ctbl" style={{ marginTop: '16px' }}>
-                    <thead>
-                        <tr>
-                            <th>比較軸</th>
-                            <th>① Vertex AI Search（プリビルト）</th>
-                            <th>② RAG API（カスタム）</th>
-                            <th>③ Grounding w/ Google Search</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td><strong>実装難易度</strong></td>
-                            <td>★☆☆（最簡単）</td>
-                            <td>★★☆（中程度）</td>
-                            <td>★☆☆（最簡単）</td>
-                        </tr>
-                        <tr>
-                            <td><strong>制御度</strong></td>
-                            <td>低（自動管理）</td>
-                            <td>高（各ステップ制御）</td>
-                            <td>低（Google管理）</td>
-                        </tr>
-                        <tr>
-                            <td><strong>データソース</strong></td>
-                            <td>社内文書・DB</td>
-                            <td>任意（カスタム）</td>
-                            <td>公開 Web（リアルタイム）</td>
-                        </tr>
-                        <tr>
-                            <td><strong>最新情報</strong></td>
-                            <td>登録次第（手動更新）</td>
-                            <td>データ次第</td>
-                            <td>◎（常時最新）</td>
-                        </tr>
-                        <tr>
-                            <td><strong>適用場面</strong></td>
-                            <td>社内ナレッジ・PoC</td>
-                            <td>高精度・専門システム</td>
-                            <td>世界の最新情報が必要な場合</td>
-                        </tr>
-                    </tbody>
-                </table>
+                <div className="table-wrapper">
+                    <table className="ctbl" style={{ marginTop: '16px' }}>
+                        <thead>
+                            <tr>
+                                <th>比較軸</th>
+                                <th>① Vertex AI Search（プリビルト）</th>
+                                <th>② RAG API（カスタム）</th>
+                                <th>③ Grounding w/ Google Search</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><strong>実装難易度</strong></td>
+                                <td>★☆☆（最簡単）</td>
+                                <td>★★☆（中程度）</td>
+                                <td>★☆☆（最簡単）</td>
+                            </tr>
+                            <tr>
+                                <td><strong>制御度</strong></td>
+                                <td>低（自動管理）</td>
+                                <td>高（各ステップ制御）</td>
+                                <td>低（Google管理）</td>
+                            </tr>
+                            <tr>
+                                <td><strong>データソース</strong></td>
+                                <td>社内文書・DB</td>
+                                <td>任意（カスタム）</td>
+                                <td>公開 Web（リアルタイム）</td>
+                            </tr>
+                            <tr>
+                                <td><strong>最新情報</strong></td>
+                                <td>登録次第（手動更新）</td>
+                                <td>データ次第</td>
+                                <td>◎（常時最新）</td>
+                            </tr>
+                            <tr>
+                                <td><strong>適用場面</strong></td>
+                                <td>社内ナレッジ・PoC</td>
+                                <td>高精度・専門システム</td>
+                                <td>世界の最新情報が必要な場合</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
 
                 <div className="bp">
                     <div className="bpt">✅ RAG オファリング選択のフレームワーク</div>
@@ -965,7 +969,7 @@ function Section33() {
                         <div className="param-name">safety_settings</div>
                         <div className="param-range">BLOCK_LOW_AND_ABOVE / BLOCK_MEDIUM_AND_ABOVE / BLOCK_ONLY_HIGH / BLOCK_NONE / OFF</div>
                         <div className="param-desc">
-                            有害コンテンツ（ヘイトスピーチ・危険情報・性的内容・暴力）の<strong style={{ color: 'var(--teal)' }}>フィルタリング強度</strong>を設定。カテゴリ別に個別設定可能。エンタープライズでは <code>BLOCK_LOW_AND_ABOVE</code> 等の厳しめ閾値を推奨。<code>BLOCK_NONE</code> は gemini-2.5-flash 以降の新モデル向け。
+                            有害コンテンツ（ヘイトスピーチ・危険情報・性的内容・暴力）の<strong style={{ color: 'var(--teal)' }}>フィルタリング強度</strong>を設定。カテゴリ別に個別設定可能。エンタープライズでは <code>BLOCK_LOW_AND_ABOVE</code> 等の厳しめ閾値を推奨。<code>BLOCK_NONE</code> は許可された場合にのみ利用可能な制限付きフィールドであり、gemini-2.5-flash 以降の新モデルでは <code>OFF</code> がデフォルト。
                         </div>
                         <div style={{ marginTop: '12px', fontSize: '12px', color: 'var(--muted)' }}>
                             <strong style={{ color: 'var(--text)' }}>カテゴリ：</strong><br />

--- a/app/gcl/genai-leader/section3/page.tsx
+++ b/app/gcl/genai-leader/section3/page.tsx
@@ -949,9 +949,9 @@ function Section33() {
                     {/* max_output_tokens */}
                     <div className="param">
                         <div className="param-name">max_output_tokens</div>
-                        <div className="param-range">モデル依存（例: Gemini Pro = 8192）</div>
+                        <div className="param-range">モデル仕様で確認が必要（モデル世代ごとに異なる）</div>
                         <div className="param-desc">
-                            生成する<strong style={{ color: 'var(--teal)' }}>最大トークン数</strong>を設定。1トークン ≒ 日本語で約1〜2文字、英語で約4文字。短い応答が必要なら小さく設定して API コストを削減できる。
+                            生成する<strong style={{ color: 'var(--teal)' }}>最大トークン数</strong>を設定。1トークン ≒ 日本語で約1〜2文字、英語で約4文字。短い応答が必要なら小さく設定して API コストを削減できる。実際の上限値は使用するモデル（Gemini 2.5 Pro / Flash 等）の公式仕様で確認すること。
                         </div>
                         <div style={{ marginTop: '12px', fontSize: '12px', color: 'var(--muted)' }}>
                             <strong style={{ color: 'var(--text)' }}>推奨設定：</strong><br />
@@ -963,9 +963,9 @@ function Section33() {
                     {/* safety_settings */}
                     <div className="param">
                         <div className="param-name">safety_settings</div>
-                        <div className="param-range">OFF / LOW / MEDIUM / HIGH / BLOCK_ALL</div>
+                        <div className="param-range">BLOCK_LOW_AND_ABOVE / BLOCK_MEDIUM_AND_ABOVE / BLOCK_ONLY_HIGH / BLOCK_NONE / OFF</div>
                         <div className="param-desc">
-                            有害コンテンツ（ヘイトスピーチ・危険情報・性的内容・暴力）の<strong style={{ color: 'var(--teal)' }}>フィルタリング強度</strong>を設定。カテゴリ別に個別設定可能。エンタープライズでは HIGH を推奨。
+                            有害コンテンツ（ヘイトスピーチ・危険情報・性的内容・暴力）の<strong style={{ color: 'var(--teal)' }}>フィルタリング強度</strong>を設定。カテゴリ別に個別設定可能。エンタープライズでは <code>BLOCK_LOW_AND_ABOVE</code> 等の厳しめ閾値を推奨。<code>BLOCK_NONE</code> は gemini-2.5-flash 以降の新モデル向け。
                         </div>
                         <div style={{ marginTop: '12px', fontSize: '12px', color: 'var(--muted)' }}>
                             <strong style={{ color: 'var(--text)' }}>カテゴリ：</strong><br />

--- a/app/gcl/genai-leader/section3/section3.css
+++ b/app/gcl/genai-leader/section3/section3.css
@@ -1012,4 +1012,10 @@
     .s3-page .fgrid { grid-template-columns: 1fr; }
     .s3-page .snav { overflow-x: auto; flex-wrap: nowrap; }
     .s3-page .hero-corner { display: none; }
+    .s3-page .ctbl {
+        display: block;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        white-space: nowrap;
+    }
 }

--- a/app/gcl/genai-leader/section3/section3.css
+++ b/app/gcl/genai-leader/section3/section3.css
@@ -1012,10 +1012,8 @@
     .s3-page .fgrid { grid-template-columns: 1fr; }
     .s3-page .snav { overflow-x: auto; flex-wrap: nowrap; }
     .s3-page .hero-corner { display: none; }
-    .s3-page .ctbl {
-        display: block;
+    .s3-page .table-wrapper {
         overflow-x: auto;
         -webkit-overflow-scrolling: touch;
-        white-space: nowrap;
     }
 }


### PR DESCRIPTION
… sections

- ACE Section 1: rename duplicated span.tid "1.1" to unique sub-IDs (1.1.1–1.1.4) preserving official ACE exam blueprint numbering (closes #8)
- GenAI Section 3: add mobile @media (max-width: 680px) horizontal scroll to .ctbl so wide comparison tables remain readable on phones (closes #30)
- GenAI Section 3: correct safety_settings enum to Vertex AI official values (BLOCK_LOW_AND_ABOVE etc.) and remove outdated max_output_tokens 8192 example, directing readers to per-model spec instead (closes #31)
- CDL constants: fix 公式サンプル問題 URL to point at the actual Google Form instead of the exam top page (closes #38)