### PR TITLE
fix(gcl): Batch B - test precision & nav aria-label (#4, #5, #6, #9, #13, #14)

### DIFF
--- a/__tests__/gcl/associate-cloud-engineer/page.test.tsx
+++ b/__tests__/gcl/associate-cloud-engineer/page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import AssociateCloudEngineerPage from '@/app/gcl/associate-cloud-engineer/page';
 
 describe('Associate Cloud Engineer ページ', () => {
@@ -29,11 +29,13 @@ describe('Associate Cloud Engineer ページ', () => {
     });
 
     it('sticky nav にセクションリンクが含まれること', () => {
-        const nav = screen.getByRole('navigation');
+        const nav = screen.getByRole('navigation', { name: /ACE セクションナビゲーション/ });
         expect(nav).toBeInTheDocument();
-        expect(screen.getByText(/S1: 環境構築/)).toBeInTheDocument();
-        expect(screen.getByText(/S2: 計画・実装/)).toBeInTheDocument();
-        expect(screen.getByText(/S3: 運用管理/)).toBeInTheDocument();
-        expect(screen.getByText(/S4: アクセス・セキュリティ/)).toBeInTheDocument();
+        const links = within(nav).getAllByRole('link');
+        expect(links).toHaveLength(5);
+        expect(within(nav).getByText(/S1: 環境構築/)).toBeInTheDocument();
+        expect(within(nav).getByText(/S2: 計画・実装/)).toBeInTheDocument();
+        expect(within(nav).getByText(/S3: 運用管理/)).toBeInTheDocument();
+        expect(within(nav).getByText(/S4: アクセス・セキュリティ/)).toBeInTheDocument();
     });
 });

--- a/__tests__/gcl/genai-leader/page.test.tsx
+++ b/__tests__/gcl/genai-leader/page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import GenaiLeaderPage from '@/app/gcl/genai-leader/page';
 
 describe('Generative AI Leader ページ', () => {
@@ -30,11 +30,13 @@ describe('Generative AI Leader ページ', () => {
 
     it('sticky nav にセクションリンクが含まれること', () => {
         render(<GenaiLeaderPage />);
-        const nav = screen.getByRole('navigation');
+        const nav = screen.getByRole('navigation', { name: /Generative AI Leader セクションナビゲーション/ });
         expect(nav).toBeInTheDocument();
-        expect(screen.getAllByText(/Section 1: Gen AI 基礎/).length).toBeGreaterThanOrEqual(1);
-        expect(screen.getAllByText(/Section 2: GCP サービス/).length).toBeGreaterThanOrEqual(1);
-        expect(screen.getAllByText(/Section 3: モデル改善/).length).toBeGreaterThanOrEqual(1);
-        expect(screen.getAllByText(/Section 4: ビジネス戦略/).length).toBeGreaterThanOrEqual(1);
+        const links = within(nav).getAllByRole('link');
+        expect(links).toHaveLength(5);
+        expect(within(nav).getByText(/Section 1: Gen AI 基礎/)).toBeInTheDocument();
+        expect(within(nav).getByText(/Section 2: GCP サービス/)).toBeInTheDocument();
+        expect(within(nav).getByText(/Section 3: モデル改善/)).toBeInTheDocument();
+        expect(within(nav).getByText(/Section 4: ビジネス戦略/)).toBeInTheDocument();
     });
 });

--- a/__tests__/gcl/genai-leader/section3/page.test.tsx
+++ b/__tests__/gcl/genai-leader/section3/page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import Section3Page from '@/app/gcl/genai-leader/section3/page';
 
 describe('Generative AI Leader Section 3 ページ', () => {
@@ -33,10 +33,10 @@ describe('Generative AI Leader Section 3 ページ', () => {
 
     it('nav にサブセクションリンクが含まれること', () => {
         render(<Section3Page />);
-        const nav = screen.getByRole('navigation');
+        const nav = screen.getByRole('navigation', { name: /Section 3 サブセクションナビゲーション/ });
         expect(nav).toBeInTheDocument();
-        expect(screen.getAllByText(/モデルの限界と克服/).length).toBeGreaterThanOrEqual(1);
-        expect(screen.getAllByText(/プロンプトエンジニアリング/).length).toBeGreaterThanOrEqual(1);
-        expect(screen.getAllByText(/グラウンディング/).length).toBeGreaterThanOrEqual(1);
+        expect(within(nav).getByText(/モデルの限界と克服/)).toBeInTheDocument();
+        expect(within(nav).getByText(/プロンプトエンジニアリング/)).toBeInTheDocument();
+        expect(within(nav).getByText(/グラウンディング/)).toBeInTheDocument();
     });
 });

--- a/__tests__/gcl/genai-leader/section4/page.test.tsx
+++ b/__tests__/gcl/genai-leader/section4/page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import Section4Page from '@/app/gcl/genai-leader/section4/page';
 
 describe('Generative AI Leader Section 4 ページ', () => {
@@ -33,10 +33,10 @@ describe('Generative AI Leader Section 4 ページ', () => {
 
     it('nav にサブセクションリンクが含まれること', () => {
         render(<Section4Page />);
-        const nav = screen.getByRole('navigation');
+        const nav = screen.getByRole('navigation', { name: /Section 4 サブセクションナビゲーション/ });
         expect(nav).toBeInTheDocument();
-        expect(screen.getAllByText(/Gen AI 実装戦略/).length).toBeGreaterThanOrEqual(1);
-        expect(screen.getAllByText(/セキュアな AI/).length).toBeGreaterThanOrEqual(1);
-        expect(screen.getAllByText(/責任ある AI/).length).toBeGreaterThanOrEqual(1);
+        expect(within(nav).getByText(/Gen AI 実装戦略/)).toBeInTheDocument();
+        expect(within(nav).getByText(/セキュアな AI/)).toBeInTheDocument();
+        expect(within(nav).getByText(/責任ある AI/)).toBeInTheDocument();
     });
 });

--- a/app/gcl/associate-cloud-engineer/page.tsx
+++ b/app/gcl/associate-cloud-engineer/page.tsx
@@ -1039,7 +1039,11 @@ function Section4() {
     );
 }
 
-/* ── メインページコンポーネント ── */
+/**
+ * Renders the Associate Cloud Engineer study guide page with a hero header, sticky section navigation, overview card, four content sections (S1–S4), and footer.
+ *
+ * @returns The page's JSX element containing the complete ACE study guide layout
+ */
 export default function AssociateCloudEngineerPage() {
     return (
         <div className="ace-page">

--- a/app/gcl/associate-cloud-engineer/page.tsx
+++ b/app/gcl/associate-cloud-engineer/page.tsx
@@ -1079,7 +1079,7 @@ export default function AssociateCloudEngineerPage() {
             </section>
 
             {/* Sticky Nav */}
-            <nav className="snav" role="navigation">
+            <nav className="snav" aria-label="ACE セクションナビゲーション">
                 <a href="#overview" className="n1"><span className="dot db" />概要</a>
                 <a href="#s1" className="n1"><span className="dot db" />S1: 環境構築</a>
                 <a href="#s2" className="n2"><span className="dot dg" />S2: 計画・実装</a>

--- a/app/gcl/genai-leader/page.tsx
+++ b/app/gcl/genai-leader/page.tsx
@@ -473,7 +473,14 @@ function Section4() {
     );
 }
 
-/* ── メインページコンポーネント ── */
+/**
+ * Render the Generative AI Leader exam study guide page including hero, navigation, main sections, and footer.
+ *
+ * The component composes a hero banner with exam metadata, a sticky section navigation, an overview with section weightings,
+ * the content sections (Section1–Section4), and a footer with references and disclaimers.
+ *
+ * @returns The React element for the full Generative AI Leader guide page.
+ */
 export default function GenaiLeaderPage() {
     return (
         <div className={`genai-leader-page ${spaceMono.variable}`}>

--- a/app/gcl/genai-leader/page.tsx
+++ b/app/gcl/genai-leader/page.tsx
@@ -498,7 +498,7 @@ export default function GenaiLeaderPage() {
             </section>
 
             {/* Sticky Nav */}
-            <nav className="sticky-nav" role="navigation">
+            <nav className="sticky-nav" aria-label="Generative AI Leader セクションナビゲーション">
                 <a href="#overview" className="nav-item"><span className="dot dot-blue" />試験概要</a>
                 <a href="#section1" className="nav-item s1"><span className="dot dot-blue" />Section 1: Gen AI 基礎</a>
                 <a href="#section2" className="nav-item s2"><span className="dot dot-green" />Section 2: GCP サービス</a>

--- a/app/gcl/genai-leader/section3/page.tsx
+++ b/app/gcl/genai-leader/section3/page.tsx
@@ -1139,7 +1139,14 @@ function SummarySection() {
     );
 }
 
-/* ── Main Page ── */
+/**
+ * Renders the Section 3 study guide page for the Generative AI Leader exam.
+ *
+ * The page includes a hero header, subsection navigation, the 3.1–3.3 content sections with dividers,
+ * and a footer with references and creation date. Global font classes are applied to the page root.
+ *
+ * @returns The React element for the complete Section 3 page, including header, navigation, main subsections, and footer.
+ */
 export default function Section3Page() {
     const fontClasses = `${outfit.variable} ${firaCode.variable}`;
 

--- a/app/gcl/genai-leader/section3/page.tsx
+++ b/app/gcl/genai-leader/section3/page.tsx
@@ -1182,7 +1182,7 @@ export default function Section3Page() {
             </header>
 
             {/* NAV */}
-            <nav className="snav">
+            <nav className="snav" aria-label="Section 3 サブセクションナビゲーション">
                 <a href="#s31" className="t1"><span className="ch ch1">3.1</span>モデルの限界と克服</a>
                 <a href="#s32" className="t2"><span className="ch ch2">3.2</span>プロンプトエンジニアリング</a>
                 <a href="#s33" className="t3"><span className="ch ch3">3.3</span>グラウンディング・RAG</a>

--- a/app/gcl/genai-leader/section4/page.tsx
+++ b/app/gcl/genai-leader/section4/page.tsx
@@ -979,7 +979,14 @@ function SummarySection() {
     );
 }
 
-/* ── Main Page ── */
+/**
+ * Render the complete Section 4 page layout for the Generative AI Leader exam guide.
+ *
+ * The page includes a hero header, accessible sub-navigation for subsections 4.1–4.3, the three detailed subsection components,
+ * a summary section, and a footer with references and creation date.
+ *
+ * @returns The JSX element for the Section 4 page containing hero, navigation, main content (Section41, Section42, Section43, SummarySection), and footer.
+ */
 export default function Section4Page() {
     const fontClasses = `${playfairDisplay.variable} ${dmMono.variable}`;
 

--- a/app/gcl/genai-leader/section4/page.tsx
+++ b/app/gcl/genai-leader/section4/page.tsx
@@ -1022,7 +1022,7 @@ export default function Section4Page() {
             </header>
 
             {/* NAV */}
-            <nav className="snav">
+            <nav className="snav" aria-label="Section 4 サブセクションナビゲーション">
                 <a href="#s41" className="n1"><span className="snav-num nn1">4.1</span>Gen AI 実装戦略</a>
                 <a href="#s42" className="n2"><span className="snav-num nn2">4.2</span>セキュアな AI</a>
                 <a href="#s43" className="n3"><span className="snav-num nn3">4.3</span>責任ある AI</a>

--- a/e2e/associate-cloud-engineer.spec.ts
+++ b/e2e/associate-cloud-engineer.spec.ts
@@ -39,7 +39,8 @@ test.describe('Associate Cloud Engineer ページ', () => {
                 errors.push(msg.text());
             }
         });
-        await page.goto('/gcl/associate-cloud-engineer');
+        // beforeEach で既にナビゲート済みのため reload してリスナー登録後のロードを観測する
+        await page.reload();
         await page.waitForLoadState('networkidle');
         expect(errors).toEqual([]);
     });

--- a/e2e/genai-leader.spec.ts
+++ b/e2e/genai-leader.spec.ts
@@ -39,7 +39,8 @@ test.describe('Generative AI Leader ページ', () => {
                 errors.push(msg.text());
             }
         });
-        await page.goto('/gcl/genai-leader');
+        // beforeEach で既にナビゲート済みのため reload してリスナー登録後のロードを観測する
+        await page.reload();
         await page.waitForLoadState('networkidle');
         expect(errors).toEqual([]);
     });


### PR DESCRIPTION
## Summary

Batch B of the issue audit triage. Test-only and minimal page changes:

### Unit tests (#4, #6, #13, #14)

`screen.getByRole('navigation')` matched ambiguously because `components/Header.tsx` also renders a `<nav>`. Fixed by:

1. Adding `aria-label="..."` to each page's sticky nav (ACE, GenAI top, Section 3, Section 4).
2. Switching tests to `getByRole('navigation', { name: /label/ })` + `within(nav).getByText(...)` so link assertions are anchored to the correct nav.

For the ACE test, also added `expect(links).toHaveLength(5)` to align with the e2e test's expectation, which had diverged from the unit test (4 vs 5).

### E2E tests (#5, #9)

`page.on('console', ...)` was registered **after** `beforeEach` already navigated, so first-load console errors were silently missed. Fixed by replacing the redundant second `page.goto(...)` inside the test with `page.reload()` after the listener attaches, so the listener observes the full load.

## Test plan

- [x] `bun run lint` — passes
- [x] `bun run build` — all 25 pages prerender successfully
- [x] `bun run test` — 310/311 pass. The 1 failure is the pre-existing CDL domain assertion already addressed in PR #71 (Batch F).

## Issues closed

Closes #4, closes #5, closes #6, closes #9, closes #13, closes #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)