### PR TITLE
fix(gcl): Batch A - CSS variable scoping & Safari compatibility (#7, #10, #16, #17)

### DIFF
--- a/app/gcl/agwa/section1/page.css
+++ b/app/gcl/agwa/section1/page.css
@@ -158,6 +158,7 @@ body {
     top: 0;
     z-index: 100;
     background: var(--color-background);
+    -webkit-backdrop-filter: blur(16px);
     backdrop-filter: blur(16px);
     border-bottom: 1px solid var(--color-border);
     padding: 0 40px;

--- a/app/gcl/associate-cloud-engineer/ace.css
+++ b/app/gcl/associate-cloud-engineer/ace.css
@@ -3,7 +3,7 @@
  * Layer 3: ページ固有テーマ変数 + コンポーネントスタイル
  */
 
-:root {
+.ace-page {
     --ace-bg: #08090f;
     --ace-surface: #0e1117;
     --ace-surface2: #141820;
@@ -123,6 +123,7 @@
     top: 0;
     z-index: 100;
     background: rgba(8, 9, 15, 0.93);
+    -webkit-backdrop-filter: blur(16px);
     backdrop-filter: blur(16px);
     border-bottom: 1px solid var(--ace-border);
     display: flex;

--- a/app/gcl/cloud-digital-leader/section5/section5.module.css
+++ b/app/gcl/cloud-digital-leader/section5/section5.module.css
@@ -33,6 +33,7 @@
     top: 0;
     z-index: 100;
     background: color-mix(in srgb, var(--color-background) 90%, transparent);
+    -webkit-backdrop-filter: blur(8px);
     backdrop-filter: blur(8px);
     border-bottom: 1px solid var(--color-border);
     padding: 1rem;

--- a/app/gcl/genai-leader/genai-leader.css
+++ b/app/gcl/genai-leader/genai-leader.css
@@ -5,7 +5,7 @@
  */
 
 /* ─── DESIGN TOKENS ─── */
-:root {
+.genai-leader-page {
     --gl-bg: #060a14;
     --gl-surface: #0d1526;
     --gl-surface2: #131e33;
@@ -122,6 +122,7 @@
     top: 0;
     z-index: 100;
     background: rgba(6, 10, 20, 0.93);
+    -webkit-backdrop-filter: blur(16px);
     backdrop-filter: blur(16px);
     border-bottom: 1px solid var(--gl-border);
     display: flex;

--- a/app/gcl/genai-leader/section1/section1.css
+++ b/app/gcl/genai-leader/section1/section1.css
@@ -194,6 +194,7 @@
     top: 0;
     z-index: 100;
     background: rgba(8, 11, 18, 0.92);
+    -webkit-backdrop-filter: blur(16px);
     backdrop-filter: blur(16px);
     border-bottom: 1px solid var(--rim);
     display: flex;

--- a/app/gcl/genai-leader/section2/section2.css
+++ b/app/gcl/genai-leader/section2/section2.css
@@ -208,6 +208,7 @@
     top: 0;
     z-index: 100;
     background: rgba(3, 4, 10, 0.92);
+    -webkit-backdrop-filter: blur(16px);
     backdrop-filter: blur(16px);
     border-bottom: 1px solid var(--line);
     display: flex;

--- a/app/gcl/genai-leader/section3/section3.css
+++ b/app/gcl/genai-leader/section3/section3.css
@@ -213,6 +213,7 @@
     top: 0;
     z-index: 100;
     background: rgba(3, 10, 10, 0.92);
+    -webkit-backdrop-filter: blur(16px);
     backdrop-filter: blur(16px);
     border-bottom: 1px solid var(--border);
     display: flex;

--- a/app/gcl/genai-leader/section4/section4.css
+++ b/app/gcl/genai-leader/section4/section4.css
@@ -202,6 +202,7 @@
     top: 0;
     z-index: 100;
     background: rgba(10, 8, 4, 0.92);
+    -webkit-backdrop-filter: blur(16px);
     backdrop-filter: blur(16px);
     border-bottom: 1px solid var(--border);
     display: flex;

--- a/app/gcl/professional-cloud-network-engineer-step-by-step/pcne-step.module.css
+++ b/app/gcl/professional-cloud-network-engineer-step-by-step/pcne-step.module.css
@@ -96,6 +96,7 @@
     top: 64px;
     z-index: 10;
     background: color-mix(in srgb, var(--color-background) 85%, transparent);
+    -webkit-backdrop-filter: blur(12px);
     backdrop-filter: blur(12px);
     border: 1px solid var(--color-border);
     border-radius: 100px;


### PR DESCRIPTION
## Summary

Batch A of the issue audit triage. Low-risk CSS-only changes:

- **#7 `--ace-*` scoping**: moved 15 ACE design tokens from `:root` into `.ace-page` so they no longer leak into other pages.
- **#10 `--gl-*` scoping**: same treatment for 14 Generative AI Leader tokens (moved from `:root` to `.genai-leader-page`).
- **#16 / #17 Safari `backdrop-filter`**: added the `-webkit-backdrop-filter` prefix to **all 9 occurrences** of `backdrop-filter` across the repo (ace.css, agwa/section1/page.css, pcne-step.module.css, cdl section5.module.css, genai-leader.css, genai-leader sections 1-4). Safari ≤ 18 still requires the prefix.

### Why scope these tokens?

CSS custom properties defined on `:root` are inherited globally. With multiple page-specific themes (ACE Aurora, GenAI Sapphire, CDL, etc.), keeping all tokens on `:root` risks accidental collision and makes it hard to reason about which page owns which token. Moving them under the page-root class scopes them to descendants only — closer to a CSS Modules-style isolation without changing the import strategy.

## Test plan

- [x] `bun run lint` — passes
- [x] `bun run build` — all 25 pages prerender successfully
- [x] `bun run test` — 310/311 pass. The 1 failure is the pre-existing CDL domain assertion already addressed in PR #71 (Batch F); not introduced here.

## Issues closed

Closes #7, closes #10, closes #16, closes #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)